### PR TITLE
reordered nav

### DIFF
--- a/apps/docs/components/ui/sidebar/Sidebar.tsx
+++ b/apps/docs/components/ui/sidebar/Sidebar.tsx
@@ -19,7 +19,7 @@ interface SidebarProps {
 
 const Sidebar = ({ data, isOpen, onClose }: SidebarProps) => {
     const sidebarRef = useRef<HTMLDivElement>(null);
-    const links = getPageLinks(data, { order: ["getting-started", "core", "semantic"] });
+    const links = getPageLinks(data, { order: ["getting-started", "semantic", "core"] });
     const pathName = usePathname();
 
     useEffect(() => {


### PR DESCRIPTION
- Some user's were baffled by the fact that Core Tokens were shown before Semantic, I reordered the nav to help discoverability.