### PR TITLE
rollback nextjs version as 13.4.x 

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -6,8 +6,7 @@ const nextConfig = {
     swcMinify: true,
     pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
     experimental: {
-        appDir: true,
-        mdxRs: false
+        appDir: true
     },
     webpack(config) {
         config.module.rules.push({

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "contentlayer": "^0.3.1",
-    "next": "13.4.10",
+    "next": "13.3.4",
     "next-contentlayer": "^0.3.1",
     "react": "18.2.0",
     "react-aria-components": "1.0.0-alpha.4",


### PR DESCRIPTION
- rollback NextJS version as 13.4.x  was creating issues with hot reload
- removed unnecessary mdxRs setting as it was triggering a false positive warning