### PR TITLE
Change build target to target es2019. 

### DIFF
--- a/.changeset/tall-avocados-glow.md
+++ b/.changeset/tall-avocados-glow.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+"@hopper-ui/icons": patch
+---
+
+Changed build target to target ES2019

--- a/packages/components/tsup.build.ts
+++ b/packages/components/tsup.build.ts
@@ -1,5 +1,6 @@
 import { defineBuildConfig } from "@workleap/tsup-configs";
 
 export default defineBuildConfig({
-    entry: ["./src/**/src/*.(ts|tsx)"]
+    entry: ["./src/**/src/*.(ts|tsx)"],
+    target: "es2019" // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
 });

--- a/packages/icons/tsup.build.ts
+++ b/packages/icons/tsup.build.ts
@@ -4,6 +4,7 @@ import packageJson from "./package.json";
 
 export default defineBuildConfig({
     entry: ["./src/**/*.(ts|tsx)"],
+    target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     esbuildPlugins: [
         createCssModuleEsbuildPlugin({
             generateScopedName: "[name]__[local]___[hash:base64:5]",

--- a/packages/styled-system/tsup.build.ts
+++ b/packages/styled-system/tsup.build.ts
@@ -4,6 +4,7 @@ import packageJson from "./package.json";
 
 export default defineBuildConfig({
     entry: ["./src/**/*.(ts|tsx)"],
+    target: "es2019", // We set target ES2019 since ES2020 syntax is not supported by older versions of storybook (used in orbiter)
     esbuildPlugins: [
         createCssModuleEsbuildPlugin({
             generateScopedName: "[name]__[local]___[hash:base64:5]",


### PR DESCRIPTION
Some tools (storybook) do not support ES2020 synthax. I had a super hard time changing the tool config to accept this, so instead i'm compiling hopper in an older version