### PR TITLE
feat: Updated DataViz Tokens to be prefixed with dataviz + Split color token tests in multiple tests

### DIFF
--- a/.changeset/wicked-seahorses-flash.md
+++ b/.changeset/wicked-seahorses-flash.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/tokens": major
+---
+
+prefixed data visualization tokens with "dataviz"

--- a/apps/docs/datas/tokens-dark.json
+++ b/apps/docs/datas/tokens-dark.json
@@ -1764,23 +1764,23 @@
         "value": "#132a27"
       },
       {
-        "name": "hop-unavailable",
+        "name": "hop-dataviz-unavailable",
         "value": "#636362"
       },
       {
-        "name": "hop-unavailable-weak",
+        "name": "hop-dataviz-unavailable-weak",
         "value": "#777775"
       },
       {
-        "name": "hop-unavailable-strong",
+        "name": "hop-dataviz-unavailable-strong",
         "value": "#505050"
       },
       {
-        "name": "hop-text-onlight",
+        "name": "hop-dataviz-text-onlight",
         "value": "#3c3c3c"
       },
       {
-        "name": "hop-text-ondark",
+        "name": "hop-dataviz-text-ondark",
         "value": "#ffffff"
       }
     ],

--- a/apps/docs/datas/tokens.json
+++ b/apps/docs/datas/tokens.json
@@ -1776,1063 +1776,1063 @@
         "value": "#115a52"
       },
       {
-        "name": "hop-monochromatic-primary-25",
+        "name": "hop-dataviz-monochromatic-primary-25",
         "value": "#f5f6ff"
       },
       {
-        "name": "hop-monochromatic-primary-50",
+        "name": "hop-dataviz-monochromatic-primary-50",
         "value": "#e6ebff"
       },
       {
-        "name": "hop-monochromatic-primary-75",
+        "name": "hop-dataviz-monochromatic-primary-75",
         "value": "#d6e0ff"
       },
       {
-        "name": "hop-monochromatic-primary-100",
+        "name": "hop-dataviz-monochromatic-primary-100",
         "value": "#b9cbff"
       },
       {
-        "name": "hop-monochromatic-primary-200",
+        "name": "hop-dataviz-monochromatic-primary-200",
         "value": "#95b1ff"
       },
       {
-        "name": "hop-monochromatic-primary-300",
+        "name": "hop-dataviz-monochromatic-primary-300",
         "value": "#6c8ffd"
       },
       {
-        "name": "hop-monochromatic-primary-400",
+        "name": "hop-dataviz-monochromatic-primary-400",
         "value": "#4767fe"
       },
       {
-        "name": "hop-monochromatic-primary-500",
+        "name": "hop-dataviz-monochromatic-primary-500",
         "value": "#3b57ff"
       },
       {
-        "name": "hop-monochromatic-primary-600",
+        "name": "hop-dataviz-monochromatic-primary-600",
         "value": "#2a43e8"
       },
       {
-        "name": "hop-monochromatic-primary-700",
+        "name": "hop-dataviz-monochromatic-primary-700",
         "value": "#2040c7"
       },
       {
-        "name": "hop-monochromatic-primary-800",
+        "name": "hop-dataviz-monochromatic-primary-800",
         "value": "#1b3587"
       },
       {
-        "name": "hop-monochromatic-primary-900",
+        "name": "hop-dataviz-monochromatic-primary-900",
         "value": "#152450"
       },
       {
-        "name": "hop-monochromatic-primary-25-hover",
+        "name": "hop-dataviz-monochromatic-primary-25-hover",
         "value": "#e6ebff"
       },
       {
-        "name": "hop-monochromatic-primary-50-hover",
+        "name": "hop-dataviz-monochromatic-primary-50-hover",
         "value": "#d6e0ff"
       },
       {
-        "name": "hop-monochromatic-primary-75-hover",
+        "name": "hop-dataviz-monochromatic-primary-75-hover",
         "value": "#b9cbff"
       },
       {
-        "name": "hop-monochromatic-primary-100-hover",
+        "name": "hop-dataviz-monochromatic-primary-100-hover",
         "value": "#95b1ff"
       },
       {
-        "name": "hop-monochromatic-primary-200-hover",
+        "name": "hop-dataviz-monochromatic-primary-200-hover",
         "value": "#6c8ffd"
       },
       {
-        "name": "hop-monochromatic-primary-300-hover",
+        "name": "hop-dataviz-monochromatic-primary-300-hover",
         "value": "#4767fe"
       },
       {
-        "name": "hop-monochromatic-primary-400-hover",
+        "name": "hop-dataviz-monochromatic-primary-400-hover",
         "value": "#3b57ff"
       },
       {
-        "name": "hop-monochromatic-primary-500-hover",
+        "name": "hop-dataviz-monochromatic-primary-500-hover",
         "value": "#2a43e8"
       },
       {
-        "name": "hop-monochromatic-primary-600-hover",
+        "name": "hop-dataviz-monochromatic-primary-600-hover",
         "value": "#2040c7"
       },
       {
-        "name": "hop-monochromatic-primary-700-hover",
+        "name": "hop-dataviz-monochromatic-primary-700-hover",
         "value": "#1b3587"
       },
       {
-        "name": "hop-monochromatic-primary-800-hover",
+        "name": "hop-dataviz-monochromatic-primary-800-hover",
         "value": "#152450"
       },
       {
-        "name": "hop-monochromatic-primary-900-hover",
+        "name": "hop-dataviz-monochromatic-primary-900-hover",
         "value": "#0b173a"
       },
       {
-        "name": "hop-monochromatic-positive-25",
+        "name": "hop-dataviz-monochromatic-positive-25",
         "value": "#f4f9e9"
       },
       {
-        "name": "hop-monochromatic-positive-50",
+        "name": "hop-dataviz-monochromatic-positive-50",
         "value": "#e3f3b9"
       },
       {
-        "name": "hop-monochromatic-positive-75",
+        "name": "hop-dataviz-monochromatic-positive-75",
         "value": "#cde8ac"
       },
       {
-        "name": "hop-monochromatic-positive-100",
+        "name": "hop-dataviz-monochromatic-positive-100",
         "value": "#aad89d"
       },
       {
-        "name": "hop-monochromatic-positive-200",
+        "name": "hop-dataviz-monochromatic-positive-200",
         "value": "#7dc291"
       },
       {
-        "name": "hop-monochromatic-positive-300",
+        "name": "hop-dataviz-monochromatic-positive-300",
         "value": "#47a584"
       },
       {
-        "name": "hop-monochromatic-positive-400",
+        "name": "hop-dataviz-monochromatic-positive-400",
         "value": "#188a71"
       },
       {
-        "name": "hop-monochromatic-positive-500",
+        "name": "hop-dataviz-monochromatic-positive-500",
         "value": "#0c796b"
       },
       {
-        "name": "hop-monochromatic-positive-600",
+        "name": "hop-dataviz-monochromatic-positive-600",
         "value": "#0a6f64"
       },
       {
-        "name": "hop-monochromatic-positive-700",
+        "name": "hop-dataviz-monochromatic-positive-700",
         "value": "#115a52"
       },
       {
-        "name": "hop-monochromatic-positive-800",
+        "name": "hop-dataviz-monochromatic-positive-800",
         "value": "#16433d"
       },
       {
-        "name": "hop-monochromatic-positive-900",
+        "name": "hop-dataviz-monochromatic-positive-900",
         "value": "#132a27"
       },
       {
-        "name": "hop-monochromatic-positive-25-hover",
+        "name": "hop-dataviz-monochromatic-positive-25-hover",
         "value": "#e3f3b9"
       },
       {
-        "name": "hop-monochromatic-positive-50-hover",
+        "name": "hop-dataviz-monochromatic-positive-50-hover",
         "value": "#cde8ac"
       },
       {
-        "name": "hop-monochromatic-positive-75-hover",
+        "name": "hop-dataviz-monochromatic-positive-75-hover",
         "value": "#aad89d"
       },
       {
-        "name": "hop-monochromatic-positive-100-hover",
+        "name": "hop-dataviz-monochromatic-positive-100-hover",
         "value": "#7dc291"
       },
       {
-        "name": "hop-monochromatic-positive-200-hover",
+        "name": "hop-dataviz-monochromatic-positive-200-hover",
         "value": "#47a584"
       },
       {
-        "name": "hop-monochromatic-positive-300-hover",
+        "name": "hop-dataviz-monochromatic-positive-300-hover",
         "value": "#188a71"
       },
       {
-        "name": "hop-monochromatic-positive-400-hover",
+        "name": "hop-dataviz-monochromatic-positive-400-hover",
         "value": "#0c796b"
       },
       {
-        "name": "hop-monochromatic-positive-500-hover",
+        "name": "hop-dataviz-monochromatic-positive-500-hover",
         "value": "#0a6f64"
       },
       {
-        "name": "hop-monochromatic-positive-600-hover",
+        "name": "hop-dataviz-monochromatic-positive-600-hover",
         "value": "#115a52"
       },
       {
-        "name": "hop-monochromatic-positive-700-hover",
+        "name": "hop-dataviz-monochromatic-positive-700-hover",
         "value": "#16433d"
       },
       {
-        "name": "hop-monochromatic-positive-800-hover",
+        "name": "hop-dataviz-monochromatic-positive-800-hover",
         "value": "#132a27"
       },
       {
-        "name": "hop-monochromatic-positive-900-hover",
+        "name": "hop-dataviz-monochromatic-positive-900-hover",
         "value": "#0a1716"
       },
       {
-        "name": "hop-monochromatic-negative-25",
+        "name": "hop-dataviz-monochromatic-negative-25",
         "value": "#fdf6f6"
       },
       {
-        "name": "hop-monochromatic-negative-50",
+        "name": "hop-dataviz-monochromatic-negative-50",
         "value": "#fde6e5"
       },
       {
-        "name": "hop-monochromatic-negative-75",
+        "name": "hop-dataviz-monochromatic-negative-75",
         "value": "#ffd6d3"
       },
       {
-        "name": "hop-monochromatic-negative-100",
+        "name": "hop-dataviz-monochromatic-negative-100",
         "value": "#ffbcb7"
       },
       {
-        "name": "hop-monochromatic-negative-200",
+        "name": "hop-dataviz-monochromatic-negative-200",
         "value": "#ff8e8e"
       },
       {
-        "name": "hop-monochromatic-negative-300",
+        "name": "hop-dataviz-monochromatic-negative-300",
         "value": "#f56263"
       },
       {
-        "name": "hop-monochromatic-negative-400",
+        "name": "hop-dataviz-monochromatic-negative-400",
         "value": "#df3236"
       },
       {
-        "name": "hop-monochromatic-negative-500",
+        "name": "hop-dataviz-monochromatic-negative-500",
         "value": "#cb2e31"
       },
       {
-        "name": "hop-monochromatic-negative-600",
+        "name": "hop-dataviz-monochromatic-negative-600",
         "value": "#ba2d2d"
       },
       {
-        "name": "hop-monochromatic-negative-700",
+        "name": "hop-dataviz-monochromatic-negative-700",
         "value": "#952927"
       },
       {
-        "name": "hop-monochromatic-negative-800",
+        "name": "hop-dataviz-monochromatic-negative-800",
         "value": "#6c2320"
       },
       {
-        "name": "hop-monochromatic-negative-900",
+        "name": "hop-dataviz-monochromatic-negative-900",
         "value": "#431a17"
       },
       {
-        "name": "hop-monochromatic-negative-25-hover",
+        "name": "hop-dataviz-monochromatic-negative-25-hover",
         "value": "#fde6e5"
       },
       {
-        "name": "hop-monochromatic-negative-50-hover",
+        "name": "hop-dataviz-monochromatic-negative-50-hover",
         "value": "#ffd6d3"
       },
       {
-        "name": "hop-monochromatic-negative-75-hover",
+        "name": "hop-dataviz-monochromatic-negative-75-hover",
         "value": "#ffbcb7"
       },
       {
-        "name": "hop-monochromatic-negative-100-hover",
+        "name": "hop-dataviz-monochromatic-negative-100-hover",
         "value": "#ff8e8e"
       },
       {
-        "name": "hop-monochromatic-negative-200-hover",
+        "name": "hop-dataviz-monochromatic-negative-200-hover",
         "value": "#f56263"
       },
       {
-        "name": "hop-monochromatic-negative-300-hover",
+        "name": "hop-dataviz-monochromatic-negative-300-hover",
         "value": "#df3236"
       },
       {
-        "name": "hop-monochromatic-negative-400-hover",
+        "name": "hop-dataviz-monochromatic-negative-400-hover",
         "value": "#cb2e31"
       },
       {
-        "name": "hop-monochromatic-negative-500-hover",
+        "name": "hop-dataviz-monochromatic-negative-500-hover",
         "value": "#ba2d2d"
       },
       {
-        "name": "hop-monochromatic-negative-600-hover",
+        "name": "hop-dataviz-monochromatic-negative-600-hover",
         "value": "#952927"
       },
       {
-        "name": "hop-monochromatic-negative-700-hover",
+        "name": "hop-dataviz-monochromatic-negative-700-hover",
         "value": "#6c2320"
       },
       {
-        "name": "hop-monochromatic-negative-800-hover",
+        "name": "hop-dataviz-monochromatic-negative-800-hover",
         "value": "#431a17"
       },
       {
-        "name": "hop-monochromatic-negative-900-hover",
+        "name": "hop-dataviz-monochromatic-negative-900-hover",
         "value": "#2d100d"
       },
       {
-        "name": "hop-diverging-sequence-1-positive9",
+        "name": "hop-dataviz-diverging-sequence-1-positive9",
         "value": "#16433d"
       },
       {
-        "name": "hop-diverging-sequence-1-positive9-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive9-hover",
         "value": "#132a27"
       },
       {
-        "name": "hop-diverging-sequence-1-positive8",
+        "name": "hop-dataviz-diverging-sequence-1-positive8",
         "value": "#115a52"
       },
       {
-        "name": "hop-diverging-sequence-1-positive8-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive8-hover",
         "value": "#16433d"
       },
       {
-        "name": "hop-diverging-sequence-1-positive7",
+        "name": "hop-dataviz-diverging-sequence-1-positive7",
         "value": "#0a6f64"
       },
       {
-        "name": "hop-diverging-sequence-1-positive7-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive7-hover",
         "value": "#115a52"
       },
       {
-        "name": "hop-diverging-sequence-1-positive6",
+        "name": "hop-dataviz-diverging-sequence-1-positive6",
         "value": "#0c796b"
       },
       {
-        "name": "hop-diverging-sequence-1-positive6-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive6-hover",
         "value": "#0a6f64"
       },
       {
-        "name": "hop-diverging-sequence-1-positive5",
+        "name": "hop-dataviz-diverging-sequence-1-positive5",
         "value": "#188a71"
       },
       {
-        "name": "hop-diverging-sequence-1-positive5-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive5-hover",
         "value": "#0c796b"
       },
       {
-        "name": "hop-diverging-sequence-1-positive4",
+        "name": "hop-dataviz-diverging-sequence-1-positive4",
         "value": "#47a584"
       },
       {
-        "name": "hop-diverging-sequence-1-positive-4-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive-4-hover",
         "value": "#188a71"
       },
       {
-        "name": "hop-diverging-sequence-1-positive3",
+        "name": "hop-dataviz-diverging-sequence-1-positive3",
         "value": "#7dc291"
       },
       {
-        "name": "hop-diverging-sequence-1-positive3-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive3-hover",
         "value": "#47a584"
       },
       {
-        "name": "hop-diverging-sequence-1-positive2",
+        "name": "hop-dataviz-diverging-sequence-1-positive2",
         "value": "#aad89d"
       },
       {
-        "name": "hop-diverging-sequence-1-positive2-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive2-hover",
         "value": "#7dc291"
       },
       {
-        "name": "hop-diverging-sequence-1-positive1",
+        "name": "hop-dataviz-diverging-sequence-1-positive1",
         "value": "#cde8ac"
       },
       {
-        "name": "hop-diverging-sequence-1-positive1-hover",
+        "name": "hop-dataviz-diverging-sequence-1-positive1-hover",
         "value": "#aad89d"
       },
       {
-        "name": "hop-diverging-sequence-1-neutral",
+        "name": "hop-dataviz-diverging-sequence-1-neutral",
         "value": "#f7e694"
       },
       {
-        "name": "hop-diverging-sequence-1-neutral-hover",
+        "name": "hop-dataviz-diverging-sequence-1-neutral-hover",
         "value": "#eac96d"
       },
       {
-        "name": "hop-diverging-sequence-1-negative1",
+        "name": "hop-dataviz-diverging-sequence-1-negative1",
         "value": "#ffd8be"
       },
       {
-        "name": "hop-diverging-sequence-1-negative1-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative1-hover",
         "value": "#ffbcb7"
       },
       {
-        "name": "hop-diverging-sequence-1-negative2",
+        "name": "hop-dataviz-diverging-sequence-1-negative2",
         "value": "#ffbcb7"
       },
       {
-        "name": "hop-diverging-sequence-1-negative2-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative2-hover",
         "value": "#ff8e8e"
       },
       {
-        "name": "hop-diverging-sequence-1-negative3",
+        "name": "hop-dataviz-diverging-sequence-1-negative3",
         "value": "#ff8e8e"
       },
       {
-        "name": "hop-diverging-sequence-1-negative3-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative3-hover",
         "value": "#f56263"
       },
       {
-        "name": "hop-diverging-sequence-1-negative4",
+        "name": "hop-dataviz-diverging-sequence-1-negative4",
         "value": "#f56263"
       },
       {
-        "name": "hop-diverging-sequence-1-negative4-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative4-hover",
         "value": "#df3236"
       },
       {
-        "name": "hop-diverging-sequence-1-negative5",
+        "name": "hop-dataviz-diverging-sequence-1-negative5",
         "value": "#df3236"
       },
       {
-        "name": "hop-diverging-sequence-1-negative5-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative5-hover",
         "value": "#cb2e31"
       },
       {
-        "name": "hop-diverging-sequence-1-negative6",
+        "name": "hop-dataviz-diverging-sequence-1-negative6",
         "value": "#cb2e31"
       },
       {
-        "name": "hop-diverging-sequence-1-negative6-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative6-hover",
         "value": "#ba2d2d"
       },
       {
-        "name": "hop-diverging-sequence-1-negative7",
+        "name": "hop-dataviz-diverging-sequence-1-negative7",
         "value": "#ba2d2d"
       },
       {
-        "name": "hop-diverging-sequence-1-negative7-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative7-hover",
         "value": "#952927"
       },
       {
-        "name": "hop-diverging-sequence-1-negative8",
+        "name": "hop-dataviz-diverging-sequence-1-negative8",
         "value": "#952927"
       },
       {
-        "name": "hop-diverging-sequence-1-negative8-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative8-hover",
         "value": "#6c2320"
       },
       {
-        "name": "hop-diverging-sequence-1-negative9",
+        "name": "hop-dataviz-diverging-sequence-1-negative9",
         "value": "#6c2320"
       },
       {
-        "name": "hop-diverging-sequence-1-negative9-hover",
+        "name": "hop-dataviz-diverging-sequence-1-negative9-hover",
         "value": "#431a17"
       },
       {
-        "name": "hop-diverging-sequence-2-positive10",
+        "name": "hop-dataviz-diverging-sequence-2-positive10",
         "value": "#16433d"
       },
       {
-        "name": "hop-diverging-sequence-2-positive10-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive10-hover",
         "value": "#132a27"
       },
       {
-        "name": "hop-diverging-sequence-2-positive9",
+        "name": "hop-dataviz-diverging-sequence-2-positive9",
         "value": "#115a52"
       },
       {
-        "name": "hop-diverging-sequence-2-positive9-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive9-hover",
         "value": "#16433d"
       },
       {
-        "name": "hop-diverging-sequence-2-positive8",
+        "name": "hop-dataviz-diverging-sequence-2-positive8",
         "value": "#0a6f64"
       },
       {
-        "name": "hop-diverging-sequence-2-positive8-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive8-hover",
         "value": "#115a52"
       },
       {
-        "name": "hop-diverging-sequence-2-positive7",
+        "name": "hop-dataviz-diverging-sequence-2-positive7",
         "value": "#0c796b"
       },
       {
-        "name": "hop-diverging-sequence-2-positive7-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive7-hover",
         "value": "#0a6f64"
       },
       {
-        "name": "hop-diverging-sequence-2-positive6",
+        "name": "hop-dataviz-diverging-sequence-2-positive6",
         "value": "#188a71"
       },
       {
-        "name": "hop-diverging-sequence-2-positive6-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive6-hover",
         "value": "#0c796b"
       },
       {
-        "name": "hop-diverging-sequence-2-positive5",
+        "name": "hop-dataviz-diverging-sequence-2-positive5",
         "value": "#47a584"
       },
       {
-        "name": "hop-diverging-sequence-2-positive5-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive5-hover",
         "value": "#188a71"
       },
       {
-        "name": "hop-diverging-sequence-2-positive4",
+        "name": "hop-dataviz-diverging-sequence-2-positive4",
         "value": "#7dc291"
       },
       {
-        "name": "hop-diverging-sequence-2-positive4-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive4-hover",
         "value": "#47a584"
       },
       {
-        "name": "hop-diverging-sequence-2-positive3",
+        "name": "hop-dataviz-diverging-sequence-2-positive3",
         "value": "#aad89d"
       },
       {
-        "name": "hop-diverging-sequence-2-positive3-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive3-hover",
         "value": "#7dc291"
       },
       {
-        "name": "hop-diverging-sequence-2-positive2",
+        "name": "hop-dataviz-diverging-sequence-2-positive2",
         "value": "#cde8ac"
       },
       {
-        "name": "hop-diverging-sequence-2-positive2-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive2-hover",
         "value": "#aad89d"
       },
       {
-        "name": "hop-diverging-sequence-2-positive1",
+        "name": "hop-dataviz-diverging-sequence-2-positive1",
         "value": "#e3f3b9"
       },
       {
-        "name": "hop-diverging-sequence-2-positive1-hover",
+        "name": "hop-dataviz-diverging-sequence-2-positive1-hover",
         "value": "#cde8ac"
       },
       {
-        "name": "hop-diverging-sequence-2-negative1",
+        "name": "hop-dataviz-diverging-sequence-2-negative1",
         "value": "#fde6e5"
       },
       {
-        "name": "hop-diverging-sequence-2-negative1-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative1-hover",
         "value": "#ffd6d3"
       },
       {
-        "name": "hop-diverging-sequence-2-negative2",
+        "name": "hop-dataviz-diverging-sequence-2-negative2",
         "value": "#ffd6d3"
       },
       {
-        "name": "hop-diverging-sequence-2-negative2-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative2-hover",
         "value": "#ffbcb7"
       },
       {
-        "name": "hop-diverging-sequence-2-negative3",
+        "name": "hop-dataviz-diverging-sequence-2-negative3",
         "value": "#ffbcb7"
       },
       {
-        "name": "hop-diverging-sequence-2-negative3-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative3-hover",
         "value": "#ff8e8e"
       },
       {
-        "name": "hop-diverging-sequence-2-negative4",
+        "name": "hop-dataviz-diverging-sequence-2-negative4",
         "value": "#ff8e8e"
       },
       {
-        "name": "hop-diverging-sequence-2-negative4-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative4-hover",
         "value": "#f56263"
       },
       {
-        "name": "hop-diverging-sequence-2-negative5",
+        "name": "hop-dataviz-diverging-sequence-2-negative5",
         "value": "#f56263"
       },
       {
-        "name": "hop-diverging-sequence-2-negative5-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative5-hover",
         "value": "#df3236"
       },
       {
-        "name": "hop-diverging-sequence-2-negative6",
+        "name": "hop-dataviz-diverging-sequence-2-negative6",
         "value": "#df3236"
       },
       {
-        "name": "hop-diverging-sequence-2-negative6-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative6-hover",
         "value": "#cb2e31"
       },
       {
-        "name": "hop-diverging-sequence-2-negative7",
+        "name": "hop-dataviz-diverging-sequence-2-negative7",
         "value": "#cb2e31"
       },
       {
-        "name": "hop-diverging-sequence-2-negative7-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative7-hover",
         "value": "#ba2d2d"
       },
       {
-        "name": "hop-diverging-sequence-2-negative8",
+        "name": "hop-dataviz-diverging-sequence-2-negative8",
         "value": "#ba2d2d"
       },
       {
-        "name": "hop-diverging-sequence-2-negative8-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative8-hover",
         "value": "#952927"
       },
       {
-        "name": "hop-diverging-sequence-2-negative9",
+        "name": "hop-dataviz-diverging-sequence-2-negative9",
         "value": "#952927"
       },
       {
-        "name": "hop-diverging-sequence-2-negative9-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative9-hover",
         "value": "#6c2320"
       },
       {
-        "name": "hop-diverging-sequence-2-negative10",
+        "name": "hop-dataviz-diverging-sequence-2-negative10",
         "value": "#6c2320"
       },
       {
-        "name": "hop-diverging-sequence-2-negative10-hover",
+        "name": "hop-dataviz-diverging-sequence-2-negative10-hover",
         "value": "#431a17"
       },
       {
-        "name": "hop-categorical-sequence-category1",
+        "name": "hop-dataviz-categorical-sequence-category1",
         "value": "#c7ebff"
       },
       {
-        "name": "hop-categorical-sequence-category1-hover",
+        "name": "hop-dataviz-categorical-sequence-category1-hover",
         "value": "#ade2ff"
       },
       {
-        "name": "hop-categorical-sequence-category2",
+        "name": "hop-dataviz-categorical-sequence-category2",
         "value": "#ecd599"
       },
       {
-        "name": "hop-categorical-sequence-category2-hover",
+        "name": "hop-dataviz-categorical-sequence-category2-hover",
         "value": "#e6c675"
       },
       {
-        "name": "hop-categorical-sequence-category3",
+        "name": "hop-dataviz-categorical-sequence-category3",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-sequence-category3-hover",
+        "name": "hop-dataviz-categorical-sequence-category3-hover",
         "value": "#bfb8f5"
       },
       {
-        "name": "hop-categorical-sequence-category4",
+        "name": "hop-dataviz-categorical-sequence-category4",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-sequence-category4-hover",
+        "name": "hop-dataviz-categorical-sequence-category4-hover",
         "value": "#a4ae98"
       },
       {
-        "name": "hop-categorical-sequence-category5",
+        "name": "hop-dataviz-categorical-sequence-category5",
         "value": "#fbbdcf"
       },
       {
-        "name": "hop-categorical-sequence-category5-hover",
+        "name": "hop-dataviz-categorical-sequence-category5-hover",
         "value": "#f99fb8"
       },
       {
-        "name": "hop-categorical-sequence-category6",
+        "name": "hop-dataviz-categorical-sequence-category6",
         "value": "#bfdca9"
       },
       {
-        "name": "hop-categorical-sequence-category6-hover",
+        "name": "hop-dataviz-categorical-sequence-category6-hover",
         "value": "#a9d08b"
       },
       {
-        "name": "hop-categorical-sequence-category7",
+        "name": "hop-dataviz-categorical-sequence-category7",
         "value": "#fbe997"
       },
       {
-        "name": "hop-categorical-sequence-category7-hover",
+        "name": "hop-dataviz-categorical-sequence-category7-hover",
         "value": "#fae275"
       },
       {
-        "name": "hop-categorical-sequence-category8",
+        "name": "hop-dataviz-categorical-sequence-category8",
         "value": "#e8ddd0"
       },
       {
-        "name": "hop-categorical-sequence-category8-hover",
+        "name": "hop-dataviz-categorical-sequence-category8-hover",
         "value": "#ddcebb"
       },
       {
-        "name": "hop-categorical-sequence-category9",
+        "name": "hop-dataviz-categorical-sequence-category9",
         "value": "#a7e6dc"
       },
       {
-        "name": "hop-categorical-sequence-category9-hover",
+        "name": "hop-dataviz-categorical-sequence-category9-hover",
         "value": "#90e0d2"
       },
       {
-        "name": "hop-categorical-sequence-category10",
+        "name": "hop-dataviz-categorical-sequence-category10",
         "value": "#aecdd5"
       },
       {
-        "name": "hop-categorical-sequence-category10-hover",
+        "name": "hop-dataviz-categorical-sequence-category10-hover",
         "value": "#93bdc8"
       },
       {
-        "name": "hop-categorical-sequence-category11",
+        "name": "hop-dataviz-categorical-sequence-category11",
         "value": "#ffbf92"
       },
       {
-        "name": "hop-categorical-sequence-category-11-hover",
+        "name": "hop-dataviz-categorical-sequence-category-11-hover",
         "value": "#ffac70"
       },
       {
-        "name": "hop-categorical-sequence-category12",
+        "name": "hop-dataviz-categorical-sequence-category12",
         "value": "#a0b8fa"
       },
       {
-        "name": "hop-categorical-sequence-cateogry12-hover",
+        "name": "hop-dataviz-categorical-sequence-cateogry12-hover",
         "value": "#779af8"
       },
       {
-        "name": "hop-categorical-sequence-category13",
+        "name": "hop-dataviz-categorical-sequence-category13",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-sequence-category13-hover",
+        "name": "hop-dataviz-categorical-sequence-category13-hover",
         "value": "#54b692"
       },
       {
-        "name": "hop-categorical-2colorgroup-option6-category2",
+        "name": "hop-dataviz-categorical-2colorgroup-option6-category2",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-2colorgroup-option6-category1",
+        "name": "hop-dataviz-categorical-2colorgroup-option6-category1",
         "value": "#ffbf92"
       },
       {
-        "name": "hop-categorical-2colorgroup-option5-category2",
+        "name": "hop-dataviz-categorical-2colorgroup-option5-category2",
         "value": "#a0b8fa"
       },
       {
-        "name": "hop-categorical-2colorgroup-option5-category1",
+        "name": "hop-dataviz-categorical-2colorgroup-option5-category1",
         "value": "#a7e6dc"
       },
       {
-        "name": "hop-categorical-2colorgroup-option4-category2",
+        "name": "hop-dataviz-categorical-2colorgroup-option4-category2",
         "value": "#6c8ffd"
       },
       {
-        "name": "hop-categorical-2colorgroup-option4-category1",
+        "name": "hop-dataviz-categorical-2colorgroup-option4-category1",
         "value": "#bfdca9"
       },
       {
-        "name": "hop-categorical-2colorgroup-option3-category2",
+        "name": "hop-dataviz-categorical-2colorgroup-option3-category2",
         "value": "#ff9b3f"
       },
       {
-        "name": "hop-categorical-2colorgroup-option3-category1",
+        "name": "hop-dataviz-categorical-2colorgroup-option3-category1",
         "value": "#2f48ff"
       },
       {
-        "name": "hop-categorical-2colorgroup-option2-category2",
+        "name": "hop-dataviz-categorical-2colorgroup-option2-category2",
         "value": "#fbe997"
       },
       {
-        "name": "hop-categorical-2colorgroup-option2-category1",
+        "name": "hop-dataviz-categorical-2colorgroup-option2-category1",
         "value": "#fbbdcf"
       },
       {
-        "name": "hop-categorical-2colorgroup-option1-category2",
+        "name": "hop-dataviz-categorical-2colorgroup-option1-category2",
         "value": "#c7ebff"
       },
       {
-        "name": "hop-categorical-2colorgroup-option1-category1",
+        "name": "hop-dataviz-categorical-2colorgroup-option1-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-3colorgroup-option1-category1",
+        "name": "hop-dataviz-categorical-3colorgroup-option1-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-3colorgroup-option1-category2",
+        "name": "hop-dataviz-categorical-3colorgroup-option1-category2",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-3colorgroup-option1-category3",
+        "name": "hop-dataviz-categorical-3colorgroup-option1-category3",
         "value": "#bfdca9"
       },
       {
-        "name": "hop-categorical-3colorgroup-option2-category1",
+        "name": "hop-dataviz-categorical-3colorgroup-option2-category1",
         "value": "#ecd599"
       },
       {
-        "name": "hop-categorical-3colorgroup-option2-category2",
+        "name": "hop-dataviz-categorical-3colorgroup-option2-category2",
         "value": "#a7e6dc"
       },
       {
-        "name": "hop-categorical-3colorgroup-option2-category3",
+        "name": "hop-dataviz-categorical-3colorgroup-option2-category3",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-3colorgroup-option3-category1",
+        "name": "hop-dataviz-categorical-3colorgroup-option3-category1",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-3colorgroup-option3-category2",
+        "name": "hop-dataviz-categorical-3colorgroup-option3-category2",
         "value": "#fbe997"
       },
       {
-        "name": "hop-categorical-3colorgroup-option3-category3",
+        "name": "hop-dataviz-categorical-3colorgroup-option3-category3",
         "value": "#aecdd5"
       },
       {
-        "name": "hop-categorical-3colorgroup-option4-category1",
+        "name": "hop-dataviz-categorical-3colorgroup-option4-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-3colorgroup-option4-category2",
+        "name": "hop-dataviz-categorical-3colorgroup-option4-category2",
         "value": "#a0b8fa"
       },
       {
-        "name": "hop-categorical-3colorgroup-option4-category3",
+        "name": "hop-dataviz-categorical-3colorgroup-option4-category3",
         "value": "#fbbdcf"
       },
       {
-        "name": "hop-categorical-4colorgroup-option1-category1",
+        "name": "hop-dataviz-categorical-4colorgroup-option1-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-4colorgroup-option1-category2",
+        "name": "hop-dataviz-categorical-4colorgroup-option1-category2",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-4colorgroup-option1-category3",
+        "name": "hop-dataviz-categorical-4colorgroup-option1-category3",
         "value": "#cde8ac"
       },
       {
-        "name": "hop-categorical-4colorgroup-option1-category4",
+        "name": "hop-dataviz-categorical-4colorgroup-option1-category4",
         "value": "#fbbdcf"
       },
       {
-        "name": "hop-categorical-4colorgroup-option2-category1",
+        "name": "hop-dataviz-categorical-4colorgroup-option2-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-4colorgroup-option2-category2",
+        "name": "hop-dataviz-categorical-4colorgroup-option2-category2",
         "value": "#c7ebff"
       },
       {
-        "name": "hop-categorical-4colorgroup-option2-category3",
+        "name": "hop-dataviz-categorical-4colorgroup-option2-category3",
         "value": "#84d0b4"
       },
       {
-        "name": "hop-categorical-4colorgroup-option2-category4",
+        "name": "hop-dataviz-categorical-4colorgroup-option2-category4",
         "value": "#fbe997"
       },
       {
-        "name": "hop-categorical-4colorgroup-option3-category1",
+        "name": "hop-dataviz-categorical-4colorgroup-option3-category1",
         "value": "#ffbf92"
       },
       {
-        "name": "hop-categorical-4colorgroup-option3-category2",
+        "name": "hop-dataviz-categorical-4colorgroup-option3-category2",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-4colorgroup-option3-category3",
+        "name": "hop-dataviz-categorical-4colorgroup-option3-category3",
         "value": "#2e70a8"
       },
       {
-        "name": "hop-categorical-4colorgroup-option3-category4",
+        "name": "hop-dataviz-categorical-4colorgroup-option3-category4",
         "value": "#ecd599"
       },
       {
-        "name": "hop-categorical-4colorgroup-option4-category1",
+        "name": "hop-dataviz-categorical-4colorgroup-option4-category1",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-4colorgroup-option4-category2",
+        "name": "hop-dataviz-categorical-4colorgroup-option4-category2",
         "value": "#c7ebff"
       },
       {
-        "name": "hop-categorical-4colorgroup-option4-category3",
+        "name": "hop-dataviz-categorical-4colorgroup-option4-category3",
         "value": "#fa4d59"
       },
       {
-        "name": "hop-categorical-4colorgroup-option4-category4",
+        "name": "hop-dataviz-categorical-4colorgroup-option4-category4",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-5colorgroup-option1-category1",
+        "name": "hop-dataviz-categorical-5colorgroup-option1-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-5colorgroup-option1-category2",
+        "name": "hop-dataviz-categorical-5colorgroup-option1-category2",
         "value": "#ff9b3f"
       },
       {
-        "name": "hop-categorical-5colorgroup-option1-category3",
+        "name": "hop-dataviz-categorical-5colorgroup-option1-category3",
         "value": "#bfdca9"
       },
       {
-        "name": "hop-categorical-5colorgroup-option1-category4",
+        "name": "hop-dataviz-categorical-5colorgroup-option1-category4",
         "value": "#ecd599"
       },
       {
-        "name": "hop-categorical-5colorgroup-option1-category5",
+        "name": "hop-dataviz-categorical-5colorgroup-option1-category5",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-5colorgroup-option2-category1",
+        "name": "hop-dataviz-categorical-5colorgroup-option2-category1",
         "value": "#ff9b3f"
       },
       {
-        "name": "hop-categorical-5colorgroup-option2-category2",
+        "name": "hop-dataviz-categorical-5colorgroup-option2-category2",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-5colorgroup-option2-category3",
+        "name": "hop-dataviz-categorical-5colorgroup-option2-category3",
         "value": "#2e70a8"
       },
       {
-        "name": "hop-categorical-5colorgroup-option2-category4",
+        "name": "hop-dataviz-categorical-5colorgroup-option2-category4",
         "value": "#fbe997"
       },
       {
-        "name": "hop-categorical-5colorgroup-option2-category5",
+        "name": "hop-dataviz-categorical-5colorgroup-option2-category5",
         "value": "#c5bef6"
       },
       {
-        "name": "hop-categorical-5colorgroup-option3-category1",
+        "name": "hop-dataviz-categorical-5colorgroup-option3-category1",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-5colorgroup-option3-category2",
+        "name": "hop-dataviz-categorical-5colorgroup-option3-category2",
         "value": "#ecd599"
       },
       {
-        "name": "hop-categorical-5colorgroup-option3-category3",
+        "name": "hop-dataviz-categorical-5colorgroup-option3-category3",
         "value": "#aecdd5"
       },
       {
-        "name": "hop-categorical-5colorgroup-option3-category4",
+        "name": "hop-dataviz-categorical-5colorgroup-option3-category4",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-5colorgroup-option3-category5",
+        "name": "hop-dataviz-categorical-5colorgroup-option3-category5",
         "value": "#ffbf92"
       },
       {
-        "name": "hop-categorical-5colorgroup-option4-category1",
+        "name": "hop-dataviz-categorical-5colorgroup-option4-category1",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-5colorgroup-option4-category2",
+        "name": "hop-dataviz-categorical-5colorgroup-option4-category2",
         "value": "#c7ebff"
       },
       {
-        "name": "hop-categorical-5colorgroup-option4-category3",
+        "name": "hop-dataviz-categorical-5colorgroup-option4-category3",
         "value": "#fa4d59"
       },
       {
-        "name": "hop-categorical-5colorgroup-option4-category4",
+        "name": "hop-dataviz-categorical-5colorgroup-option4-category4",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-5colorgroup-option4-category5",
+        "name": "hop-dataviz-categorical-5colorgroup-option4-category5",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-6colorgroup-option1-category1",
+        "name": "hop-dataviz-categorical-6colorgroup-option1-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-6colorgroup-option1-category2",
+        "name": "hop-dataviz-categorical-6colorgroup-option1-category2",
         "value": "#a0b8fa"
       },
       {
-        "name": "hop-categorical-6colorgroup-option1-category3",
+        "name": "hop-dataviz-categorical-6colorgroup-option1-category3",
         "value": "#bfdca9"
       },
       {
-        "name": "hop-categorical-6colorgroup-option1-category4",
+        "name": "hop-dataviz-categorical-6colorgroup-option1-category4",
         "value": "#fa4d59"
       },
       {
-        "name": "hop-categorical-6colorgroup-option1-category5",
+        "name": "hop-dataviz-categorical-6colorgroup-option1-category5",
         "value": "#ecd599"
       },
       {
-        "name": "hop-categorical-6colorgroup-option1-category6",
+        "name": "hop-dataviz-categorical-6colorgroup-option1-category6",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-6colorgroup-option2-category1",
+        "name": "hop-dataviz-categorical-6colorgroup-option2-category1",
         "value": "#2e70a8"
       },
       {
-        "name": "hop-categorical-6colorgroup-option2-category2",
+        "name": "hop-dataviz-categorical-6colorgroup-option2-category2",
         "value": "#fbe997"
       },
       {
-        "name": "hop-categorical-6colorgroup-option2-category3",
+        "name": "hop-dataviz-categorical-6colorgroup-option2-category3",
         "value": "#69bfa0"
       },
       {
-        "name": "hop-categorical-6colorgroup-option2-category4",
+        "name": "hop-dataviz-categorical-6colorgroup-option2-category4",
         "value": "#ff9b3f"
       },
       {
-        "name": "hop-categorical-6colorgroup-option2-category5",
+        "name": "hop-dataviz-categorical-6colorgroup-option2-category5",
         "value": "#a7e6dc"
       },
       {
-        "name": "hop-categorical-6colorgroup-option2-category6",
+        "name": "hop-dataviz-categorical-6colorgroup-option2-category6",
         "value": "#d2cdf8"
       },
       {
-        "name": "hop-categorical-6colorgroup-option3-category1",
+        "name": "hop-dataviz-categorical-6colorgroup-option3-category1",
         "value": "#b6bead"
       },
       {
-        "name": "hop-categorical-6colorgroup-option3-category2",
+        "name": "hop-dataviz-categorical-6colorgroup-option3-category2",
         "value": "#aecdd5"
       },
       {
-        "name": "hop-categorical-6colorgroup-option3-category3",
+        "name": "hop-dataviz-categorical-6colorgroup-option3-category3",
         "value": "#e8ddd0"
       },
       {
-        "name": "hop-categorical-6colorgroup-option3-category4",
+        "name": "hop-dataviz-categorical-6colorgroup-option3-category4",
         "value": "#a7e6dc"
       },
       {
-        "name": "hop-categorical-6colorgroup-option3-category5",
+        "name": "hop-dataviz-categorical-6colorgroup-option3-category5",
         "value": "#2e70a8"
       },
       {
-        "name": "hop-categorical-6colorgroup-option3-category6",
+        "name": "hop-dataviz-categorical-6colorgroup-option3-category6",
         "value": "#fbbdcf"
       },
       {
-        "name": "hop-categorical-6colorgroup-option4-category1",
+        "name": "hop-dataviz-categorical-6colorgroup-option4-category1",
         "value": "#fbbdcf"
       },
       {
-        "name": "hop-categorical-6colorgroup-option4-category2",
+        "name": "hop-dataviz-categorical-6colorgroup-option4-category2",
         "value": "#a0b8fa"
       },
       {
-        "name": "hop-categorical-6colorgroup-option4-category3",
+        "name": "hop-dataviz-categorical-6colorgroup-option4-category3",
         "value": "#ffbf92"
       },
       {
-        "name": "hop-categorical-6colorgroup-option4-category4",
+        "name": "hop-dataviz-categorical-6colorgroup-option4-category4",
         "value": "#c7ebff"
       },
       {
-        "name": "hop-categorical-6colorgroup-option4-category5",
+        "name": "hop-dataviz-categorical-6colorgroup-option4-category5",
         "value": "#bfdca9"
       },
       {
-        "name": "hop-categorical-6colorgroup-option4-category6",
+        "name": "hop-dataviz-categorical-6colorgroup-option4-category6",
         "value": "#fbe997"
       },
       {
-        "name": "hop-unavailable",
+        "name": "hop-dataviz-unavailable",
         "value": "#e0dfdd"
       },
       {
-        "name": "hop-unavailable-weak",
+        "name": "hop-dataviz-unavailable-weak",
         "value": "#ecebe8"
       },
       {
-        "name": "hop-unavailable-strong",
+        "name": "hop-dataviz-unavailable-strong",
         "value": "#ccccca"
       },
       {
-        "name": "hop-text-onlight",
+        "name": "hop-dataviz-text-onlight",
         "value": "#3c3c3c"
       },
       {
-        "name": "hop-text-ondark",
+        "name": "hop-dataviz-text-ondark",
         "value": "#ffffff"
       }
     ],

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -45,8 +45,7 @@
         "@workleap/tsup-configs": "3.0.1",
         "@workleap/typescript-configs": "3.0.2",
         "tsup": "7.2.0",
