### PR TITLE
Add `pnpm build` command to readme for first time cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ After cloning the source code, run `pnpm` to install dependencies.
 git clone https://github.com/gsoft-inc/wl-hopper.git
 cd wl-hopper
 pnpm i
+pnpm build
 ```
 
 ### Scripts


### PR DESCRIPTION
Hey all 👋🏻 while pulling this repo down and attempting to run it I hit a small snag on the imports for `@hopper-ui/tokens/fonts.css` in a few component files. After getting some help from @fraincs we realized the `build` command is never mentioned as a step to take for local development. 

This adds in that command after you install your `node_modules` to go ahead and build out the packages in the workspace as well. 