### PR TITLE
Feature/54 57

### DIFF
--- a/.changeset/wise-apes-rescue.md
+++ b/.changeset/wise-apes-rescue.md
@@ -1,0 +1,6 @@
+---
+"@hopper-ui/tokens": major
+"docs": patch
+---
+
+Removed unnecessary line-height / fix rounding for some line height tokens

--- a/apps/docs/components/ui/sectionPopover/sectionPopover.tsx
+++ b/apps/docs/components/ui/sectionPopover/sectionPopover.tsx
@@ -48,7 +48,7 @@ const SectionPopover = ({ links }: React.PropsWithoutRef<SectionPopoverProps>) =
                 <div className="hd-section-popover">
                     <Button className={cx("hd-section-popover__button", isOpen && "hd-section-popover__button--open")} onPress={togglePopover}>
                         On this page
-                        <ChevronIcon className="hd-section-popover__button-icon"/>
+                        <ChevronIcon className="hd-section-popover__button-icon" />
                     </Button>
                     <div className={cx("hd-section-popover__popover", isOpen && "hd-section-popover__popover--open")}>
                         <a className="hd-section-popover__top-section" href="#top" onClick={togglePopover}>Return to top</a>

--- a/apps/docs/datas/tokens-dark.json
+++ b/apps/docs/datas/tokens-dark.json
@@ -653,7 +653,7 @@
       },
       {
         "name": "hop-line-height-1-14",
-        "value": "1.14"
+        "value": "1.1428571"
       },
       {
         "name": "hop-line-height-1-20",
@@ -665,15 +665,11 @@
       },
       {
         "name": "hop-line-height-1-33",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-line-height-1-4285",
-        "value": "1.4285"
-      },
-      {
-        "name": "hop-line-height-1-4295",
-        "value": "1.4295"
+        "value": "1.4285714"
       },
       {
         "name": "hop-line-height-1-50",

--- a/apps/docs/datas/tokens.json
+++ b/apps/docs/datas/tokens.json
@@ -653,7 +653,7 @@
       },
       {
         "name": "hop-line-height-1-14",
-        "value": "1.14"
+        "value": "1.1428571"
       },
       {
         "name": "hop-line-height-1-20",
@@ -665,15 +665,11 @@
       },
       {
         "name": "hop-line-height-1-33",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-line-height-1-4285",
-        "value": "1.4285"
-      },
-      {
-        "name": "hop-line-height-1-4295",
-        "value": "1.4295"
+        "value": "1.4285714"
       },
       {
         "name": "hop-line-height-1-50",
@@ -1989,7 +1985,7 @@
     "lineHeight": [
       {
         "name": "hop-heading-3xl-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-heading-2xl-line-height",
@@ -1997,11 +1993,11 @@
       },
       {
         "name": "hop-heading-xl-line-height",
-        "value": "1.14"
+        "value": "1.1428571"
       },
       {
         "name": "hop-heading-lg-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-heading-md-line-height",
@@ -2021,7 +2017,7 @@
       },
       {
         "name": "hop-overline-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-2xl-line-height",
@@ -2029,27 +2025,27 @@
       },
       {
         "name": "hop-body-xl-line-height",
-        "value": "1.14"
+        "value": "1.1428571"
       },
       {
         "name": "hop-body-lg-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-lg-medium-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-lg-semibold-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-lg-bold-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-lg-underline-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-md-line-height",
@@ -2073,43 +2069,43 @@
       },
       {
         "name": "hop-body-sm-line-height",
-        "value": "1.4285"
+        "value": "1.4285714"
       },
       {
         "name": "hop-body-sm-medium-line-height",
-        "value": "1.4295"
+        "value": "1.4285714"
       },
       {
         "name": "hop-body-sm-semibold-line-height",
-        "value": "1.4295"
+        "value": "1.4285714"
       },
       {
         "name": "hop-body-sm-bold-line-height",
-        "value": "1.4295"
+        "value": "1.4285714"
       },
       {
         "name": "hop-body-sm-underline-line-height",
-        "value": "1.4295"
+        "value": "1.4285714"
       },
       {
         "name": "hop-body-xs-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-xs-medium-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-xs-semibold-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-xs-bold-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-body-xs-underline-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       },
       {
         "name": "hop-accent-lg-line-height",
@@ -2117,7 +2113,7 @@
       },
       {
         "name": "hop-accent-sm-line-height",
-        "value": "1.33"
+        "value": "1.3333333"
       }
     ],
     "borderRadius": [

--- a/packages/tokens/src/tokens/core/fonts.tokens.json
+++ b/packages/tokens/src/tokens/core/fonts.tokens.json
@@ -94,7 +94,7 @@
         },
         "1-14": {
             "$type": "lineHeight",
-            "$value": "1.14"
+            "$value": "1.1428571"
         },
         "1-20": {
             "$type": "lineHeight",
@@ -106,15 +106,11 @@
         },
         "1-33": {
             "$type": "lineHeight",
-            "$value": "1.33"
+            "$value": "1.3333333"
         },
         "1-4285": {
             "$type": "lineHeight",
-            "$value": "1.4285"
-        },
-        "1-4295": {
-            "$type": "lineHeight",
-            "$value": "1.4295"
+            "$value": "1.4285714"
         },
         "1-50": {
             "$type": "lineHeight",

--- a/packages/tokens/src/tokens/semantic/light/fonts.tokens.json
+++ b/packages/tokens/src/tokens/semantic/light/fonts.tokens.json
@@ -412,7 +412,7 @@
                 },
                 "line-height": {
                     "$type": "lineHeight",
-                    "$value": "{line-height.1-4295}"
+                    "$value": "{line-height.1-4285}"
                 }
             },
             "semibold": {
@@ -430,7 +430,7 @@
                 },
                 "line-height": {
                     "$type": "lineHeight",
-                    "$value": "{line-height.1-4295}"
+                    "$value": "{line-height.1-4285}"
                 }
             },
             "bold": {
@@ -448,7 +448,7 @@
                 },
                 "line-height": {
                     "$type": "lineHeight",
-                    "$value": "{line-height.1-4295}"
+                    "$value": "{line-height.1-4285}"
                 }
             },
             "underline": {
@@ -465,8 +465,8 @@
                     "$value": "{font.weight.505}"
                 },
                 "line-height": {
-                    "$type": "lineHeight", 
-                    "$value": "{line-height.1-4295}"
+                    "$type": "lineHeight",
+                    "$value": "{line-height.1-4285}"
                 }
             }
         },


### PR DESCRIPTION
Fix for issue #54 / #57 

- Rounding line-height values was only causing rounding errors in browsers.
- A line height token has been added by mistake in the Figma file, it was of no use as it was too close to another one.