### PR TITLE
fix for typo in withBodyStyle prop

### DIFF
--- a/apps/docs/content/icons/react-icons/standalone-installation.mdx
+++ b/apps/docs/content/icons/react-icons/standalone-installation.mdx
@@ -51,7 +51,7 @@ import App from "./App";
 const root = createRoot(document.getElementById("root")!);
 
 root.render(
-    <StyledSystemProvider withBodyStyles colorScheme="light">
+    <StyledSystemProvider withBodyStyle colorScheme="light">
         <App />
     </StyledSystemProvider>
 );


### PR DESCRIPTION
- documentation example had a typo for the icon.