### PR TITLE
Added an exception for overline to output the right values in the doc

### DIFF
--- a/apps/docs/components/ui/table/TypographyTable.tsx
+++ b/apps/docs/components/ui/table/TypographyTable.tsx
@@ -52,11 +52,21 @@ function groupItemsByPropertiesAndSizes(tokenData: TokenData, itemType: string):
             const matchingItem = tokenData[propertyKey].find(item => {
                 const nameParts = item.name.split("-");
 
-                return nameParts.includes(itemType === "overline" ? "md" : itemType) && nameParts.includes(size);
+                return nameParts.includes(itemType) && nameParts.includes(size);
+            });
+
+            const matchingItemOverline = tokenData[propertyKey].find(item => {
+                const nameParts = item.name.split("-");
+
+                return nameParts.includes(itemType);
             });
 
             if (matchingItem) {
                 groupedItems[sizeKey][propertyKey] = matchingItem.value;
+            }
+
+            if (matchingItemOverline && sizeKey === "md") {
+                groupedItems[sizeKey][propertyKey] = matchingItemOverline.value;
             }
         });
 

--- a/apps/docs/content/tokens/semantic/typography.mdx
+++ b/apps/docs/content/tokens/semantic/typography.mdx
@@ -35,7 +35,7 @@ Headings are used to create a hierarchy of content. They are used to help users 
 
 Used to introduce a headline.
 
-_Adding a text-transform of uppercase is necessary in order to render overline as intended by the Design._
+_Adding a text-transform of uppercase is necessary in order to render overline as intended by the Design. A letter spacing of 0.24px is also necessary._
 
 <TypographyTable type="overline" data={tokens.semantic} />
 


### PR DESCRIPTION
The documentation for the overline text style was returning Heading-md values. This PR fixes this, the cause was due to overline not having a size.