### PR TITLE
chore: add changeset settings to ignore bumping packages with peer dependencies for nothing.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
Even tho the name of the property is scary, it's widely used by projects inside and outside workleap