### PR TITLE
patch: Change the breakpoint context to now throw when the provider has not been declared

### DIFF
--- a/.changeset/famous-clocks-occur.md
+++ b/.changeset/famous-clocks-occur.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/styled-system": patch
+---
+
+Modify the breakpoint context to not throw, so components can render even if no provider has been declared

--- a/packages/styled-system/src/responsive/BreakpointContext.tsx
+++ b/packages/styled-system/src/responsive/BreakpointContext.tsx
@@ -1,20 +1,17 @@
 import { createContext, useContext } from "react";
-import { isNil } from "../utils/assertion.ts";
 import type { Breakpoint } from "./Breakpoints.ts";
 
 export interface BreakpointContextType {
     matchedBreakpoints: Breakpoint[];
 }
 
-export const BreakpointContext = createContext<BreakpointContextType | undefined>(undefined);
+export const BreakpointContext = createContext<BreakpointContextType>({
+    matchedBreakpoints: []
+});
 
 
 export function useBreakpointContext() {
     const context = useContext(BreakpointContext);
-
-    if (isNil(context)) {
-        throw new Error("useBreakpointContext must be used within a BreakpointProvider");
-    }
 
     return context;
 }


### PR DESCRIPTION
Modify breakpoint context to not throw, so component can render even if no provider has been declared