### PR TITLE
removed localhost from link

### DIFF
--- a/apps/docs/content/guides/css/text-crop.mdx
+++ b/apps/docs/content/guides/css/text-crop.mdx
@@ -24,7 +24,7 @@ It is suggested to apply this technique on a text element, such as a `span`, rat
 
 Using a negative margin on the top and bottom of the text will crop the whitespace while preserving line height between lines in a multi-line block of text.
 
-If you need to implement this technique, you can use the following CSS. Keep in mind that each font weight and line-height combinations have their own set of values. You need to use the right token for the job, these are documented in the [tokens section](http://localhost:3000/tokens/semantic/typography).
+If you need to implement this technique, you can use the following CSS. Keep in mind that each font weight and line-height combinations have their own set of values. You need to use the right token for the job, these are documented in the [tokens section](/tokens/semantic/typography).
 
 ```tsx title="component.tsx"
 <div className="myBadge">


### PR DESCRIPTION
The documentation of Text Crop was linking to localhost.