### PR TITLE
Add import rules to our monorepo

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,10 +1,11 @@
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import type { StorybookConfig } from "@storybook/react-webpack5";
+import type { Options } from "@storybook/types";
+import type { Options as SwcOptions } from "@swc/core";
 import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
+
 import { swcConfig as SwcBuildConfig } from "./swc.build.ts";
 import { swcConfig as SwcDevConfig } from "./swc.dev.ts";
-import type { Options as SwcOptions } from "@swc/core";
-import type { Options } from "@storybook/types";
 
 // We sometimes need to disable the lazyCompilation to properly run the test runner on stories
 const isLazyCompilation = !(process.env.STORYBOOK_NO_LAZY === "true");

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,3 @@
-import type { Preview } from "@storybook/react";
 import { withHopperProvider, viewport } from "@hopper-ui/storybook-addon";
 import {
     Description,
@@ -6,6 +5,7 @@ import {
     Subtitle,
     Title
 } from "@storybook/blocks";
+import type { Preview } from "@storybook/react";
 
 import "./stories.css";
 import "@hopper-ui/tokens/fonts.css";

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -37,5 +37,3 @@ export const config = {
         });
     }
 } satisfies TestRunnerConfig;
-
-

--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -5,6 +5,27 @@
     "rules": {
         "no-console": ["warn", { "allow": ["warn", "error"] }],
         "react/destructuring-assignment": "off",
-        "no-param-reassign": "off"
+        "no-param-reassign": "off",
+
+        "import/order": ["error", {
+            "newlines-between": "always",
+            "groups": [
+                ["builtin", "external"], //external components / types included
+                "parent", // local components
+                ["sibling", "index"]
+            ],
+            "pathGroups": [
+                {
+                    "pattern": "./*.module.css", // CSS comes in a group after the last group
+                    "group": "object",
+                    "position": "after"
+                }
+            ],
+            "pathGroupsExcludedImportTypes": ["builtin"],
+            "alphabetize": {
+                "order": "asc",
+                "caseInsensitive": true
+            }
+        }]
     }
 }

--- a/packages/components/jest.config.ts
+++ b/packages/components/jest.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "jest";
 import { pathsToModuleNameMapper } from "ts-jest";
+
 import { swcConfig } from "./swc.jest.ts";
 import { compilerOptions } from "./tsconfig.json";
 

--- a/packages/components/src/HopperProvider/tests/chromatic/HopperProvider.stories.tsx
+++ b/packages/components/src/HopperProvider/tests/chromatic/HopperProvider.stories.tsx
@@ -1,8 +1,9 @@
-import { HopperProvider } from "../../src/HopperProvider.tsx";
+import { hopperParameters, a11yParameters } from "@hopper-ui/storybook-addon";
 import { Div, useColorSchemeContext } from "@hopper-ui/styled-system";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