-        "typescript": "5.2.2",
-        "style-dictionary": "3.9.0"
+        "typescript": "5.2.2"
     },
     "sideEffects": false,
     "engines": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -37,16 +37,16 @@
         "build": "pnpm run build:ts && pnpm run build:tokens && pnpm run clean:build"
     },
     "dependencies": {
-        "style-dictionary": "^3.8.0"
+        "style-dictionary": "3.9.0"
     },
     "devDependencies": {
-        "@types/react": "^18.2.23",
-        "@types/node": "18.15.11",
-        "@workleap/eslint-plugin": "1.8.1",
-        "@workleap/tsup-configs": "^2.0.0",
-        "@workleap/typescript-configs": "2.3.1",
-        "tsup": "^7.1.0",
-        "typescript": "5.0.3"
+        "@types/node": "20.8.10",
+        "@workleap/eslint-plugin": "3.0.0",
+        "@workleap/tsup-configs": "3.0.1",
+        "@workleap/typescript-configs": "3.0.2",
+        "tsup": "7.2.0",
+        "typescript": "5.2.2",
+        "style-dictionary": "3.9.0"
     },
     "sideEffects": false,
     "engines": {

--- a/packages/tokens/src/stories/components/List.tsx
+++ b/packages/tokens/src/stories/components/List.tsx
@@ -1,14 +1,81 @@
+import type { ComponentProps } from "react";
 import "./list.css";
 
+interface Style { name: string; value: string }
+type TokenType = "core" | "background" | "border" | "text" | "icon" | "dataViz";
 interface ListProps {
-    styles: { name: string; value: string }[];
+    styles: Style[];
+    tokenType: TokenType;
 }
 
-export const List = ({ styles }: ListProps) => {
-    const listItems = styles.map(style => {
+interface DisplayComponentProps extends ComponentProps<"div">{
+    value: Style["value"];
+    tokenType : TokenType;
+}
+
+function DisplayComponent({ value, tokenType, style, ...rest }: DisplayComponentProps) {
+    switch (tokenType) {
+        case "core":
+            return (
+                <div style={{ backgroundColor: value, ...style }} {...rest}>
+                </div>);
+        case "background":
+            return (
+                <div {...rest} style={{ backgroundColor: value, ...style }} >
+                </div>);
+        case "border":
+            return (
+                <div {...rest} style={{ border: `1px solid ${value}`, backgroundColor: value === "#ffffff" ? "black" : undefined, ...style }} >
+                </div>);
+        case "text":
+            return (
+                <div {...rest} style={{ color: value, backgroundColor: value === "#ffffff" ? "black" : undefined, ...style }} >
+                    Aa
+                </div>);
+        case "icon":
+            return (
+                <div {...rest} style={{ color: value, backgroundColor: value === "#ffffff" ? "black" : undefined, ...style }} >
+                    {/* eslint-disable-next-line max-len */}
+                    <svg viewBox="0 0 24 24" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        {/* eslint-disable-next-line max-len */}
+                        <path fillRule="evenodd" clipRule="evenodd" d="M12.673 4.557a.75.75 0 0 0-1.345 0L9.173 8.923l-4.819.7a.75.75 0 0 0-.416 1.28L7.425 14.3l-.823 4.8a.75.75 0 0 0 1.088.79L12 17.625l4.31 2.266a.75.75 0 0 0 1.088-.79l-.823-4.8 3.487-3.399a.75.75 0 0 0-.416-1.279l-4.819-.7-2.154-4.366Z" fill="currentColor"></path>
+                    </svg>
+                </div>);
+        case "dataViz":
+            return (
+                <div {...rest} style={{ backgroundColor: value, ...style }} >
+                </div>);
+    }
+}
+
+function filterByTokenType(styles: Style[], tokenType: TokenType) {
+    switch (tokenType) {
+        case "core":
+            return styles.filter(style =>
+                !style.name.includes("core") &&
+                !style.name.includes("surface") &&
+                !style.name.includes("border") &&
+                !style.name.includes("text") &&
+                !style.name.includes("icon")
+            );
+        case "background":
+            return styles.filter(style => style.name.includes("surface"));
+        case "border":
+            return styles.filter(style => style.name.includes("border"));
+        case "text":
+            return styles.filter(style => style.name.includes("text"));
+        case "icon":
+            return styles.filter(style => style.name.includes("icon"));
+        case "dataViz":
+            return styles.filter(style => style.name.includes("dataviz"));
+    }
+}
+
+export const List = ({ styles, tokenType }: ListProps) => {
+    const listItems = filterByTokenType(styles, tokenType).map(style => {
         return (
             <li className="list__item" key={style.name} >
-                <div className="list__color" style={{ backgroundColor: style.value }} />
+                <DisplayComponent className="list__color" value={style.value} tokenType={tokenType} />
                 <span className="list__value">{style.value}</span>
                 <span className="list__name">{style.name}</span>
             </li>);

--- a/packages/tokens/src/stories/components/List.tsx
+++ b/packages/tokens/src/stories/components/List.tsx
@@ -3,6 +3,7 @@ import "./list.css";
 
 export interface Style { name: string; value: string }
 export type TokenType = "core" | "background" | "border" | "text" | "icon" | "dataViz";
+
 interface ListProps {
     styles: Style[];
     tokenType: TokenType;

--- a/packages/tokens/src/stories/components/List.tsx
+++ b/packages/tokens/src/stories/components/List.tsx
@@ -1,12 +1,26 @@
 import type { ComponentProps } from "react";
 import "./list.css";
 
-interface Style { name: string; value: string }
-type TokenType = "core" | "background" | "border" | "text" | "icon" | "dataViz";
+export interface Style { name: string; value: string }
+export type TokenType = "core" | "background" | "border" | "text" | "icon" | "dataViz";
 interface ListProps {
     styles: Style[];
     tokenType: TokenType;
 }
+
+export const List = ({ styles, tokenType }: ListProps) => {
+    const listItems = styles.map(style => {
+        return (
+            <li className="list__item" key={style.name} >
+                <DisplayComponent className="list__color" value={style.value} tokenType={tokenType} />
+                <span className="list__value">{style.value}</span>
+                <span className="list__name">{style.name}</span>
+            </li>);
+    });
+
+    return <ul className="list">{listItems}</ul>;
+};
+
 
 interface DisplayComponentProps extends ComponentProps<"div">{
     value: Style["value"];
@@ -16,12 +30,10 @@ interface DisplayComponentProps extends ComponentProps<"div">{
 function DisplayComponent({ value, tokenType, style, ...rest }: DisplayComponentProps) {
     switch (tokenType) {
         case "core":
+        case "background":
+        case "dataViz":
             return (
                 <div style={{ backgroundColor: value, ...style }} {...rest}>
-                </div>);
-        case "background":
-            return (
-                <div {...rest} style={{ backgroundColor: value, ...style }} >
                 </div>);
         case "border":
             return (
@@ -35,51 +47,10 @@ function DisplayComponent({ value, tokenType, style, ...rest }: DisplayComponent
         case "icon":
             return (
                 <div {...rest} style={{ color: value, backgroundColor: value === "#ffffff" ? "black" : undefined, ...style }} >
-                    {/* eslint-disable-next-line max-len */}
                     <svg viewBox="0 0 24 24" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         {/* eslint-disable-next-line max-len */}
                         <path fillRule="evenodd" clipRule="evenodd" d="M12.673 4.557a.75.75 0 0 0-1.345 0L9.173 8.923l-4.819.7a.75.75 0 0 0-.416 1.28L7.425 14.3l-.823 4.8a.75.75 0 0 0 1.088.79L12 17.625l4.31 2.266a.75.75 0 0 0 1.088-.79l-.823-4.8 3.487-3.399a.75.75 0 0 0-.416-1.279l-4.819-.7-2.154-4.366Z" fill="currentColor"></path>
                     </svg>
                 </div>);
-        case "dataViz":
-            return (
-                <div {...rest} style={{ backgroundColor: value, ...style }} >
-                </div>);
     }
 }
-
-function filterByTokenType(styles: Style[], tokenType: TokenType) {
-    switch (tokenType) {
-        case "core":
-            return styles.filter(style =>
-                !style.name.includes("core") &&
-                !style.name.includes("surface") &&
-                !style.name.includes("border") &&
-                !style.name.includes("text") &&
-                !style.name.includes("icon")
-            );
-        case "background":
-            return styles.filter(style => style.name.includes("surface"));
-        case "border":
-            return styles.filter(style => style.name.includes("border"));
-        case "text":
-            return styles.filter(style => style.name.includes("text"));
-        case "icon":
-            return styles.filter(style => style.name.includes("icon"));
-        case "dataViz":
-            return styles.filter(style => style.name.includes("dataviz"));
-    }
-}
-
-export const List = ({ styles, tokenType }: ListProps) => {
-    const listItems = filterByTokenType(styles, tokenType).map(style => {
-        return (
-            <li className="list__item" key={style.name} >
-                <DisplayComponent className="list__color" value={style.value} tokenType={tokenType} />
-                <span className="list__value">{style.value}</span>
-                <span className="list__name">{style.name}</span>
-            </li>);
-    });
-
-    return <ul className="list">{listItems}</ul>;
-};

--- a/packages/tokens/src/stories/components/list.css
+++ b/packages/tokens/src/stories/components/list.css
@@ -17,6 +17,9 @@
 .list__color {
     width: 3rem;
     aspect-ratio: 16/9;
+    display:flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .list__value {

--- a/packages/tokens/src/stories/tokens.stories.ts
+++ b/packages/tokens/src/stories/tokens.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { List } from "./components/List.tsx";
+import { List, type Style, type TokenType } from "./components/List.tsx";
 import darkTokens from "./datas/tokens-dark.json";
 import tokens from "./datas/tokens.json";
 
@@ -8,88 +8,114 @@ export default {
     component: List
 } satisfies Meta<typeof List>;
 
+
+function filterByTokenType(styles: Style[], tokenType: TokenType) {
+    switch (tokenType) {
+        case "core":
+            return styles.filter(style =>
+                !style.name.includes("core") &&
+                !style.name.includes("surface") &&
+                !style.name.includes("border") &&
+                !style.name.includes("text") &&
+                !style.name.includes("icon") &&
+                !style.name.includes("dataviz")
+            );
+        case "background":
+            return styles.filter(style => style.name.includes("surface"));
+        case "border":
+            return styles.filter(style => style.name.includes("border"));
+        case "text":
+            return styles.filter(style => style.name.includes("text"));
+        case "icon":
+            return styles.filter(style => style.name.includes("icon"));
+        case "dataViz":
+            return styles.filter(style => style.name.includes("dataviz"));
+    }
+}
+
+
 type Story = StoryObj<typeof List>;
 
 export const CoreLight: Story = {
     args: {
-        styles: tokens,
+        styles: filterByTokenType(tokens, "core"),
         tokenType: "core"
     }
 };
 
 export const CoreDark = {
     args: {
-        styles: darkTokens,
+        styles: filterByTokenType(darkTokens, "core"),
         tokenType: "core"
     }
 };
 
 export const SemanticBackgroundLight: Story = {
     args: {
-        styles: tokens,
+        styles: filterByTokenType(tokens, "background"),
         tokenType: "background"
     }
 };
 
 export const SemanticBackgroundDark = {
     args: {
-        styles: darkTokens,
+        styles: filterByTokenType(darkTokens, "background"),
         tokenType: "background"
     }
 };
 
 export const SemanticBorderLight: Story = {
     args: {
-        styles: tokens,
+        styles: filterByTokenType(tokens, "border"),
         tokenType: "border"
     }
 };
 
 export const SemanticBorderDark = {
     args: {
-        styles: darkTokens,
+        styles: filterByTokenType(darkTokens, "border"),
         tokenType: "border"
     }
 };
 
 export const SemanticIconLight: Story = {
     args: {
-        styles: tokens,
+        styles: filterByTokenType(tokens, "icon"),
         tokenType: "icon"
     }
 };
 
 export const SemanticIconDark = {
     args: {
-        styles: darkTokens,
+        styles: filterByTokenType(darkTokens, "icon"),
         tokenType: "icon"
     }
 };
 
 export const SemanticTextLight: Story = {
     args: {
-        styles: tokens,
+        styles: filterByTokenType(tokens, "text"),
         tokenType: "text"
     }
 };
 
 export const SemanticTextDark = {
     args: {
-        styles: darkTokens,
+        styles: filterByTokenType(darkTokens, "text"),
         tokenType: "text"
     }
 };
 
 export const DataVizLight: Story = {
     args: {
-        styles: tokens,
+        styles: filterByTokenType(tokens, "dataViz"),
         tokenType: "dataViz"
     }
 };
 
 export const DataVizDark = {
     args: {
-        styles: darkTokens,
+        styles: filterByTokenType(darkTokens, "dataViz"),
         tokenType: "dataViz"
     }
 };

--- a/packages/tokens/src/stories/tokens.stories.ts
+++ b/packages/tokens/src/stories/tokens.stories.ts
@@ -36,16 +36,9 @@ function filterByTokenType(styles: Style[], tokenType: TokenType) {
 
 type Story = StoryObj<typeof List>;
 
-export const CoreLight: Story = {
+export const Core: Story = {
     args: {
         styles: filterByTokenType(tokens, "core"),
-        tokenType: "core"
-    }
-};
-
-export const CoreDark = {
-    args: {
-        styles: filterByTokenType(darkTokens, "core"),
         tokenType: "core"
     }
 };

--- a/packages/tokens/src/stories/tokens.stories.ts
+++ b/packages/tokens/src/stories/tokens.stories.ts
@@ -1,21 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react";
 import { List } from "./components/List.tsx";
-
-import tokens from "./datas/tokens.json";
 import darkTokens from "./datas/tokens-dark.json";
+import tokens from "./datas/tokens.json";
 
 export default {
     title: "Tokens/Colors",
     component: List
-};
+} satisfies Meta<typeof List>;
 
-export const Light = {
+type Story = StoryObj<typeof List>;
+
+export const CoreLight: Story = {
     args: {
-        styles: tokens
+        styles: tokens,
+        tokenType: "core"
     }
 };
 
-export const Dark = {
+export const CoreDark = {
     args: {
-        styles: darkTokens
+        styles: darkTokens,
+        tokenType: "core"
+    }
+};
+
+export const SemanticBackgroundLight: Story = {
+    args: {
+        styles: tokens,
+        tokenType: "background"
+    }
+};
+
+export const SemanticBackgroundDark = {
+    args: {
+        styles: darkTokens,
+        tokenType: "background"
+    }
+};
+
+export const SemanticBorderLight: Story = {
+    args: {
+        styles: tokens,
+        tokenType: "border"
+    }
+};
+
+export const SemanticBorderDark = {
+    args: {
+        styles: darkTokens,
+        tokenType: "border"
+    }
+};
+
+export const SemanticIconLight: Story = {
+    args: {
+        styles: tokens,
+        tokenType: "icon"
+    }
+};
+
+export const SemanticIconDark = {
+    args: {
+        styles: darkTokens,
+        tokenType: "icon"
+    }
+};
+
+export const SemanticTextLight: Story = {
+    args: {
+        styles: tokens,
+        tokenType: "text"
+    }
+};
+
+export const SemanticTextDark = {
+    args: {
+        styles: darkTokens,
+        tokenType: "text"
+    }
+};
+
+export const DataVizLight: Story = {
+    args: {
+        styles: tokens,
+        tokenType: "dataViz"
+    }
+};
+
+export const DataVizDark = {
+    args: {
+        styles: darkTokens,
+        tokenType: "dataViz"
     }
 };

--- a/packages/tokens/src/tokens/semantic/dark/dataViz.tokens.json
+++ b/packages/tokens/src/tokens/semantic/dark/dataViz.tokens.json
@@ -1,22 +1,24 @@
 {
-  "unavailable": {
-    "$type": "color",
-    "$value": "{rock.600}"
-  },
-  "unavailable-weak": {
-    "$type": "color",
-    "$value": "{rock.400}"
-  },
-  "unavailable-strong": {
-    "$type": "color",
-    "$value": "{rock.700}"
-  },
-  "text-onlight": {
-    "$type": "color",
-    "$value": "{rock.800}"
-  },
-  "text-ondark": {
-    "$type": "color",
-    "$value": "{samoyed}"
-  }
+    "dataviz": {
+        "unavailable": {
+            "$type": "color",
+            "$value": "{rock.600}"
+        },
+        "unavailable-weak": {
+            "$type": "color",
+            "$value": "{rock.400}"
+        },
+        "unavailable-strong": {
+            "$type": "color",
+            "$value": "{rock.700}"
+        },
+        "text-onlight": {
+            "$type": "color",
+            "$value": "{rock.800}"
+        },
+        "text-ondark": {
+            "$type": "color",
+            "$value": "{samoyed}"
+        }
+    }
 }

--- a/packages/tokens/src/tokens/semantic/light/dataViz.tokens.json
+++ b/packages/tokens/src/tokens/semantic/light/dataViz.tokens.json
@@ -1,1134 +1,1136 @@
 {
-  "monochromatic": {
-    "primary": {
-      "25": {
-        "$type": "color",
-        "$value": "#f5f6ff"
-      },
-      "50": {
-        "$type": "color",
-        "$value": "#e6ebff"
-      },
-      "75": {
-        "$type": "color",
-        "$value": "#d6e0ff"
-      },
-      "100": {
-        "$type": "color",
-        "$value": "#b9cbff"
-      },
-      "200": {
-        "$type": "color",
-        "$value": "#95b1ff"
-      },
-      "300": {
-        "$type": "color",
-        "$value": "#6c8ffd"
-      },
-      "400": {
-        "$type": "color",
-        "$value": "#4767fe"
-      },
-      "500": {
-        "$type": "color",
-        "$value": "#3b57ff"
-      },
-      "600": {
-        "$type": "color",
-        "$value": "#2a43e8"
-      },
-      "700": {
-        "$type": "color",
-        "$value": "#2040c7"
-      },
-      "800": {
-        "$type": "color",
-        "$value": "#1b3587"
-      },
-      "900": {
-        "$type": "color",
-        "$value": "#152450"
-      },
-      "25-hover": {
-        "$type": "color",
-        "$value": "#e6ebff"
-      },
-      "50-hover": {
-        "$type": "color",
-        "$value": "#d6e0ff"
-      },
-      "75-hover": {
-        "$type": "color",
-        "$value": "#b9cbff"
-      },
-      "100-hover": {
-        "$type": "color",
-        "$value": "#95b1ff"
-      },
-      "200-hover": {
-        "$type": "color",
-        "$value": "#6c8ffd"
-      },
-      "300-hover": {
-        "$type": "color",
-        "$value": "#4767fe"
-      },
-      "400-hover": {
-        "$type": "color",
-        "$value": "#3b57ff"
-      },
-      "500-hover": {
-        "$type": "color",
-        "$value": "#2a43e8"
-      },
-      "600-hover": {
-        "$type": "color",
-        "$value": "#2040c7"
-      },
-      "700-hover": {
-        "$type": "color",
-        "$value": "#1b3587"
-      },
-      "800-hover": {
-        "$type": "color",
-        "$value": "#152450"
-      },
-      "900-hover": {
-        "$type": "color",
-        "$value": "#0b173a"
-      }
-    },
-    "positive": {
-      "25": {
-        "$type": "color",
-        "$value": "#f4f9e9"
-      },
-      "50": {
-        "$type": "color",
-        "$value": "#e3f3b9"
-      },
-      "75": {
-        "$type": "color",
-        "$value": "#cde8ac"
-      },
-      "100": {
-        "$type": "color",
-        "$value": "#aad89d"
-      },
-      "200": {
-        "$type": "color",
-        "$value": "#7dc291"
-      },
-      "300": {
-        "$type": "color",
-        "$value": "#47a584"
-      },
-      "400": {
-        "$type": "color",
-        "$value": "#188a71"
-      },
-      "500": {
-        "$type": "color",
-        "$value": "#0c796b"
-      },
-      "600": {
-        "$type": "color",
-        "$value": "#0a6f64"
-      },
-      "700": {
-        "$type": "color",
-        "$value": "#115a52"
-      },
-      "800": {
-        "$type": "color",
-        "$value": "#16433d"
-      },
-      "900": {
-        "$type": "color",
-        "$value": "#132a27"
-      },
-      "25-hover": {
-        "$type": "color",
-        "$value": "#e3f3b9"
-      },
-      "50-hover": {
-        "$type": "color",
-        "$value": "#cde8ac"
-      },
-      "75-hover": {
-        "$type": "color",
-        "$value": "#aad89d"
-      },
-      "100-hover": {
-        "$type": "color",
-        "$value": "#7dc291"
-      },
-      "200-hover": {
-        "$type": "color",
-        "$value": "#47a584"
-      },
-      "300-hover": {
-        "$type": "color",
-        "$value": "#188a71"
-      },
-      "400-hover": {
-        "$type": "color",
-        "$value": "#0c796b"
-      },
-      "500-hover": {
-        "$type": "color",
-        "$value": "#0a6f64"
-      },
-      "600-hover": {
-        "$type": "color",
-        "$value": "#115a52"
-      },
-      "700-hover": {
-        "$type": "color",
-        "$value": "#16433d"
-      },
-      "800-hover": {
-        "$type": "color",
-        "$value": "#132a27"
-      },
-      "900-hover": {
-        "$type": "color",
-        "$value": "#0a1716"
-      }
-    },
-    "negative": {
-      "25": {
-        "$type": "color",
-        "$value": "#fdf6f6"
-      },
-      "50": {
-        "$type": "color",
-        "$value": "#fde6e5"
-      },
-      "75": {
-        "$type": "color",
-        "$value": "#ffd6d3"
-      },
-      "100": {
-        "$type": "color",
-        "$value": "#ffbcb7"
-      },
-      "200": {
-        "$type": "color",
-        "$value": "#ff8e8e"
-      },
-      "300": {
-        "$type": "color",
-        "$value": "#f56263"
-      },
-      "400": {
-        "$type": "color",
-        "$value": "#df3236"
-      },
-      "500": {
-        "$type": "color",
-        "$value": "#cb2e31"
-      },
-      "600": {
-        "$type": "color",
-        "$value": "#ba2d2d"
-      },
-      "700": {
-        "$type": "color",
-        "$value": "#952927"
-      },
-      "800": {
-        "$type": "color",
-        "$value": "#6c2320"
-      },
-      "900": {
-        "$type": "color",
-        "$value": "#431a17"
-      },
-      "25-hover": {
-        "$type": "color",
-        "$value": "#fde6e5"
-      },
-      "50-hover": {
-        "$type": "color",
-        "$value": "#ffd6d3"
-      },
-      "75-hover": {
-        "$type": "color",
-        "$value": "#ffbcb7"
-      },
-      "100-hover": {
-        "$type": "color",
-        "$value": "#ff8e8e"
-      },
-      "200-hover": {
-        "$type": "color",
-        "$value": "#f56263"
-      },
-      "300-hover": {
-        "$type": "color",
-        "$value": "#df3236"
-      },
-      "400-hover": {
-        "$type": "color",
-        "$value": "#cb2e31"
-      },
-      "500-hover": {
-        "$type": "color",
-        "$value": "#ba2d2d"
-      },
-      "600-hover": {
-        "$type": "color",
-        "$value": "#952927"
-      },
-      "700-hover": {
-        "$type": "color",
-        "$value": "#6c2320"
-      },
-      "800-hover": {
-        "$type": "color",
-        "$value": "#431a17"
-      },
-      "900-hover": {
-        "$type": "color",
-        "$value": "#2d100d"
-      }
+    "dataviz": {
+        "monochromatic": {
+            "primary": {
+                "25": {
+                    "$type": "color",
+                    "$value": "#f5f6ff"
+                },
+                "50": {
+                    "$type": "color",
+                    "$value": "#e6ebff"
+                },
+                "75": {
+                    "$type": "color",
+                    "$value": "#d6e0ff"
+                },
+                "100": {
+                    "$type": "color",
+                    "$value": "#b9cbff"
+                },
+                "200": {
+                    "$type": "color",
+                    "$value": "#95b1ff"
+                },
+                "300": {
+                    "$type": "color",
+                    "$value": "#6c8ffd"
+                },
+                "400": {
+                    "$type": "color",
+                    "$value": "#4767fe"
+                },
+                "500": {
+                    "$type": "color",
+                    "$value": "#3b57ff"
+                },
+                "600": {
+                    "$type": "color",
+                    "$value": "#2a43e8"
+                },
+                "700": {
+                    "$type": "color",
+                    "$value": "#2040c7"
+                },
+                "800": {
+                    "$type": "color",
+                    "$value": "#1b3587"
+                },
+                "900": {
+                    "$type": "color",
+                    "$value": "#152450"
+                },
+                "25-hover": {
+                    "$type": "color",
+                    "$value": "#e6ebff"
+                },
+                "50-hover": {
+                    "$type": "color",
+                    "$value": "#d6e0ff"
+                },
+                "75-hover": {
+                    "$type": "color",
+                    "$value": "#b9cbff"
+                },
+                "100-hover": {
+                    "$type": "color",
+                    "$value": "#95b1ff"
+                },
+                "200-hover": {
+                    "$type": "color",
+                    "$value": "#6c8ffd"
+                },
+                "300-hover": {
+                    "$type": "color",
+                    "$value": "#4767fe"
+                },
+                "400-hover": {
+                    "$type": "color",
+                    "$value": "#3b57ff"
+                },
+                "500-hover": {
+                    "$type": "color",
+                    "$value": "#2a43e8"
+                },
+                "600-hover": {
+                    "$type": "color",
+                    "$value": "#2040c7"
+                },
+                "700-hover": {
+                    "$type": "color",
+                    "$value": "#1b3587"
+                },
+                "800-hover": {
+                    "$type": "color",
+                    "$value": "#152450"
+                },
+                "900-hover": {
+                    "$type": "color",
+                    "$value": "#0b173a"
+                }
+            },
+            "positive": {
+                "25": {
+                    "$type": "color",
+                    "$value": "#f4f9e9"
+                },
+                "50": {
+                    "$type": "color",
+                    "$value": "#e3f3b9"
+                },
+                "75": {
+                    "$type": "color",
+                    "$value": "#cde8ac"
+                },
+                "100": {
+                    "$type": "color",
+                    "$value": "#aad89d"
+                },
+                "200": {
+                    "$type": "color",
+                    "$value": "#7dc291"
+                },
+                "300": {
+                    "$type": "color",
+                    "$value": "#47a584"
+                },
+                "400": {
+                    "$type": "color",
+                    "$value": "#188a71"
+                },
+                "500": {
+                    "$type": "color",
+                    "$value": "#0c796b"
+                },
+                "600": {
+                    "$type": "color",
+                    "$value": "#0a6f64"
+                },
+                "700": {
+                    "$type": "color",
+                    "$value": "#115a52"
+                },
+                "800": {
+                    "$type": "color",
+                    "$value": "#16433d"
+                },
+                "900": {
+                    "$type": "color",
+                    "$value": "#132a27"
+                },
+                "25-hover": {
+                    "$type": "color",
+                    "$value": "#e3f3b9"
+                },
+                "50-hover": {
+                    "$type": "color",
+                    "$value": "#cde8ac"
+                },
+                "75-hover": {
+                    "$type": "color",
+                    "$value": "#aad89d"
+                },
+                "100-hover": {
+                    "$type": "color",
+                    "$value": "#7dc291"
+                },
+                "200-hover": {
+                    "$type": "color",
+                    "$value": "#47a584"
+                },
+                "300-hover": {
+                    "$type": "color",
+                    "$value": "#188a71"
+                },
+                "400-hover": {
+                    "$type": "color",
+                    "$value": "#0c796b"
+                },
+                "500-hover": {
+                    "$type": "color",
+                    "$value": "#0a6f64"
+                },
+                "600-hover": {
+                    "$type": "color",
+                    "$value": "#115a52"
+                },
+                "700-hover": {
+                    "$type": "color",
+                    "$value": "#16433d"
+                },
+                "800-hover": {
+                    "$type": "color",
+                    "$value": "#132a27"
+                },
+                "900-hover": {
+                    "$type": "color",
+                    "$value": "#0a1716"
+                }
+            },
+            "negative": {
+                "25": {
+                    "$type": "color",
+                    "$value": "#fdf6f6"
+                },
+                "50": {
+                    "$type": "color",
+                    "$value": "#fde6e5"
+                },
+                "75": {
+                    "$type": "color",
+                    "$value": "#ffd6d3"
+                },
+                "100": {
+                    "$type": "color",
+                    "$value": "#ffbcb7"
+                },
+                "200": {
+                    "$type": "color",
+                    "$value": "#ff8e8e"
+                },
+                "300": {
+                    "$type": "color",
+                    "$value": "#f56263"
+                },
+                "400": {
+                    "$type": "color",
+                    "$value": "#df3236"
+                },
+                "500": {
+                    "$type": "color",
+                    "$value": "#cb2e31"
+                },
+                "600": {
+                    "$type": "color",
+                    "$value": "#ba2d2d"
+                },
+                "700": {
+                    "$type": "color",
+                    "$value": "#952927"
+                },
+                "800": {
+                    "$type": "color",
+                    "$value": "#6c2320"
+                },
+                "900": {
+                    "$type": "color",
+                    "$value": "#431a17"
+                },
+                "25-hover": {
+                    "$type": "color",
+                    "$value": "#fde6e5"
+                },
+                "50-hover": {
+                    "$type": "color",
+                    "$value": "#ffd6d3"
+                },
+                "75-hover": {
+                    "$type": "color",
+                    "$value": "#ffbcb7"
+                },
+                "100-hover": {
+                    "$type": "color",
+                    "$value": "#ff8e8e"
+                },
+                "200-hover": {
+                    "$type": "color",
+                    "$value": "#f56263"
+                },
+                "300-hover": {
+                    "$type": "color",
+                    "$value": "#df3236"
+                },
+                "400-hover": {
+                    "$type": "color",
+                    "$value": "#cb2e31"
+                },
+                "500-hover": {
+                    "$type": "color",
+                    "$value": "#ba2d2d"
+                },
+                "600-hover": {
+                    "$type": "color",
+                    "$value": "#952927"
+                },
+                "700-hover": {
+                    "$type": "color",
+                    "$value": "#6c2320"
+                },
+                "800-hover": {
+                    "$type": "color",
+                    "$value": "#431a17"
+                },
+                "900-hover": {
+                    "$type": "color",
+                    "$value": "#2d100d"
+                }
+            }
+        },
+        "diverging": {
+            "sequence 1": {
+                "positive9": {
+                    "$type": "color",
+                    "$value": "#16433d"
+                },
+                "positive9-hover": {
+                    "$type": "color",
+                    "$value": "#132a27"
+                },
+                "positive8": {
+                    "$type": "color",
+                    "$value": "#115a52"
+                },
+                "positive8-hover": {
+                    "$type": "color",
+                    "$value": "#16433d"
+                },
+                "positive7": {
+                    "$type": "color",
+                    "$value": "#0a6f64"
+                },
+                "positive7-hover": {
+                    "$type": "color",
+                    "$value": "#115a52"
+                },
+                "positive6": {
+                    "$type": "color",
+                    "$value": "#0c796b"
+                },
+                "positive6-hover": {
+                    "$type": "color",
+                    "$value": "#0a6f64"
+                },
+                "positive5": {
+                    "$type": "color",
+                    "$value": "#188a71"
+                },
+                "positive5-hover": {
+                    "$type": "color",
+                    "$value": "#0c796b"
+                },
+                "positive4": {
+                    "$type": "color",
+                    "$value": "#47a584"
+                },
+                "positive-4-hover": {
+                    "$type": "color",
+                    "$value": "#188a71"
+                },
+                "positive3": {
+                    "$type": "color",
+                    "$value": "#7dc291"
+                },
+                "positive3-hover": {
+                    "$type": "color",
+                    "$value": "#47a584"
+                },
+                "positive2": {
+                    "$type": "color",
+                    "$value": "#aad89d"
+                },
+                "positive2-hover": {
+                    "$type": "color",
+                    "$value": "#7dc291"
+                },
+                "positive1": {
+                    "$type": "color",
+                    "$value": "#cde8ac"
+                },
+                "positive1-hover": {
+                    "$type": "color",
+                    "$value": "#aad89d"
+                },
+                "neutral": {
+                    "$type": "color",
+                    "$value": "#f7e694"
+                },
+                "neutral-hover": {
+                    "$type": "color",
+                    "$value": "#eac96d"
+                },
+                "negative1": {
+                    "$type": "color",
+                    "$value": "#ffd8be"
+                },
+                "negative1-hover": {
+                    "$type": "color",
+                    "$value": "#ffbcb7"
+                },
+                "negative2": {
+                    "$type": "color",
+                    "$value": "#ffbcb7"
+                },
+                "negative2-hover": {
+                    "$type": "color",
+                    "$value": "#ff8e8e"
+                },
+                "negative3": {
+                    "$type": "color",
+                    "$value": "#ff8e8e"
+                },
+                "negative3-hover": {
+                    "$type": "color",
+                    "$value": "#f56263"
+                },
+                "negative4": {
+                    "$type": "color",
+                    "$value": "#f56263"
+                },
+                "negative4-hover": {
+                    "$type": "color",
+                    "$value": "#df3236"
+                },
+                "negative5": {
+                    "$type": "color",
+                    "$value": "#df3236"
+                },
+                "negative5-hover": {
+                    "$type": "color",
+                    "$value": "#cb2e31"
+                },
+                "negative6": {
+                    "$type": "color",
+                    "$value": "#cb2e31"
+                },
+                "negative6-hover": {
+                    "$type": "color",
+                    "$value": "#ba2d2d"
+                },
+                "negative7": {
+                    "$type": "color",
+                    "$value": "#ba2d2d"
+                },
+                "negative7-hover": {
+                    "$type": "color",
+                    "$value": "#952927"
+                },
+                "negative8": {
+                    "$type": "color",
+                    "$value": "#952927"
+                },
+                "negative8-hover": {
+                    "$type": "color",
+                    "$value": "#6c2320"
+                },
+                "negative9": {
+                    "$type": "color",
+                    "$value": "#6c2320"
+                },
+                "negative9-hover": {
+                    "$type": "color",
+                    "$value": "#431a17"
+                }
+            },
+            "sequence 2": {
+                "positive10": {
+                    "$type": "color",
+                    "$value": "#16433d"
+                },
+                "positive10-hover": {
+                    "$type": "color",
+                    "$value": "#132a27"
+                },
+                "positive9": {
+                    "$type": "color",
+                    "$value": "#115a52"
+                },
+                "positive9-hover": {
+                    "$type": "color",
+                    "$value": "#16433d"
+                },
+                "positive8": {
+                    "$type": "color",
+                    "$value": "#0a6f64"
+                },
+                "positive8-hover": {
+                    "$type": "color",
+                    "$value": "#115a52"
+                },
+                "positive7": {
+                    "$type": "color",
+                    "$value": "#0c796b"
+                },
+                "positive7-hover": {
+                    "$type": "color",
+                    "$value": "#0a6f64"
+                },
+                "positive6": {
+                    "$type": "color",
+                    "$value": "#188a71"
+                },
+                "positive6-hover": {
+                    "$type": "color",
+                    "$value": "#0c796b"
+                },
+                "positive5": {
+                    "$type": "color",
+                    "$value": "#47a584"
+                },
+                "positive5-hover": {
+                    "$type": "color",
+                    "$value": "#188a71"
+                },
+                "positive4": {
+                    "$type": "color",
+                    "$value": "#7dc291"
+                },
+                "positive4-hover": {
+                    "$type": "color",
+                    "$value": "#47a584"
+                },
+                "positive3": {
+                    "$type": "color",
+                    "$value": "#aad89d"
+                },
+                "positive3-hover": {
+                    "$type": "color",
+                    "$value": "#7dc291"
+                },
+                "positive2": {
+                    "$type": "color",
+                    "$value": "#cde8ac"
+                },
+                "positive2-hover": {
+                    "$type": "color",
+                    "$value": "#aad89d"
+                },
+                "positive1": {
+                    "$type": "color",
+                    "$value": "#e3f3b9"
+                },
+                "positive1-hover": {
+                    "$type": "color",
+                    "$value": "#cde8ac"
+                },
+                "negative1": {
+                    "$type": "color",
+                    "$value": "#fde6e5"
+                },
+                "negative1-hover": {
+                    "$type": "color",
+                    "$value": "#ffd6d3"
+                },
+                "negative2": {
+                    "$type": "color",
+                    "$value": "#ffd6d3"
+                },
+                "negative2-hover": {
+                    "$type": "color",
+                    "$value": "#ffbcb7"
+                },
+                "negative3": {
+                    "$type": "color",
+                    "$value": "#ffbcb7"
+                },
+                "negative3-hover": {
+                    "$type": "color",
+                    "$value": "#ff8e8e"
+                },
+                "negative4": {
+                    "$type": "color",
+                    "$value": "#ff8e8e"
+                },
+                "negative4-hover": {
+                    "$type": "color",
+                    "$value": "#f56263"
+                },
+                "negative5": {
+                    "$type": "color",
+                    "$value": "#f56263"
+                },
+                "negative5-hover": {
+                    "$type": "color",
+                    "$value": "#df3236"
+                },
+                "negative6": {
+                    "$type": "color",
+                    "$value": "#df3236"
+                },
+                "negative6-hover": {
+                    "$type": "color",
+                    "$value": "#cb2e31"
+                },
+                "negative7": {
+                    "$type": "color",
+                    "$value": "#cb2e31"
+                },
+                "negative7-hover": {
+                    "$type": "color",
+                    "$value": "#ba2d2d"
+                },
+                "negative8": {
+                    "$type": "color",
+                    "$value": "#ba2d2d"
+                },
+                "negative8-hover": {
+                    "$type": "color",
+                    "$value": "#952927"
+                },
+                "negative9": {
+                    "$type": "color",
+                    "$value": "#952927"
+                },
+                "negative9-hover": {
+                    "$type": "color",
+                    "$value": "#6c2320"
+                },
+                "negative10": {
+                    "$type": "color",
+                    "$value": "#6c2320"
+                },
+                "negative10-hover": {
+                    "$type": "color",
+                    "$value": "#431a17"
+                }
+            }
+        },
+        "categorical": {
+            "sequence": {
+                "category1": {
+                    "$type": "color",
+                    "$value": "#c7ebff"
+                },
+                "category1-hover": {
+                    "$type": "color",
+                    "$value": "#ade2ff"
+                },
+                "category2": {
+                    "$type": "color",
+                    "$value": "#ecd599"
+                },
+                "category2-hover": {
+                    "$type": "color",
+                    "$value": "#e6c675"
+                },
+                "category3": {
+                    "$type": "color",
+                    "$value": "#d2cdf8"
+                },
+                "category3-hover": {
+                    "$type": "color",
+                    "$value": "#bfb8f5"
+                },
+                "category4": {
+                    "$type": "color",
+                    "$value": "#b6bead"
+                },
+                "category4-hover": {
+                    "$type": "color",
+                    "$value": "#a4ae98"
+                },
+                "category5": {
+                    "$type": "color",
+                    "$value": "#fbbdcf"
+                },
+                "category5-hover": {
+                    "$type": "color",
+                    "$value": "#f99fb8"
+                },
+                "category6": {
+                    "$type": "color",
+                    "$value": "#bfdca9"
+                },
+                "category6-hover": {
+                    "$type": "color",
+                    "$value": "#a9d08b"
+                },
+                "category7": {
+                    "$type": "color",
+                    "$value": "#fbe997"
+                },
+                "category7-hover": {
+                    "$type": "color",
+                    "$value": "#fae275"
+                },
+                "category8": {
+                    "$type": "color",
+                    "$value": "#e8ddd0"
+                },
+                "category8-hover": {
+                    "$type": "color",
+                    "$value": "#ddcebb"
+                },
+                "category9": {
+                    "$type": "color",
+                    "$value": "#a7e6dc"
+                },
+                "category9-hover": {
+                    "$type": "color",
+                    "$value": "#90e0d2"
+                },
+                "category10": {
+                    "$type": "color",
+                    "$value": "#aecdd5"
+                },
+                "category10-hover": {
+                    "$type": "color",
+                    "$value": "#93bdc8"
+                },
+                "category11": {
+                    "$type": "color",
+                    "$value": "#ffbf92"
+                },
+                "category-11-hover": {
+                    "$type": "color",
+                    "$value": "#ffac70"
+                },
+                "category12": {
+                    "$type": "color",
+                    "$value": "#a0b8fa"
+                },
+                "cateogry12-hover": {
+                    "$type": "color",
+                    "$value": "#779af8"
+                },
+                "category13": {
+                    "$type": "color",
+                    "$value": "#69bfa0"
+                },
+                "category13-hover": {
+                    "$type": "color",
+                    "$value": "#54b692"
+                }
+            },
+            "2colorgroup": {
+                "option6": {
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    },
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#ffbf92"
+                    }
+                },
+                "option5": {
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#a0b8fa"
+                    },
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#a7e6dc"
+                    }
+                },
+                "option4": {
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#6c8ffd"
+                    },
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#bfdca9"
+                    }
+                },
+                "option3": {
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#ff9b3f"
+                    },
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#2f48ff"
+                    }
+                },
+                "option2": {
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#fbe997"
+                    },
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#fbbdcf"
+                    }
+                },
+                "option1": {
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#c7ebff"
+                    },
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    }
+                }
+            },
+            "3colorgroup": {
+                "option1": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#d2cdf8"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#bfdca9"
+                    }
+                },
+                "option2": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#ecd599"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#a7e6dc"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    }
+                },
+                "option3": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#fbe997"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#aecdd5"
+                    }
+                },
+                "option4": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#a0b8fa"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#fbbdcf"
+                    }
+                }
+            },
+            "4colorgroup": {
+                "option1": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#d2cdf8"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#cde8ac"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#fbbdcf"
+                    }
+                },
+                "option2": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#c7ebff"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#84d0b4"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#fbe997"
+                    }
+                },
+                "option3": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#ffbf92"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#2e70a8"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#ecd599"
+                    }
+                },
+                "option4": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#c7ebff"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#fa4d59"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#d2cdf8"
+                    }
+                }
+            },
+            "5colorgroup": {
+                "option1": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#ff9b3f"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#bfdca9"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#ecd599"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    }
+                },
+                "option2": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#ff9b3f"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#2e70a8"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#fbe997"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#c5bef6"
+                    }
+                },
+                "option3": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#d2cdf8"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#ecd599"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#aecdd5"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#ffbf92"
+                    }
+                },
+                "option4": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#c7ebff"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#fa4d59"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#d2cdf8"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    }
+                }
+            },
+            "6colorgroup": {
+                "option1": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#a0b8fa"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#bfdca9"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#fa4d59"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#ecd599"
+                    },
+                    "category6": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    }
+                },
+                "option2": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#2e70a8"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#fbe997"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#69bfa0"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#ff9b3f"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#a7e6dc"
+                    },
+                    "category6": {
+                        "$type": "color",
+                        "$value": "#d2cdf8"
+                    }
+                },
+                "option3": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#b6bead"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#aecdd5"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#e8ddd0"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#a7e6dc"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#2e70a8"
+                    },
+                    "category6": {
+                        "$type": "color",
+                        "$value": "#fbbdcf"
+                    }
+                },
+                "option4": {
+                    "category1": {
+                        "$type": "color",
+                        "$value": "#fbbdcf"
+                    },
+                    "category2": {
+                        "$type": "color",
+                        "$value": "#a0b8fa"
+                    },
+                    "category3": {
+                        "$type": "color",
+                        "$value": "#ffbf92"
+                    },
+                    "category4": {
+                        "$type": "color",
+                        "$value": "#c7ebff"
+                    },
+                    "category5": {
+                        "$type": "color",
+                        "$value": "#bfdca9"
+                    },
+                    "category6": {
+                        "$type": "color",
+                        "$value": "#fbe997"
+                    }
+                }
+            }
+        },
+        "unavailable": {
+            "$type": "color",
+            "$value": "{rock.75}"
+        },
+        "unavailable-weak": {
+            "$type": "color",
+            "$value": "{rock.50}"
+        },
+        "unavailable-strong": {
+            "$type": "color",
+            "$value": "{rock.100}"
+        },
+        "text-onlight": {
+            "$type": "color",
+            "$value": "{rock.800}"
+        },
+        "text-ondark": {
+            "$type": "color",
+            "$value": "{samoyed}"
+        }
     }
