### PR TITLE
modified the copied code when clicking an icon in the icon doc

### DIFF
--- a/apps/docs/components/iconTable/IconItem.tsx
+++ b/apps/docs/components/iconTable/IconItem.tsx
@@ -32,9 +32,7 @@ const IconItem: React.FC<IconItemProps> = ({ name, type, size }) => {
 
     const formattedName = name.replace("Icon", "");
     const copyString = type === "react"
-        ? size !== "md"
-            ? `<${name} size="${size}" />`
-            : `<${name} />`
+        ? `${name}`
         : `${toKebabCase(formattedName).toLowerCase()}-${getIconNumericSize(size)}.svg`;
 
     const Component = IconLibrary[name];


### PR DESCRIPTION
Copy pasting a React Icon was in the way as it was copying the whole component. 