-import { hopperParameters, a11yParameters } from "@hopper-ui/storybook-addon";
+
+import { HopperProvider } from "../../src/HopperProvider.tsx";
 
 const ColoredDiv = () => {
     return (

--- a/packages/components/src/HopperProvider/tests/jest/HopperProvider.ssr.test.tsx
+++ b/packages/components/src/HopperProvider/tests/jest/HopperProvider.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { HopperProvider } from "../../../HopperProvider/index.ts";
 import { renderToString } from "react-dom/server";
+
+import { HopperProvider } from "../../../HopperProvider/index.ts";
 
 describe("HopperProvider", () => {
     it("should render on the server", () => {

--- a/packages/components/src/HopperProvider/tests/jest/HopperProvider.test.tsx
+++ b/packages/components/src/HopperProvider/tests/jest/HopperProvider.test.tsx
@@ -1,7 +1,8 @@
-import { HopperProvider } from "../../src/index.ts";
-import { createRef } from "react";
 import { render, renderHook, screen } from "@hopper-ui/test-utils";
+import { createRef } from "react";
 import { useLocale } from "react-aria-components";
+
+import { HopperProvider } from "../../src/index.ts";
 
 describe("HopperProvider", () => {
     it("should render with default class", () => {

--- a/packages/components/src/IconList/docs/IconList.stories.tsx
+++ b/packages/components/src/IconList/docs/IconList.stories.tsx
@@ -1,9 +1,10 @@
-import { IconList } from "../src/IconList.tsx";
 import { AddIcon, PlusIcon } from "@hopper-ui/icons";
 import type { Meta, StoryObj } from "@storybook/react";
+
 import { Stack } from "../../layout/src/Stack.tsx";
-import { IconListContext } from "../src/IconListContext.ts";
 import { SlotProvider } from "../../utils/index.ts";
+import { IconList } from "../src/IconList.tsx";
+import { IconListContext } from "../src/IconListContext.ts";
 
 /**
  * A component that allows you to render a list of icons

--- a/packages/components/src/IconList/src/IconList.tsx
+++ b/packages/components/src/IconList/src/IconList.tsx
@@ -1,12 +1,15 @@
-import { useContextProps } from "react-aria-components";
-import styles from "./IconList.module.css";
-import { IconListContext } from "./IconListContext.ts";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
-import type { BaseComponentProps } from "../../utils/index.ts";
-import clsx from "clsx";
-import { useStyledSystem, type StyledSystemProps, type ResponsiveProp } from "@hopper-ui/styled-system";
 import { IconContext } from "@hopper-ui/icons";
+import { useStyledSystem, type StyledSystemProps, type ResponsiveProp } from "@hopper-ui/styled-system";
+import clsx from "clsx";
+import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
+import { useContextProps } from "react-aria-components";
+
+import type { BaseComponentProps } from "../../utils/index.ts";
 import { SlotProvider } from "../../utils/index.ts";
+
+import { IconListContext } from "./IconListContext.ts";
+
+import styles from "./IconList.module.css";
 
 export const GlobalIconListCssSelector = "hop-IconList";
 

--- a/packages/components/src/IconList/src/IconListContext.ts
+++ b/packages/components/src/IconList/src/IconListContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { ContextValue } from "react-aria-components";
+
 import type { IconListProps } from "./IconList.tsx";
 
 export const IconListContext = createContext<ContextValue<IconListProps, HTMLSpanElement>>({});

--- a/packages/components/src/IconList/tests/chromatic/IconList.stories.tsx
+++ b/packages/components/src/IconList/tests/chromatic/IconList.stories.tsx
@@ -1,6 +1,7 @@
 import { AddIcon, PlusIcon } from "@hopper-ui/icons";
-import { IconList } from "../../src/IconList.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { IconList } from "../../src/IconList.tsx";
 
 const meta = {
     title: "Components/IconList",

--- a/packages/components/src/IconList/tests/jest/IconList.ssr.test.tsx
+++ b/packages/components/src/IconList/tests/jest/IconList.ssr.test.tsx
@@ -1,9 +1,10 @@
 /**
  * @jest-environment node
  */
-import { IconList } from "../../src/IconList.tsx";
-import { renderToString } from "react-dom/server";
 import { AddIcon, PlusIcon } from "@hopper-ui/icons";
+import { renderToString } from "react-dom/server";
+
+import { IconList } from "../../src/IconList.tsx";
 
 describe("IconList", () => {
     it("should render on the server", () => {

--- a/packages/components/src/IconList/tests/jest/IconList.test.tsx
+++ b/packages/components/src/IconList/tests/jest/IconList.test.tsx
@@ -1,8 +1,9 @@
-import { IconList } from "../../src/IconList.tsx";
-import { IconListContext } from "../../src/IconListContext.ts";
-import { createRef } from "react";
 import { AddIcon, PlusIcon } from "@hopper-ui/icons";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef } from "react";
+
+import { IconList } from "../../src/IconList.tsx";
+import { IconListContext } from "../../src/IconListContext.ts";
 
 describe("IconList", () => {
     it("should render with default class", () => {

--- a/packages/components/src/Label/docs/Label.stories.tsx
+++ b/packages/components/src/Label/docs/Label.stories.tsx
@@ -1,9 +1,10 @@
 import { Div } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
 import { Stack } from "../../layout/src/Stack.tsx";
+import { SlotProvider } from "../../utils/index.ts";
 import { Label } from "../src/Label.tsx";
 import { LabelContext } from "../src/LabelContext.ts";
-import type { Meta, StoryObj } from "@storybook/react";
-import { SlotProvider } from "../../utils/index.ts";
 
 /**
  * A primitive label component matching Hopper's typography type scale.

--- a/packages/components/src/Label/src/Label.tsx
+++ b/packages/components/src/Label/src/Label.tsx
@@ -1,10 +1,14 @@
 import { type StyledComponentProps, useStyledSystem, type ResponsiveProp, useResponsiveValue } from "@hopper-ui/styled-system";
+import clsx from "clsx";
 import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { Label as RACLabel, useContextProps, type LabelProps as RACLabelProps } from "react-aria-components";
-import clsx from "clsx";
-import styles from "./Label.module.css";
+
+
 import { cssModule } from "../../utils/src/cssModule.ts";
+
 import { LabelContext } from "./LabelContext.ts";
+
+import styles from "./Label.module.css";
 
 export const GlobalLabelCssSelector = "hop-Label";
 

--- a/packages/components/src/Label/src/LabelContext.ts
+++ b/packages/components/src/Label/src/LabelContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { ContextValue } from "react-aria-components";
+
 import type { LabelProps } from "./Label.tsx";
 
 export const LabelContext = createContext<ContextValue<LabelProps, HTMLLabelElement>>({});

--- a/packages/components/src/Label/tests/chromatic/Label.stories.tsx
+++ b/packages/components/src/Label/tests/chromatic/Label.stories.tsx
@@ -1,5 +1,6 @@
-import { Label } from "../../src/Label.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Label } from "../../src/Label.tsx";
 
 const meta = {
     title: "Components/Typography/Label",

--- a/packages/components/src/Label/tests/jest/Label.ssr.test.tsx
+++ b/packages/components/src/Label/tests/jest/Label.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Label } from "../../src/Label.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Label } from "../../src/Label.tsx";
 
 describe("Label", () => {
     it("should render on the server", () => {

--- a/packages/components/src/Label/tests/jest/Label.test.tsx
+++ b/packages/components/src/Label/tests/jest/Label.test.tsx
@@ -1,7 +1,8 @@
+import { render, screen } from "@hopper-ui/test-utils";
+import { createRef } from "react";
+
 import { Label } from "../../src/Label.tsx";
 import { LabelContext } from "../../src/LabelContext.ts";
-import { createRef } from "react";
-import { render, screen } from "@hopper-ui/test-utils";
 
 describe("Label", () => {
     it("should render with default class", () => {

--- a/packages/components/src/Spinner/docs/Spinner.stories.tsx
+++ b/packages/components/src/Spinner/docs/Spinner.stories.tsx
@@ -1,9 +1,10 @@
 import { Div } from "@hopper-ui/styled-system";
-import { Spinner } from "../src/Spinner.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
 import { Inline } from "../../layout/index.ts";
-import { SpinnerContext } from "../src/SpinnerContext.ts";
 import { SlotProvider } from "../../utils/index.ts";
+import { Spinner } from "../src/Spinner.tsx";
+import { SpinnerContext } from "../src/SpinnerContext.ts";
 
 /**
  * A spinner indicates that a part of the product is currently performing a task, and the duration of this process is unknown.

--- a/packages/components/src/Spinner/src/Spinner.tsx
+++ b/packages/components/src/Spinner/src/Spinner.tsx
@@ -1,11 +1,14 @@
 import { useStyledSystem, type ResponsiveProp, useResponsiveValue, type StyledSystemProps } from "@hopper-ui/styled-system";
 import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { ProgressBar, useContextProps } from "react-aria-components";
+
+import { Label, type LabelProps } from "../../Label/src/Label.tsx";
 import { composeClassnameRenderProps, cssModule, type SizeAdapter } from "../../utils/index.ts";
 import type { BaseComponentProps } from "../../utils/src/types.ts";
-import styles from "./Spinner.module.css";
+
 import { SpinnerContext } from "./SpinnerContext.ts";
-import { Label, type LabelProps } from "../../Label/src/Label.tsx";
+
+import styles from "./Spinner.module.css";
 
 export const GlobalSpinnerCssSelector = "hop-Spinner";
 

--- a/packages/components/src/Spinner/src/SpinnerContext.ts
+++ b/packages/components/src/Spinner/src/SpinnerContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { ContextValue } from "react-aria-components";
+
 import type { SpinnerProps } from "./Spinner.tsx";
 
 export const SpinnerContext = createContext<ContextValue<SpinnerProps, HTMLDivElement>>({});

--- a/packages/components/src/Spinner/tests/chromatic/Spinner.stories.tsx
+++ b/packages/components/src/Spinner/tests/chromatic/Spinner.stories.tsx
@@ -1,6 +1,7 @@
-import { Spinner } from "../../src/Spinner.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
 import { Inline, Stack } from "../../../layout/index.ts";
+import { Spinner } from "../../src/Spinner.tsx";
 
 const meta = {
     component: Spinner,

--- a/packages/components/src/Spinner/tests/jest/Spinner.ssr.test.tsx
+++ b/packages/components/src/Spinner/tests/jest/Spinner.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Spinner } from "../../src/Spinner.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Spinner } from "../../src/Spinner.tsx";
 
 describe("Spinner", () => {
     it("should render on the server", () => {

--- a/packages/components/src/Spinner/tests/jest/Spinner.test.tsx
+++ b/packages/components/src/Spinner/tests/jest/Spinner.test.tsx
@@ -1,7 +1,8 @@
-import { SpinnerContext } from "../../src/SpinnerContext.ts";
-import { Spinner } from "../../src/Spinner.tsx";
-import { createRef } from "react";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef } from "react";
+
+import { Spinner } from "../../src/Spinner.tsx";
+import { SpinnerContext } from "../../src/SpinnerContext.ts";
 
 describe("Spinner", () => {
     it("should render with default class", () => {

--- a/packages/components/src/Text/docs/Text.stories.tsx
+++ b/packages/components/src/Text/docs/Text.stories.tsx
@@ -1,9 +1,11 @@
+import { Div } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Stack } from "../../layout/src/Stack.tsx";
+import { SlotProvider } from "../../utils/index.ts";
 import { Text } from "../src/Text.tsx";
 import { TextContext } from "../src/TextContext.ts";
-import type { Meta, StoryObj } from "@storybook/react";
-import { Stack } from "../../layout/src/Stack.tsx";
-import { Div } from "@hopper-ui/styled-system";
-import { SlotProvider } from "../../utils/index.ts";
+
 
 /**
  * A primitive text component matching Hopper's typography type scale.

--- a/packages/components/src/Text/src/Text.tsx
+++ b/packages/components/src/Text/src/Text.tsx
@@ -1,18 +1,20 @@
 import { type StyledComponentProps, useStyledSystem, type ResponsiveProp, useResponsiveValue } from "@hopper-ui/styled-system";
+import clsx from "clsx";
 import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { Text as RACText, useContextProps, type TextProps as RACTextProps } from "react-aria-components";
-import clsx from "clsx";
-import styles from "./Text.module.css";
-import { cssModule } from "../../utils/src/cssModule.ts";
-import { TextContext } from "./TextContext.ts";
-import { ClearContainerSlots } from "../../utils/src/ClearSlots.tsx";
+
 import { SlotProvider } from "../../index.ts";
+import { ClearContainerSlots } from "../../utils/src/ClearSlots.tsx";
+import { cssModule } from "../../utils/src/cssModule.ts";
+
+import { TextContext } from "./TextContext.ts";
+
+import styles from "./Text.module.css";
 
 export const GlobalTextCssSelector = "hop-Text";
 
 // Won't be needed in next react-aria-components release: https://github.com/adobe/react-spectrum/pull/5850
 const DefaultTextSlot = "text";
-
 
 export interface TextProps extends StyledComponentProps<RACTextProps> {
     /**

--- a/packages/components/src/Text/src/TextContext.ts
+++ b/packages/components/src/Text/src/TextContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { ContextValue } from "react-aria-components";
+
 import type { TextProps } from "./Text.tsx";
 
 export const TextContext = createContext<ContextValue<TextProps, HTMLSpanElement>>({});

--- a/packages/components/src/Text/tests/chromatic/Text.stories.tsx
+++ b/packages/components/src/Text/tests/chromatic/Text.stories.tsx
@@ -1,6 +1,7 @@
-import { Text } from "../../src/Text.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
 import { a11yParameters } from "@hopper-ui/storybook-addon";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Text } from "../../src/Text.tsx";
 
 const meta = {
     title: "Components/Typography/Text",

--- a/packages/components/src/Text/tests/jest/Text.ssr.test.tsx
+++ b/packages/components/src/Text/tests/jest/Text.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Text } from "../../src/Text.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Text } from "../../src/Text.tsx";
 
 describe("Text", () => {
     it("should render on the server", () => {

--- a/packages/components/src/Text/tests/jest/Text.test.tsx
+++ b/packages/components/src/Text/tests/jest/Text.test.tsx
@@ -1,8 +1,9 @@
-import { TextContext } from "../../src/TextContext.ts";
-import { Text } from "../../src/Text.tsx";
-import { createRef } from "react";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef } from "react";
+
 import { ButtonGroupContext } from "../../../buttons/src/ButtonGroupContext.ts";
+import { Text } from "../../src/Text.tsx";
+import { TextContext } from "../../src/TextContext.ts";
 
 describe("Text", () => {
     it("should render with default class", () => {

--- a/packages/components/src/buttons/docs/Button.stories.tsx
+++ b/packages/components/src/buttons/docs/Button.stories.tsx
@@ -1,12 +1,13 @@
+import { PlusIcon } from "@hopper-ui/icons";
+import type { Meta, StoryObj } from "@storybook/react";
+import { RouterProvider, createMemoryRouter, useNavigate } from "react-router-dom";
+
+import { HopperProvider } from "../../index.ts";
+import { Inline, Stack } from "../../layout/index.ts";
 import { Text } from "../../Text/index.ts";
+import { SlotProvider } from "../../utils/index.ts";
 import { Button } from "../src/Button.tsx";
 import { ButtonContext } from "../src/ButtonContext.ts";
-import type { Meta, StoryObj } from "@storybook/react";
-import { PlusIcon } from "@hopper-ui/icons";
-import { SlotProvider } from "../../utils/index.ts";
-import { Inline, Stack } from "../../layout/index.ts";
-import { HopperProvider } from "../../index.ts";
-import { RouterProvider, createMemoryRouter, useNavigate } from "react-router-dom";
 
 /**
  * Buttons are used to initialize an action. Button labels express what action will occur when the user interacts with it.

--- a/packages/components/src/buttons/docs/ButtonGroup.stories.tsx
+++ b/packages/components/src/buttons/docs/ButtonGroup.stories.tsx
@@ -1,7 +1,8 @@
-import { Button } from "../src/Button.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
-import { ButtonGroup } from "../src/ButtonGroup.tsx";
+
 import { Stack } from "../../layout/src/Stack.tsx";
+import { Button } from "../src/Button.tsx";
+import { ButtonGroup } from "../src/ButtonGroup.tsx";
 
 /**
  * ButtonGroup handles the spacing and orientation for a grouping of buttons whose actions are related to each other.

--- a/packages/components/src/buttons/src/Button.module.css
+++ b/packages/components/src/buttons/src/Button.module.css
@@ -415,7 +415,6 @@
     --spinner-color: var(--hop-Button-ghost-secondary-spinner-color);
 }
 
-
 .hop-Button--ghost-secondary[data-disabled]:not([data-loading]) {
     --background-color: var(--hop-Button-ghost-secondary-background-color-disabled);
     --color: var(--hop-Button-ghost-secondary-color-disabled);

--- a/packages/components/src/buttons/src/Button.tsx
+++ b/packages/components/src/buttons/src/Button.tsx
@@ -1,21 +1,24 @@
+import { IconContext } from "@hopper-ui/icons";
 import { type StyledComponentProps, useStyledSystem, type ResponsiveProp, useResponsiveValue } from "@hopper-ui/styled-system";
-import { type ForwardedRef, forwardRef, type MouseEvent, type MutableRefObject } from "react";
-import { useContextProps, composeRenderProps, type ButtonProps as RACButtonProps, type ButtonRenderProps, ButtonContext as RACButtonContext } from "react-aria-components";
 import { useRouter, shouldClientNavigate, filterDOMProps, chain } from "@react-aria/utils";
-import styles from "./Button.module.css";
+import { type ForwardedRef, forwardRef, type MouseEvent, type MutableRefObject } from "react";
 import { useButton, useHover, useFocusRing, mergeProps } from "react-aria";
-import { cssModule } from "../../utils/src/cssModule.ts";
+import { useContextProps, composeRenderProps, type ButtonProps as RACButtonProps, type ButtonRenderProps, ButtonContext as RACButtonContext } from "react-aria-components";
+
+import { IconListContext } from "../../IconList/index.ts";
+import { useLocalizedString } from "../../intl/index.ts";
+import { Spinner } from "../../Spinner/index.ts";
+import { TextContext } from "../../Text/index.ts";
 import { Text } from "../../Text/src/Text.tsx";
 import { composeClassnameRenderProps, SlotProvider } from "../../utils/index.ts";
-import { IconContext } from "@hopper-ui/icons";
-import { ButtonContext, type ButtonContextValue } from "./ButtonContext.ts";
-import { TextContext } from "../../Text/index.ts";
-import { IconListContext } from "../../IconList/index.ts";
-import { Spinner } from "../../Spinner/index.ts";
+import { cssModule } from "../../utils/src/cssModule.ts";
+import { useSlot } from "../../utils/src/index.ts";
 import { isTextOnlyChildren } from "../../utils/src/isTextOnlyChildren.ts";
 import { useRenderProps } from "../../utils/src/useRenderProps.ts";
-import { useSlot } from "../../utils/src/index.ts";
-import { useLocalizedString } from "../../intl/index.ts";
+
+import { ButtonContext, type ButtonContextValue } from "./ButtonContext.ts";
+
+import styles from "./Button.module.css";
 
 export const GlobalButtonCssSelector = "hop-Button";
 

--- a/packages/components/src/buttons/src/ButtonContext.ts
+++ b/packages/components/src/buttons/src/ButtonContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { ContextValue } from "react-aria-components";
+
 import type { ButtonProps } from "./Button.tsx";
 
 export interface ButtonContextValue extends ButtonProps {

--- a/packages/components/src/buttons/src/ButtonGroup.tsx
+++ b/packages/components/src/buttons/src/ButtonGroup.tsx
@@ -1,13 +1,16 @@
-import { forwardRef, type ForwardedRef, type HTMLAttributes, type CSSProperties } from "react";
-import { ButtonContext } from "./ButtonContext.ts";
-import type { Orientation } from "react-aria";
 import { useStyledSystem, type StyledComponentProps, useResponsiveValue, type ResponsiveProp } from "@hopper-ui/styled-system";
-import { useContextProps } from "react-aria-components";
-import { ButtonGroupContext } from "./ButtonGroupContext.ts";
-import { SlotProvider, cssModule } from "../../utils/index.ts";
-import styles from "./ButtonGroup.module.css";
 import { filterDOMProps } from "@react-aria/utils";
 import clsx from "clsx";
+import { forwardRef, type ForwardedRef, type HTMLAttributes, type CSSProperties } from "react";
+import type { Orientation } from "react-aria";
+import { useContextProps } from "react-aria-components";
+
+import { SlotProvider, cssModule } from "../../utils/index.ts";
+
+import { ButtonContext } from "./ButtonContext.ts";
+import { ButtonGroupContext } from "./ButtonGroupContext.ts";
+
+import styles from "./ButtonGroup.module.css";
 
 export interface ButtonGroupProps extends StyledComponentProps<HTMLAttributes<HTMLDivElement>> {
     /**

--- a/packages/components/src/buttons/src/ButtonGroupContext.ts
+++ b/packages/components/src/buttons/src/ButtonGroupContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { ContextValue } from "react-aria-components";
+
 import type { ButtonGroupProps } from "./ButtonGroup.tsx";
 
 export const ButtonGroupContext = createContext<ContextValue<ButtonGroupProps, HTMLDivElement>>({});

--- a/packages/components/src/buttons/tests/chromatic/Button.stories.tsx
+++ b/packages/components/src/buttons/tests/chromatic/Button.stories.tsx
@@ -1,12 +1,13 @@
-import { Div } from "@hopper-ui/styled-system";
-import { Button, type ButtonProps } from "../../src/Button.tsx";
-import { IconList } from "../../../IconList/src/IconList.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
-import { Text } from "../../../Text/src/Text.tsx";
 import { RefreshIcon, PlusIcon } from "@hopper-ui/icons";
+import { Div } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
 import { within } from "@storybook/test";
+
+import { IconList } from "../../../IconList/src/IconList.tsx";
 import { Inline, Stack } from "../../../layout/index.ts";
+import { Text } from "../../../Text/src/Text.tsx";
 import { ButtonContext } from "../../index.ts";
+import { Button, type ButtonProps } from "../../src/Button.tsx";
 
 const meta = {
     title: "Components/Buttons/Button",

--- a/packages/components/src/buttons/tests/chromatic/ButtonAsLink.stories.tsx
+++ b/packages/components/src/buttons/tests/chromatic/ButtonAsLink.stories.tsx
@@ -1,5 +1,7 @@
-import { Button } from "../../src/Button.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "../../src/Button.tsx";
+
 import { Primary as PrimaryButtonStory, PrimaryStates as PrimaryStatesButtonStory } from "./Button.stories.tsx";
 
 const meta = {

--- a/packages/components/src/buttons/tests/chromatic/ButtonGroup.stories.tsx
+++ b/packages/components/src/buttons/tests/chromatic/ButtonGroup.stories.tsx
@@ -1,8 +1,9 @@
 import { AddIcon } from "@hopper-ui/icons";
 import type { Meta, StoryObj } from "@storybook/react";
-import { ButtonGroup } from "../../src/ButtonGroup.tsx";
-import { Button } from "../../src/Button.tsx";
+
 import { Stack } from "../../../layout/index.ts";
+import { Button } from "../../src/Button.tsx";
+import { ButtonGroup } from "../../src/ButtonGroup.tsx";
 
 const meta = {
     title: "Components/Buttons/ButtonGroup",

--- a/packages/components/src/buttons/tests/chromatic/IconButton.stories.tsx
+++ b/packages/components/src/buttons/tests/chromatic/IconButton.stories.tsx
@@ -1,9 +1,10 @@
-import { Button, type ButtonProps } from "../../src/Button.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
-import { Inline, Stack } from "../../../layout/index.ts";
 import { AddIcon } from "@hopper-ui/icons";
+import type { Meta, StoryObj } from "@storybook/react";
 import { within } from "@storybook/test";
+
+import { Inline, Stack } from "../../../layout/index.ts";
 import { ButtonContext } from "../../index.ts";
+import { Button, type ButtonProps } from "../../src/Button.tsx";
 
 const meta = {
     title: "Components/Buttons/Button/Icon Only",
@@ -66,7 +67,6 @@ export const GhostPrimary: Story = {
         variant: "ghost-primary"
     }
 };
-
 
 export const GhostSecondary: Story = {
     ...Primary,

--- a/packages/components/src/buttons/tests/jest/Button.ssr.test.tsx
+++ b/packages/components/src/buttons/tests/jest/Button.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Button } from "../../src/Button.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Button } from "../../src/Button.tsx";
 
 describe("Button", () => {
     it("should render on the server", () => {

--- a/packages/components/src/buttons/tests/jest/Button.test.tsx
+++ b/packages/components/src/buttons/tests/jest/Button.test.tsx
@@ -1,10 +1,12 @@
 import { act, screen, waitFor, render, fireEvent } from "@hopper-ui/test-utils";
+import { userEvent } from "@testing-library/user-event";
+import { createRef, type PropsWithChildren } from "react";
+import { createMemoryRouter, RouterProvider, useNavigate } from "react-router-dom";
+
+import { HopperProvider } from "../../../HopperProvider/index.ts";
 import { Button } from "../../src/Button.tsx";
 import { ButtonContext } from "../../src/ButtonContext.ts";
-import { createRef, type PropsWithChildren } from "react";
-import { userEvent } from "@testing-library/user-event";
-import { HopperProvider } from "../../../HopperProvider/index.ts";
-import { createMemoryRouter, RouterProvider, useNavigate } from "react-router-dom";
+
 
 function WithReactRouterProvider({ children }: PropsWithChildren) {
     const navigate = useNavigate();

--- a/packages/components/src/buttons/tests/jest/ButtonGroup.ssr.test.tsx
+++ b/packages/components/src/buttons/tests/jest/ButtonGroup.ssr.test.tsx
@@ -1,9 +1,10 @@
 /**
  * @jest-environment node
  */
-import { ButtonGroup } from "../../src/ButtonGroup.tsx";
-import { Button } from "../../src/Button.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Button } from "../../src/Button.tsx";
+import { ButtonGroup } from "../../src/ButtonGroup.tsx";
 
 describe("ButtonGroup", () => {
     it("should render on the server", () => {

--- a/packages/components/src/buttons/tests/jest/ButtonGroup.test.tsx
+++ b/packages/components/src/buttons/tests/jest/ButtonGroup.test.tsx
@@ -1,6 +1,7 @@
 import { screen, render } from "@hopper-ui/test-utils";
-import { Button } from "../../src/Button.tsx";
 import { createRef, forwardRef } from "react";
+
+import { Button } from "../../src/Button.tsx";
 import { ButtonGroup, type ButtonGroupProps } from "../../src/ButtonGroup.tsx";
 import { ButtonGroupContext } from "../../src/ButtonGroupContext.ts";
 
@@ -16,7 +17,6 @@ const ExampleButtonGroup = forwardRef<HTMLDivElement, Omit<ButtonGroupProps, "ch
         </ButtonGroup>
     );
 });
-
 
 describe("ButtonGroup", () => {
     it("should render with default class", () => {

--- a/packages/components/src/layout/docs/Flex.stories.tsx
+++ b/packages/components/src/layout/docs/Flex.stories.tsx
@@ -1,7 +1,9 @@
 import { Div } from "@hopper-ui/styled-system";
-import { Flex } from "../src/Flex.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
 import type { DivProps } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Flex } from "../src/Flex.tsx";
+
 
 /**
  * The Flex component is used to create a flex container and provides some shortcuts for the flex properties.

--- a/packages/components/src/layout/docs/Grid.stories.tsx
+++ b/packages/components/src/layout/docs/Grid.stories.tsx
@@ -1,7 +1,8 @@
 import { Div } from "@hopper-ui/styled-system";
-import { Grid, fitContent, minmax, repeat } from "../src/Grid.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
 import type { DivProps } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Grid, fitContent, minmax, repeat } from "../src/Grid.tsx";
 
 /**
  * The Grid component is used to create a grid container and provides some shortcuts for the grid properties.
@@ -194,5 +195,3 @@ export const FitContent: Story = {
         ]
     }
 };
-
-

--- a/packages/components/src/layout/docs/Inline.stories.tsx
+++ b/packages/components/src/layout/docs/Inline.stories.tsx
@@ -1,7 +1,8 @@
 import { Div } from "@hopper-ui/styled-system";
-import { Inline } from "../src/Inline.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
 import type { DivProps } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Inline } from "../src/Inline.tsx";
 
 /**
  * The Inline pattern is a layout primitive that can be used to stack elements in the horizontal direction and apply a space between them.

--- a/packages/components/src/layout/docs/Stack.stories.tsx
+++ b/packages/components/src/layout/docs/Stack.stories.tsx
@@ -1,7 +1,9 @@
 import { Div } from "@hopper-ui/styled-system";
-import { Stack } from "../src/Stack.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
 import type { DivProps } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Stack } from "../src/Stack.tsx";
+
 
 /**
  * The Stack pattern is a layout primitive that can be used to stack elements in the vertical direction and apply a space between them.

--- a/packages/components/src/layout/src/Grid.tsx
+++ b/packages/components/src/layout/src/Grid.tsx
@@ -117,7 +117,6 @@ export function repeat(count: number | "auto-fill" | "auto-fit", repetition: UNS
     return `repeat(${count}, ${Array.isArray(repetition) ? interpolateGridTemplateArray(repetition) : getSizingValue(repetition)})` as CssGrid;
 }
 
-
 /**
  * Defines a size range greater than or equal to min and less than or equal to max.
  * See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/minmax).

--- a/packages/components/src/layout/src/Inline.tsx
+++ b/packages/components/src/layout/src/Inline.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type Ref } from "react";
+
 import { Flex, type FlexProps } from "./Flex.tsx";
 
 export interface InlineProps extends Omit<FlexProps, "direction" | "alignItems" | "justifyContent"> {

--- a/packages/components/src/layout/src/Stack.tsx
+++ b/packages/components/src/layout/src/Stack.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type Ref } from "react";
+
 import { Flex, type FlexProps } from "./Flex.tsx";
 
 export interface StackProps extends Omit<FlexProps, "direction" | "alignItems" | "justifyContent"> {

--- a/packages/components/src/layout/tests/chromatic/Flex.stories.tsx
+++ b/packages/components/src/layout/tests/chromatic/Flex.stories.tsx
@@ -1,6 +1,7 @@
 import { Div, type DivProps } from "@hopper-ui/styled-system";
-import { Flex } from "../../src/Flex.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Flex } from "../../src/Flex.tsx";
 
 function Square(props: DivProps) {
     return <Div backgroundColor="decorative-option1" height="core_640" width="core_640" {...props} />;

--- a/packages/components/src/layout/tests/chromatic/FlexColumn.stories.tsx
+++ b/packages/components/src/layout/tests/chromatic/FlexColumn.stories.tsx
@@ -1,7 +1,8 @@
 import { Div, type DivProps } from "@hopper-ui/styled-system";
-import { Inline } from "../../src/Inline.tsx";
-import { Flex } from "../../src/Flex.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Flex } from "../../src/Flex.tsx";
+import { Inline } from "../../src/Inline.tsx";
 
 function Square(props: DivProps) {
     return <Div backgroundColor="decorative-option1" height="core_640" width="core_640" {...props} />;
@@ -26,7 +27,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 };
-
 
 export const Gap: Story = {
     args:{
@@ -91,7 +91,6 @@ export const JustifyContentEnd: Story = {
         width: "100%"
     }
 };
-
 
 export const JustifyContentSpaceBetween: Story = {
     ...JustifyContentStart,

--- a/packages/components/src/layout/tests/chromatic/FlexRow.stories.tsx
+++ b/packages/components/src/layout/tests/chromatic/FlexRow.stories.tsx
@@ -1,7 +1,8 @@
 import { Div, type DivProps } from "@hopper-ui/styled-system";
-import { Inline } from "../../src/Inline.tsx";
-import { Flex } from "../../src/Flex.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Flex } from "../../src/Flex.tsx";
+import { Inline } from "../../src/Inline.tsx";
 
 const meta = {
     title: "Components/Flex/Row",

--- a/packages/components/src/layout/tests/chromatic/Grid.stories.tsx
+++ b/packages/components/src/layout/tests/chromatic/Grid.stories.tsx
@@ -1,9 +1,11 @@
 import { Div } from "@hopper-ui/styled-system";
+import type { DivProps } from "@hopper-ui/styled-system";
+import type { Meta, StoryObj } from "@storybook/react";
+
 import { Grid, fitContent, minmax, repeat } from "../../src/Grid.tsx";
 import { Inline } from "../../src/Inline.tsx";
 import { Stack } from "../../src/Stack.tsx";
-import type { Meta, StoryObj } from "@storybook/react";
-import type { DivProps } from "@hopper-ui/styled-system";
+
 
 const viewports = [640, 768, 1024, 1280, 1440];
 

--- a/packages/components/src/layout/tests/chromatic/Inline.stories.tsx
+++ b/packages/components/src/layout/tests/chromatic/Inline.stories.tsx
@@ -1,6 +1,7 @@
 import { Div, type DivProps } from "@hopper-ui/styled-system";
-import { Inline } from "../../src/Inline.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Inline } from "../../src/Inline.tsx";
 
 function Square(props: DivProps) {
     return <Div backgroundColor="decorative-option1" height="core_640" width="core_640" flexShrink={0} {...props} />;

--- a/packages/components/src/layout/tests/chromatic/Stack.stories.tsx
+++ b/packages/components/src/layout/tests/chromatic/Stack.stories.tsx
@@ -1,6 +1,7 @@
 import { Div, type DivProps } from "@hopper-ui/styled-system";
-import { Stack } from "../../src/Stack.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { Stack } from "../../src/Stack.tsx";
 
 function Square(props: DivProps) {
     return <Div backgroundColor="decorative-option1" height="core_640" width="core_640" flexShrink={0} {...props} />;

--- a/packages/components/src/layout/tests/jest/Flex.ssr.test.tsx
+++ b/packages/components/src/layout/tests/jest/Flex.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Flex } from "../../src/Flex.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Flex } from "../../src/Flex.tsx";
 
 describe("Flex", () => {
     it("should render on the server", () => {

--- a/packages/components/src/layout/tests/jest/Flex.test.tsx
+++ b/packages/components/src/layout/tests/jest/Flex.test.tsx
@@ -1,6 +1,7 @@
-import { Flex, type FlexProps } from "../../src/Flex.tsx";
-import { createRef, forwardRef } from "react";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef, forwardRef } from "react";
+
+import { Flex, type FlexProps } from "../../src/Flex.tsx";
 
 const TestId = "TestId";
 

--- a/packages/components/src/layout/tests/jest/Grid.ssr.test.tsx
+++ b/packages/components/src/layout/tests/jest/Grid.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Grid } from "../../src/Grid.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Grid } from "../../src/Grid.tsx";
 
 describe("Grid", () => {
     it("should render on the server", () => {

--- a/packages/components/src/layout/tests/jest/Grid.test.tsx
+++ b/packages/components/src/layout/tests/jest/Grid.test.tsx
@@ -1,6 +1,7 @@
-import { Grid, type GridProps } from "../../src/Grid.tsx";
-import { createRef, forwardRef } from "react";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef, forwardRef } from "react";
+
+import { Grid, type GridProps } from "../../src/Grid.tsx";
 
 const TestId = "TestId";
 

--- a/packages/components/src/layout/tests/jest/Inline.ssr.test.tsx
+++ b/packages/components/src/layout/tests/jest/Inline.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Inline } from "../../src/Inline.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Inline } from "../../src/Inline.tsx";
 
 describe("Inline", () => {
     it("should render on the server", () => {

--- a/packages/components/src/layout/tests/jest/Inline.test.tsx
+++ b/packages/components/src/layout/tests/jest/Inline.test.tsx
@@ -1,6 +1,7 @@
-import { Inline, type InlineProps } from "../../src/Inline.tsx";
-import { createRef, forwardRef } from "react";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef, forwardRef } from "react";
+
+import { Inline, type InlineProps } from "../../src/Inline.tsx";
 
 const TestId = "TestId";
 

--- a/packages/components/src/layout/tests/jest/Stack.ssr.test.tsx
+++ b/packages/components/src/layout/tests/jest/Stack.ssr.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Stack } from "../../src/Stack.tsx";
 import { renderToString } from "react-dom/server";
+
+import { Stack } from "../../src/Stack.tsx";
 
 describe("Stack", () => {
     it("should render on the server", () => {

--- a/packages/components/src/layout/tests/jest/Stack.test.tsx
+++ b/packages/components/src/layout/tests/jest/Stack.test.tsx
@@ -1,6 +1,7 @@
-import { Stack, type StackProps } from "../../src/Stack.tsx";
-import { createRef, forwardRef } from "react";
 import { render, screen } from "@hopper-ui/test-utils";
+import { createRef, forwardRef } from "react";
+
+import { Stack, type StackProps } from "../../src/Stack.tsx";
 
 const TestId = "TestId";
 

--- a/packages/components/src/utils/src/index.ts
+++ b/packages/components/src/utils/src/index.ts
@@ -6,3 +6,4 @@ export * from "./isTextOnlyChildren.ts";
 export * from "./SlotProvider.ts";
 export * from "./useSlot.ts";
 export * from "./ClearSlots.tsx";
+export * from "./useRenderProps.ts";

--- a/packages/components/src/utils/src/types.ts
+++ b/packages/components/src/utils/src/types.ts
@@ -1,5 +1,5 @@
-import type { CSSProperties, ReactNode } from "react";
 import type { DOMProps as SharedDOMProps, AriaLabelingProps } from "@react-types/shared";
+import type { CSSProperties, ReactNode } from "react";
 import type { SlotProps } from "react-aria-components";
 
 /**

--- a/packages/components/src/utils/src/useRenderProps.ts
+++ b/packages/components/src/utils/src/useRenderProps.ts
@@ -1,4 +1,5 @@
 import { useMemo, type CSSProperties, type ReactNode } from "react";
+
 import type { RenderPropsHookOptions } from "./types.ts";
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,12 +110,9 @@ importers:
       stylelint:
         specifier: 16.3.1
         version: 16.3.1(typescript@5.4.2)
-<<<<<<< HEAD
       stylelint-config-clean-order:
         specifier: 5.4.2
         version: 5.4.2(stylelint@16.3.1)
-=======
->>>>>>> main
       stylelint-use-logical:
         specifier: 2.1.2
         version: 2.1.2(stylelint@16.3.1)
@@ -19086,7 +19083,6 @@ packages:
       client-only: 0.0.1
       react: 18.2.0
 
-<<<<<<< HEAD
   /stylelint-config-clean-order@5.4.2(stylelint@16.3.1):
     resolution: {integrity: sha512-lhPnDUL1gQbZYqG9kQx5dfEfiD/EpyVbb6jOiR7YfKzkIVv7Rw4jSKzvxr4v5PZqmRyCSzM3goc93jqfF+OZbA==}
     peerDependencies:
@@ -19096,8 +19092,6 @@ packages:
       stylelint-order: 6.0.4(stylelint@16.3.1)
     dev: true
 
-=======
->>>>>>> main
   /stylelint-config-recommended@14.0.0(stylelint@16.3.1):
     resolution: {integrity: sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==}
     engines: {node: '>=18.12.0'}
@@ -19117,7 +19111,6 @@ packages:
       stylelint-config-recommended: 14.0.0(stylelint@16.3.1)
     dev: true
 
-<<<<<<< HEAD
   /stylelint-order@6.0.4(stylelint@16.3.1):
     resolution: {integrity: sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==}
     peerDependencies:
@@ -19128,8 +19121,6 @@ packages:
       stylelint: 16.3.1(typescript@5.4.2)
     dev: true
 
-=======
->>>>>>> main
   /stylelint-prettier@5.0.0(prettier@3.2.5)(stylelint@16.3.1):
     resolution: {integrity: sha512-RHfSlRJIsaVg5Br94gZVdWlz/rBTyQzZflNE6dXvSxt/GthWMY3gEHsWZEBaVGg7GM+XrtVSp4RznFlB7i0oyw==}
     engines: {node: '>=18.12.0'}

--- a/tooling/storybook-addon/withHopperProvider.tsx
+++ b/tooling/storybook-addon/withHopperProvider.tsx
@@ -1,5 +1,6 @@
 import { type ColorScheme, HopperProvider } from "@hopper-ui/components";
 import { makeDecorator } from "@storybook/preview-api";
+
 import { DisableAnimations } from "./DisableAnimations.tsx";
 import "./disableAnimations.css";
 

--- a/tooling/test-utils/renderWithTheme.tsx
+++ b/tooling/test-utils/renderWithTheme.tsx
@@ -1,5 +1,6 @@
 import { HopperProvider, type ColorScheme } from "@hopper-ui/components";
 import { render, renderHook, type RenderHookOptions, type RenderOptions } from "@testing-library/react";
+
 import type { ReactElement } from "react";
 
 export interface HopperProviderWrapperOptions {


### PR DESCRIPTION
Closes #178

The standard we are trying to achieve: 

```
// import external components

// import types of external components

// import local component with alias

// import utilities and helper

// import style.css
```

What i understood from it

```

// external packages

// local components ---> parent folders

// utilities and helpers ----> siblings  

// style.module.css -> alone at the end

```

we could create a separate section for all imports in ../../utils/index.ts, but it seems odd? 