-  },
-  "diverging": {
-    "sequence 1": {
-      "positive9": {
-        "$type": "color",
-        "$value": "#16433d"
-      },
-      "positive9-hover": {
-        "$type": "color",
-        "$value": "#132a27"
-      },
-      "positive8": {
-        "$type": "color",
-        "$value": "#115a52"
-      },
-      "positive8-hover": {
-        "$type": "color",
-        "$value": "#16433d"
-      },
-      "positive7": {
-        "$type": "color",
-        "$value": "#0a6f64"
-      },
-      "positive7-hover": {
-        "$type": "color",
-        "$value": "#115a52"
-      },
-      "positive6": {
-        "$type": "color",
-        "$value": "#0c796b"
-      },
-      "positive6-hover": {
-        "$type": "color",
-        "$value": "#0a6f64"
-      },
-      "positive5": {
-        "$type": "color",
-        "$value": "#188a71"
-      },
-      "positive5-hover": {
-        "$type": "color",
-        "$value": "#0c796b"
-      },
-      "positive4": {
-        "$type": "color",
-        "$value": "#47a584"
-      },
-      "positive-4-hover": {
-        "$type": "color",
-        "$value": "#188a71"
-      },
-      "positive3": {
-        "$type": "color",
-        "$value": "#7dc291"
-      },
-      "positive3-hover": {
-        "$type": "color",
-        "$value": "#47a584"
-      },
-      "positive2": {
-        "$type": "color",
-        "$value": "#aad89d"
-      },
-      "positive2-hover": {
-        "$type": "color",
-        "$value": "#7dc291"
-      },
-      "positive1": {
-        "$type": "color",
-        "$value": "#cde8ac"
-      },
-      "positive1-hover": {
-        "$type": "color",
-        "$value": "#aad89d"
-      },
-      "neutral": {
-        "$type": "color",
-        "$value": "#f7e694"
-      },
-      "neutral-hover": {
-        "$type": "color",
-        "$value": "#eac96d"
-      },
-      "negative1": {
-        "$type": "color",
-        "$value": "#ffd8be"
-      },
-      "negative1-hover": {
-        "$type": "color",
-        "$value": "#ffbcb7"
-      },
-      "negative2": {
-        "$type": "color",
-        "$value": "#ffbcb7"
-      },
-      "negative2-hover": {
-        "$type": "color",
-        "$value": "#ff8e8e"
-      },
-      "negative3": {
-        "$type": "color",
-        "$value": "#ff8e8e"
-      },
-      "negative3-hover": {
-        "$type": "color",
-        "$value": "#f56263"
-      },
-      "negative4": {
-        "$type": "color",
-        "$value": "#f56263"
-      },
-      "negative4-hover": {
-        "$type": "color",
-        "$value": "#df3236"
-      },
-      "negative5": {
-        "$type": "color",
-        "$value": "#df3236"
-      },
-      "negative5-hover": {
-        "$type": "color",
-        "$value": "#cb2e31"
-      },
-      "negative6": {
-        "$type": "color",
-        "$value": "#cb2e31"
-      },
-      "negative6-hover": {
-        "$type": "color",
-        "$value": "#ba2d2d"
-      },
-      "negative7": {
-        "$type": "color",
-        "$value": "#ba2d2d"
-      },
-      "negative7-hover": {
-        "$type": "color",
-        "$value": "#952927"
-      },
-      "negative8": {
-        "$type": "color",
-        "$value": "#952927"
-      },
-      "negative8-hover": {
-        "$type": "color",
-        "$value": "#6c2320"
-      },
-      "negative9": {
-        "$type": "color",
-        "$value": "#6c2320"
-      },
-      "negative9-hover": {
-        "$type": "color",
-        "$value": "#431a17"
-      }
-    },
-    "sequence 2": {
-      "positive10": {
-        "$type": "color",
-        "$value": "#16433d"
-      },
-      "positive10-hover": {
-        "$type": "color",
-        "$value": "#132a27"
-      },
-      "positive9": {
-        "$type": "color",
-        "$value": "#115a52"
-      },
-      "positive9-hover": {
-        "$type": "color",
-        "$value": "#16433d"
-      },
-      "positive8": {
-        "$type": "color",
-        "$value": "#0a6f64"
-      },
-      "positive8-hover": {
-        "$type": "color",
-        "$value": "#115a52"
-      },
-      "positive7": {
-        "$type": "color",
-        "$value": "#0c796b"
-      },
-      "positive7-hover": {
-        "$type": "color",
-        "$value": "#0a6f64"
-      },
-      "positive6": {
-        "$type": "color",
-        "$value": "#188a71"
-      },
-      "positive6-hover": {
-        "$type": "color",
-        "$value": "#0c796b"
-      },
-      "positive5": {
-        "$type": "color",
-        "$value": "#47a584"
-      },
-      "positive5-hover": {
-        "$type": "color",
-        "$value": "#188a71"
-      },
-      "positive4": {
-        "$type": "color",
-        "$value": "#7dc291"
-      },
-      "positive4-hover": {
-        "$type": "color",
-        "$value": "#47a584"
-      },
-      "positive3": {
-        "$type": "color",
-        "$value": "#aad89d"
-      },
-      "positive3-hover": {
-        "$type": "color",
-        "$value": "#7dc291"
-      },
-      "positive2": {
-        "$type": "color",
-        "$value": "#cde8ac"
-      },
-      "positive2-hover": {
-        "$type": "color",
-        "$value": "#aad89d"
-      },
-      "positive1": {
-        "$type": "color",
-        "$value": "#e3f3b9"
-      },
-      "positive1-hover": {
-        "$type": "color",
-        "$value": "#cde8ac"
-      },
-      "negative1": {
-        "$type": "color",
-        "$value": "#fde6e5"
-      },
-      "negative1-hover": {
-        "$type": "color",
-        "$value": "#ffd6d3"
-      },
-      "negative2": {
-        "$type": "color",
-        "$value": "#ffd6d3"
-      },
-      "negative2-hover": {
-        "$type": "color",
-        "$value": "#ffbcb7"
-      },
-      "negative3": {
-        "$type": "color",
-        "$value": "#ffbcb7"
-      },
-      "negative3-hover": {
-        "$type": "color",
-        "$value": "#ff8e8e"
-      },
-      "negative4": {
-        "$type": "color",
-        "$value": "#ff8e8e"
-      },
-      "negative4-hover": {
-        "$type": "color",
-        "$value": "#f56263"
-      },
-      "negative5": {
-        "$type": "color",
-        "$value": "#f56263"
-      },
-      "negative5-hover": {
-        "$type": "color",
-        "$value": "#df3236"
-      },
-      "negative6": {
-        "$type": "color",
-        "$value": "#df3236"
-      },
-      "negative6-hover": {
-        "$type": "color",
-        "$value": "#cb2e31"
-      },
-      "negative7": {
-        "$type": "color",
-        "$value": "#cb2e31"
-      },
-      "negative7-hover": {
-        "$type": "color",
-        "$value": "#ba2d2d"
-      },
-      "negative8": {
-        "$type": "color",
-        "$value": "#ba2d2d"
-      },
-      "negative8-hover": {
-        "$type": "color",
-        "$value": "#952927"
-      },
-      "negative9": {
-        "$type": "color",
-        "$value": "#952927"
-      },
-      "negative9-hover": {
-        "$type": "color",
-        "$value": "#6c2320"
-      },
-      "negative10": {
-        "$type": "color",
-        "$value": "#6c2320"
-      },
-      "negative10-hover": {
-        "$type": "color",
-        "$value": "#431a17"
-      }
-    }
-  },
-  "categorical": {
-    "sequence": {
-      "category1": {
-        "$type": "color",
-        "$value": "#c7ebff"
-      },
-      "category1-hover": {
-        "$type": "color",
-        "$value": "#ade2ff"
-      },
-      "category2": {
-        "$type": "color",
-        "$value": "#ecd599"
-      },
-      "category2-hover": {
-        "$type": "color",
-        "$value": "#e6c675"
-      },
-      "category3": {
-        "$type": "color",
-        "$value": "#d2cdf8"
-      },
-      "category3-hover": {
-        "$type": "color",
-        "$value": "#bfb8f5"
-      },
-      "category4": {
-        "$type": "color",
-        "$value": "#b6bead"
-      },
-      "category4-hover": {
-        "$type": "color",
-        "$value": "#a4ae98"
-      },
-      "category5": {
-        "$type": "color",
-        "$value": "#fbbdcf"
-      },
-      "category5-hover": {
-        "$type": "color",
-        "$value": "#f99fb8"
-      },
-      "category6": {
-        "$type": "color",
-        "$value": "#bfdca9"
-      },
-      "category6-hover": {
-        "$type": "color",
-        "$value": "#a9d08b"
-      },
-      "category7": {
-        "$type": "color",
-        "$value": "#fbe997"
-      },
-      "category7-hover": {
-        "$type": "color",
-        "$value": "#fae275"
-      },
-      "category8": {
-        "$type": "color",
-        "$value": "#e8ddd0"
-      },
-      "category8-hover": {
-        "$type": "color",
-        "$value": "#ddcebb"
-      },
-      "category9": {
-        "$type": "color",
-        "$value": "#a7e6dc"
-      },
-      "category9-hover": {
-        "$type": "color",
-        "$value": "#90e0d2"
-      },
-      "category10": {
-        "$type": "color",
-        "$value": "#aecdd5"
-      },
-      "category10-hover": {
-        "$type": "color",
-        "$value": "#93bdc8"
-      },
-      "category11": {
-        "$type": "color",
-        "$value": "#ffbf92"
-      },
-      "category-11-hover": {
-        "$type": "color",
-        "$value": "#ffac70"
-      },
-      "category12": {
-        "$type": "color",
-        "$value": "#a0b8fa"
-      },
-      "cateogry12-hover": {
-        "$type": "color",
-        "$value": "#779af8"
-      },
-      "category13": {
-        "$type": "color",
-        "$value": "#69bfa0"
-      },
-      "category13-hover": {
-        "$type": "color",
-        "$value": "#54b692"
-      }
-    },
-    "2colorgroup": {
-      "option6": {
-        "category2": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        },
-        "category1": {
-          "$type": "color",
-          "$value": "#ffbf92"
-        }
-      },
-      "option5": {
-        "category2": {
-          "$type": "color",
-          "$value": "#a0b8fa"
-        },
-        "category1": {
-          "$type": "color",
-          "$value": "#a7e6dc"
-        }
-      },
-      "option4": {
-        "category2": {
-          "$type": "color",
-          "$value": "#6c8ffd"
-        },
-        "category1": {
-          "$type": "color",
-          "$value": "#bfdca9"
-        }
-      },
-      "option3": {
-        "category2": {
-          "$type": "color",
-          "$value": "#ff9b3f"
-        },
-        "category1": {
-          "$type": "color",
-          "$value": "#2f48ff"
-        }
-      },
-      "option2": {
-        "category2": {
-          "$type": "color",
-          "$value": "#fbe997"
-        },
-        "category1": {
-          "$type": "color",
-          "$value": "#fbbdcf"
-        }
-      },
-      "option1": {
-        "category2": {
-          "$type": "color",
-          "$value": "#c7ebff"
-        },
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        }
-      }
-    },
-    "3colorgroup": {
-      "option1": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#d2cdf8"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#bfdca9"
-        }
-      },
-      "option2": {
-        "category1": {
-          "$type": "color",
-          "$value": "#ecd599"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#a7e6dc"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        }
-      },
-      "option3": {
-        "category1": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#fbe997"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#aecdd5"
-        }
-      },
-      "option4": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#a0b8fa"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#fbbdcf"
-        }
-      }
-    },
-    "4colorgroup": {
-      "option1": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#d2cdf8"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#cde8ac"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#fbbdcf"
-        }
-      },
-      "option2": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#c7ebff"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#84d0b4"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#fbe997"
-        }
-      },
-      "option3": {
-        "category1": {
-          "$type": "color",
-          "$value": "#ffbf92"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#2e70a8"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#ecd599"
-        }
-      },
-      "option4": {
-        "category1": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#c7ebff"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#fa4d59"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#d2cdf8"
-        }
-      }
-    },
-    "5colorgroup": {
-      "option1": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#ff9b3f"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#bfdca9"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#ecd599"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        }
-      },
-      "option2": {
-        "category1": {
-          "$type": "color",
-          "$value": "#ff9b3f"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#2e70a8"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#fbe997"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#c5bef6"
-        }
-      },
-      "option3": {
-        "category1": {
-          "$type": "color",
-          "$value": "#d2cdf8"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#ecd599"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#aecdd5"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#ffbf92"
-        }
-      },
-      "option4": {
-        "category1": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#c7ebff"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#fa4d59"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#d2cdf8"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#b6bead"
-        }
-      }
-    },
-    "6colorgroup": {
-      "option1": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#a0b8fa"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#bfdca9"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#fa4d59"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#ecd599"
-        },
-        "category6": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        }
-      },
-      "option2": {
-        "category1": {
-          "$type": "color",
-          "$value": "#2e70a8"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#fbe997"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#69bfa0"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#ff9b3f"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#a7e6dc"
-        },
-        "category6": {
-          "$type": "color",
-          "$value": "#d2cdf8"
-        }
-      },
-      "option3": {
-        "category1": {
-          "$type": "color",
-          "$value": "#b6bead"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#aecdd5"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#e8ddd0"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#a7e6dc"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#2e70a8"
-        },
-        "category6": {
-          "$type": "color",
-          "$value": "#fbbdcf"
-        }
-      },
-      "option4": {
-        "category1": {
-          "$type": "color",
-          "$value": "#fbbdcf"
-        },
-        "category2": {
-          "$type": "color",
-          "$value": "#a0b8fa"
-        },
-        "category3": {
-          "$type": "color",
-          "$value": "#ffbf92"
-        },
-        "category4": {
-          "$type": "color",
-          "$value": "#c7ebff"
-        },
-        "category5": {
-          "$type": "color",
-          "$value": "#bfdca9"
-        },
-        "category6": {
-          "$type": "color",
-          "$value": "#fbe997"
-        }
-      }
-    }
-  },
-  "unavailable": {
-    "$type": "color",
-    "$value": "{rock.75}"
-  },
-  "unavailable-weak": {
-    "$type": "color",
-    "$value": "{rock.50}"
-  },
-  "unavailable-strong": {
-    "$type": "color",
-    "$value": "{rock.100}"
-  },
-  "text-onlight": {
-    "$type": "color",
-    "$value": "{rock.800}"
-  },
-  "text-ondark": {
-    "$type": "color",
-    "$value": "{samoyed}"
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,30 +167,27 @@ importers:
   packages/tokens:
     dependencies:
       style-dictionary:
-        specifier: ^3.8.0
-        version: 3.8.0
+        specifier: 3.9.0
+        version: 3.9.0
     devDependencies:
       '@types/node':
-        specifier: 18.15.11
-        version: 18.15.11
-      '@types/react':
-        specifier: ^18.2.23
-        version: 18.2.23
+        specifier: 20.8.10
+        version: 20.8.10
       '@workleap/eslint-plugin':
-        specifier: 1.8.1
-        version: 1.8.1(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.0.3)
+        specifier: 3.0.0
+        version: 3.0.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.2.2)
       '@workleap/tsup-configs':
