### PR TITLE
chore: Removed warning in tokens' package build

### DIFF
--- a/packages/tokens/src/style-dictionary/config.ts
+++ b/packages/tokens/src/style-dictionary/config.ts
@@ -10,7 +10,7 @@ export const fontsConfig: Config = {
     "source": ["src/tokens/asset/*.tokens.json"],
     "platforms": {
         "css-font-face": {
-            "transforms": ["attribute/font"],
+            "transforms": ["name/cti/kebab", "attribute/font"],
             "buildPath": `${BUILD_PATH}`,
             "files": [
                 {
@@ -101,7 +101,6 @@ export function getStyleDictionaryConfig(mode: "light" | "dark"): Config {
     const darkConfig: File = {
         "destination": "dark/tokens.css",
         "format": "css/dark-mode",
-        "filter": "mode/dark",
         "options": {
             "outputReferences": true
         }

--- a/packages/tokens/src/style-dictionary/format/css-dark-mode.ts
+++ b/packages/tokens/src/style-dictionary/format/css-dark-mode.ts
@@ -1,9 +1,8 @@
 import type { Dictionary } from "style-dictionary";
+import { isDarkTokens } from "../filter/isDarkTokens.ts";
 
 export const cssDarkMode = function ({ dictionary }: { dictionary: Dictionary }) {
-    const darkTokens = dictionary.allTokens.filter(token => {
-        return token.filePath.includes("dark");
-    }).map(token => {
+    const darkTokens = dictionary.allTokens.filter(isDarkTokens).map(token => {
         let value = token.value;
 
         if (dictionary.usesReference(token.original.value)) {


### PR DESCRIPTION
Problem 1: 
![image](https://github.com/gsoft-inc/wl-hopper/assets/38871812/f3de5752-6eed-499b-9bf7-e3b5bd2457bb)

since multiple token had the "410" name, 
"asset" / "font" / "Inter" / "normal" / "410"
"asset" / "font" / "ABC Favorit Mono" / "normal" / "410"

there was a name clash with 410. By adding "name/cti/kebab" to the transforms, names are now unique. Since the transform after that uses the paths, and not the name, the rest works perfectly fine

Problem 2: 
![image](https://github.com/gsoft-inc/wl-hopper/assets/38871812/cb090287-a7f7-4446-9dd2-d52e2bbc200a)

Since the darkmode.css file refers to core values, it has to import those value. However, we had a mode/filter which excluded them all right after. So there was a warning telling us they were ignore. We can safely remove "mode/dark" filter, since the formatter "css/dark-mode" already filter out dark mode tokens inside it's code.