-        specifier: ^2.0.0
-        version: 2.0.0(tsup@7.1.0)
+        specifier: 3.0.1
+        version: 3.0.1(tsup@7.2.0)(typescript@5.2.2)
       '@workleap/typescript-configs':
-        specifier: 2.3.1
-        version: 2.3.1(typescript@5.0.3)
+        specifier: 3.0.2
+        version: 3.0.2(typescript@5.2.2)
       tsup:
-        specifier: ^7.1.0
-        version: 7.1.0(postcss@8.4.29)(typescript@5.0.3)
+        specifier: 7.2.0
+        version: 7.2.0(postcss@8.4.29)(typescript@5.2.2)
       typescript:
-        specifier: 5.0.3
-        version: 5.0.3
+        specifier: 5.2.2
+        version: 5.2.2
 
 packages:
 
@@ -2417,7 +2414,7 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.9
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
     dev: false
 
   /@grpc/proto-loader@0.7.9:
@@ -2543,7 +2540,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -2555,7 +2552,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -2684,7 +2681,7 @@ packages:
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.7
-      '@types/react': 18.2.31
+      '@types/react': 18.2.34
       react: 18.2.0
     dev: true
 
@@ -6893,23 +6890,23 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
 
   /@types/concat-stream@2.0.0:
     resolution: {integrity: sha512-t3YCerNM7NTVjLuICZo5gYAXYoDvpuuTceCcFQWcDQz26kxUR5uIWolxbIR5jRNIXpMqhOpW/b8imCR1LEmuJw==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
     dev: true
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
 
   /@types/cross-spawn@6.0.2:
     resolution: {integrity: sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
 
   /@types/debug@4.1.8:
     resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
@@ -6966,7 +6963,7 @@ packages:
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -6986,13 +6983,13 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
     dev: true
 
   /@types/hast@2.3.5:
@@ -7075,7 +7072,7 @@ packages:
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       form-data: 3.0.1
 
   /@types/node@12.20.55:
@@ -7084,6 +7081,11 @@ packages:
 
   /@types/node@18.15.11:
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
+
+  /@types/node@20.8.10:
+    resolution: {integrity: sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/node@20.8.8:
     resolution: {integrity: sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==}
@@ -7120,16 +7122,16 @@ packages:
       '@types/react': 18.2.31
     dev: true
 
-  /@types/react@18.2.23:
-    resolution: {integrity: sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==}
+  /@types/react@18.2.31:
+    resolution: {integrity: sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
     dev: true
 
-  /@types/react@18.2.31:
-    resolution: {integrity: sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==}
+  /@types/react@18.2.34:
+    resolution: {integrity: sha512-U6eW/alrRk37FU/MS2RYMjx0Va2JGIVXELTODaTIYgvWGCV4Y4TfTUzG8DdmpDNIT0Xpj/R7GfyHOJJrDttcvg==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
@@ -7150,14 +7152,14 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
 
   /@types/serve-static@1.15.2:
     resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
 
   /@types/supports-color@8.1.1:
     resolution: {integrity: sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw==}
@@ -7184,34 +7186,6 @@ packages:
     resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: true
-
-  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.8.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      '@typescript-eslint/scope-manager': 5.57.1
-      '@typescript-eslint/type-utils': 5.57.1(eslint@8.52.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.52.0)(typescript@5.0.3)
-      debug: 4.3.4
-      eslint: 8.52.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/eslint-plugin@6.9.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.2.2):
@@ -7243,26 +7217,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.3)
-      debug: 4.3.4
-      eslint: 8.52.0
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@6.9.0(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -7284,14 +7238,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@5.57.1:
-    resolution: {integrity: sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/visitor-keys': 5.57.1
-    dev: true
-
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7306,26 +7252,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.9.0
       '@typescript-eslint/visitor-keys': 6.9.0
-    dev: true
-
-  /@typescript-eslint/type-utils@5.57.1(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.52.0)(typescript@5.0.3)
-      debug: 4.3.4
-      eslint: 8.52.0
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/type-utils@6.9.0(eslint@8.52.0)(typescript@5.2.2):
@@ -7348,11 +7274,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.57.1:
-    resolution: {integrity: sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7361,48 +7282,6 @@ packages:
   /@typescript-eslint/types@6.9.0:
     resolution: {integrity: sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.57.1(typescript@5.0.3):
-    resolution: {integrity: sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/visitor-keys': 5.57.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.3):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
@@ -7447,46 +7326,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.57.1(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.1
-      '@typescript-eslint/scope-manager': 5.57.1
-      '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.3)
-      eslint: 8.52.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils@5.62.0(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.1
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.3)
-      eslint: 8.52.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils@5.62.0(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7524,14 +7363,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/visitor-keys@5.57.1:
-    resolution: {integrity: sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.57.1
-      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@typescript-eslint/visitor-keys@5.62.0:
@@ -7680,37 +7511,6 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@workleap/eslint-plugin@1.8.1(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-2xUExTMkxQJaF1L7qK3tNvdbHgfERBrkzRScJU2rhqSr9qyl9BE8HXrpaCEegAA/8b9UHK1cekndrzf4AqXmsA==}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.0.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      eslint: 8.52.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.57.1)(eslint@8.52.0)(typescript@5.0.3)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.52.0)
-      eslint-plugin-mdx: 2.0.5(eslint@8.52.0)
-      eslint-plugin-react: 7.32.2(eslint@8.52.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.52.0)
-      eslint-plugin-storybook: 0.6.11(eslint@8.52.0)(typescript@5.0.3)
-      eslint-plugin-testing-library: 5.10.2(eslint@8.52.0)(typescript@5.0.3)
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-    dev: true
-
   /@workleap/eslint-plugin@3.0.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-GRvezpKhUW/UcjQrzTQ6T9KsF3Hr6UnCMS137+VVMjGd0hfGdUMwUf9rMpe2L2pFKlYfJRXuvHoVTzBlnVUPeg==}
     peerDependencies:
@@ -7761,20 +7561,14 @@ packages:
       stylelint-prettier: 2.0.0(prettier@2.8.8)(stylelint@15.11.0)
     dev: true
 
-  /@workleap/tsup-configs@2.0.0(tsup@7.1.0):
-    resolution: {integrity: sha512-kRhxfZqnVTJPrl1KfMWfZHv6wwn77FoM38fw6BOJ86OhmPOMLUOIdtB7bgSFApmmQSyDZvc1nQ1I/c+UCQ9GBQ==}
+  /@workleap/tsup-configs@3.0.1(tsup@7.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-myN5djL5rFwYsqSaj2emccUZJ2lD/R7Z2RyHif5Yy6ruNWpC5iJ+l0jXCFFJ3Zl6hYgm5HHjvPFreJqbER70EQ==}
     peerDependencies:
       tsup: '*'
-    dependencies:
-      tsup: 7.1.0(postcss@8.4.29)(typescript@5.0.3)
-    dev: true
-
-  /@workleap/typescript-configs@2.3.1(typescript@5.0.3):
-    resolution: {integrity: sha512-sGWZdzDWRkEKmdKIMfPGYiQmz5QFOM/rXpvD9pMBzHI7/T49s0SOqGcyKe45yuM7I6wJs1c2tI8Bo4bOk5Dv2A==}
-    peerDependencies:
       typescript: '*'
     dependencies:
-      typescript: 5.0.3
+      tsup: 7.2.0(postcss@8.4.29)(typescript@5.2.2)
+      typescript: 5.2.2
     dev: true
 
   /@workleap/typescript-configs@3.0.2(typescript@5.2.2):
@@ -9980,35 +9774,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.52.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      debug: 3.2.7
-      eslint: 8.52.0
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.0)(eslint@8.52.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
@@ -10036,39 +9801,6 @@ packages:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.0(@typescript-eslint/parser@6.9.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.52.0)
     transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.52.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.52.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.52.0)
-      has: 1.0.3
-      is-core-module: 2.13.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.7
-      resolve: 1.22.4
-      semver: 6.3.1
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
@@ -10105,27 +9837,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
-
-  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.57.1)(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.62.0)(eslint@8.52.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      eslint: 8.52.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /eslint-plugin-jest@27.4.3(@typescript-eslint/eslint-plugin@6.9.0)(eslint@8.52.0)(typescript@5.2.2):
@@ -10186,25 +9897,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-mdx@2.0.5(eslint@8.52.0):
-    resolution: {integrity: sha512-j2xN97jSlc5IoH94rJTHqYMztl46+hHzyC8Zqjx+OI1Rvv33isyf8xSSBHN6f0z8IJmgPgGsb/fH90JbvKplXg==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '>=8.0.0'
-    dependencies:
-      eslint: 8.52.0
-      eslint-mdx: 2.2.0(eslint@8.52.0)
-      eslint-plugin-markdown: 3.0.1(eslint@8.52.0)
-      remark-mdx: 2.3.0
-      remark-parse: 10.0.2
-      remark-stringify: 10.0.3
-      tslib: 2.6.2
-      unified: 10.1.2
-      vfile: 5.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-plugin-mdx@2.2.0(eslint@8.52.0):
     resolution: {integrity: sha512-OseoMXUIr8iy3E0me+wJLVAxuB0kxHP1plxuYAJDynzorzOj2OKv8Fhr+rIOJ32zfl3bnEWsqFnUiCnyznr1JQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -10233,30 +9925,6 @@ packages:
       eslint: 8.52.0
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@8.52.0):
-    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flatmap: 1.3.1
-      array.prototype.tosorted: 1.1.1
-      doctrine: 2.1.0
-      eslint: 8.52.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      object.hasown: 1.1.3
-      object.values: 1.1.7
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.4
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.9
-    dev: true
-
   /eslint-plugin-react@7.33.2(eslint@8.52.0):
     resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
     engines: {node: '>=4'}
@@ -10282,22 +9950,6 @@ packages:
       string.prototype.matchall: 4.0.9
     dev: true
 
-  /eslint-plugin-storybook@0.6.11(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-lIVmCqQgA0bhcuS1yWYBFrnPHBKPEQI+LHPDtlN81UE1/17onCqgwUW7Nyt7gS2OHjCAiOR4npjTGEoe0hssKw==}
-    engines: {node: 12.x || 14.x || >= 16}
-    peerDependencies:
-      eslint: '>=6'
-    dependencies:
-      '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      eslint: 8.52.0
-      requireindex: 1.2.0
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /eslint-plugin-storybook@0.6.15(eslint@8.52.0)(typescript@5.2.2):
     resolution: {integrity: sha512-lAGqVAJGob47Griu29KXYowI4G7KwMoJDOkEip8ujikuDLxU+oWJ1l0WL6F2oDO4QiyUFXvtDkEkISMOPzo+7w==}
     engines: {node: 12.x || 14.x || >= 16}
@@ -10309,19 +9961,6 @@ packages:
       eslint: 8.52.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /eslint-plugin-testing-library@5.10.2(eslint@8.52.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.52.0)(typescript@5.0.3)
-      eslint: 8.52.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11219,6 +10858,7 @@ packages:
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+    dev: false
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -12151,7 +11791,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12169,7 +11809,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
     dev: true
 
   /jest-regex-util@29.6.3:
@@ -12182,7 +11822,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -12193,7 +11833,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -12202,7 +11842,7 @@ packages:
     resolution: {integrity: sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       jest-util: 29.6.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -13527,10 +13167,6 @@ packages:
     resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
     dev: false
 
-  /natural-compare-lite@1.4.0:
-    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-    dev: true
-
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -14486,7 +14122,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.8.8
+      '@types/node': 20.8.10
       long: 5.2.3
     dev: false
 
@@ -15910,8 +15546,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /style-dictionary@3.8.0:
-    resolution: {integrity: sha512-wHlB/f5eO3mDcYv6WtOz6gvQC477jBKrwuIXe+PtHskTCBsJdAOvL8hCquczJxDui2TnwpeNE+2msK91JJomZg==}
+  /style-dictionary@3.9.0:
+    resolution: {integrity: sha512-mnq8QfPJoj3ellKHRKZwmCgYUGgwYtoagW5edyKpR09O1W4/XqBdeKXoY/LbeIKqHrqVR7sGgk6E/dNYkPS4aA==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
@@ -16455,8 +16091,8 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.1.0(postcss@8.4.29)(typescript@5.0.3):
-    resolution: {integrity: sha512-mazl/GRAk70j8S43/AbSYXGgvRP54oQeX8Un4iZxzATHt0roW0t6HYDVZIXMw0ZQIpvr1nFMniIVnN5186lW7w==}
+  /tsup@7.2.0(postcss@8.4.29)(typescript@5.2.2):
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
     peerDependencies:
@@ -16486,20 +16122,10 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.0.3
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
-    dev: true
-
-  /tsutils@3.21.0(typescript@5.0.3):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.0.3
     dev: true
 
   /tsutils@3.21.0(typescript@5.2.2):
@@ -16626,12 +16252,6 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typescript@5.0.3:
-    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-    dev: true
-
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
@@ -16667,6 +16287,9 @@ packages:
 
   /undici-types@5.25.3:
     resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   /unenv@1.7.4:
     resolution: {integrity: sha512-fjYsXYi30It0YCQYqLOcT6fHfMXsBr2hw9XC7ycf8rTG7Xxpe3ZssiqUnD0khrjiZEmkBXWLwm42yCSCH46fMw==}


### PR DESCRIPTION
As discussed with both Francis, it's easier to distinguish core tokens from dataviz tokens if dataviz tokens are prefixed with dataviz. 

Also colors for test values have been split in multiple tests, with a better representation of their color 

![image](https://github.com/gsoft-inc/wl-hopper/assets/38871812/a46eaa6b-6a8d-4348-b754-44818e551577)
![image](https://github.com/gsoft-inc/wl-hopper/assets/38871812/b2eb57e1-98d3-49d6-bf6e-3b622d3091a0)
![image](https://github.com/gsoft-inc/wl-hopper/assets/38871812/da05ed16-7fec-4cb7-9ea7-1f284261b27a)
![image](https://github.com/gsoft-inc/wl-hopper/assets/38871812/aaf51d50-0c77-44a6-ba4f-9e791fd41742)
