### PR TITLE
Add custom eslint rules in components to ensure better imports synthax

### DIFF
--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -6,5 +6,58 @@
         "no-console": ["warn", { "allow": ["warn", "error"] }],
         "react/destructuring-assignment": "off",
         "no-param-reassign": "off"
-    }
+    },
+    "overrides": [
+        {
+            "files": ["src/**/src/*"],
+            "rules": {
+                "no-restricted-imports": ["error", {
+                    "patterns": [
+                        {
+                            "group": ["../**/src/*"],
+                            "message": "Please import from the nearest index.ts file instead. ../../Text/src/Text.tsx -> ../../Text/index.ts"
+                        },
+                        {
+                            "group": ["../../index.ts", "../index.ts", "../../../index.", "./index"],
+                            "message": "Avoid importing from index.ts files directly next or above the current file"
+                        }
+                    ]
+                }]
+            }
+        },
+        {
+            "files": ["src/**/tests/*"],
+            "rules": {
+                "no-restricted-imports": ["error", {
+                    "patterns": [
+                        {
+                            "group": ["../../../**/src/*"],
+                            "message": "Please import from the nearest index.ts file instead. example: ../../utils/src/file.tsx -> ../../utils/index.ts"
+                        },
+                        {
+                            "group": ["../../index.ts", "../index.ts", "../../../index.", "./index"],
+                            "message": "avoid importing from index.ts files directly next or above the current file"
+                        }
+                    ]
+                }]
+            }
+        },
+        {
+            "files": ["src/**/docs/*"],
+            "rules": {
+                "no-restricted-imports": ["error", {
+                    "patterns": [
+                        {
+                            "group": ["../../**/src/*"],
+                            "message": "Please import from the nearest index.ts file instead. example: ../../utils/src/file.tsx -> ../../utils/index.ts"
+                        },
+                        {
+                            "group": ["../../index.ts", "../index.ts", "../../../index.", "./index"],
+                            "message": "avoid importing from index.ts files directly next or above the current file"
+                        }
+                    ]
+                }]
+            }
+        }
+    ]
 }

--- a/packages/components/src/IconList/docs/IconList.stories.tsx
+++ b/packages/components/src/IconList/docs/IconList.stories.tsx
@@ -1,7 +1,7 @@
 import { IconList } from "../src/IconList.tsx";
 import { AddIcon, PlusIcon } from "@hopper-ui/icons";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Stack } from "../../layout/src/Stack.tsx";
+import { Stack } from "../../layout/index.ts";
 import { IconListContext } from "../src/IconListContext.ts";
 import { SlotProvider } from "../../utils/index.ts";
 

--- a/packages/components/src/Label/docs/Label.stories.tsx
+++ b/packages/components/src/Label/docs/Label.stories.tsx
@@ -1,5 +1,5 @@
 import { Div } from "@hopper-ui/styled-system";
-import { Stack } from "../../layout/src/Stack.tsx";
+import { Stack } from "../../layout/index.ts";
 import { Label } from "../src/Label.tsx";
 import { LabelContext } from "../src/LabelContext.ts";
 import type { Meta, StoryObj } from "@storybook/react";

--- a/packages/components/src/Label/src/Label.tsx
+++ b/packages/components/src/Label/src/Label.tsx
@@ -3,7 +3,7 @@ import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { Label as RACLabel, useContextProps, type LabelProps as RACLabelProps } from "react-aria-components";
 import clsx from "clsx";
 import styles from "./Label.module.css";
-import { cssModule } from "../../utils/src/cssModule.ts";
+import { cssModule } from "../../utils/index.ts";
 import { LabelContext } from "./LabelContext.ts";
 
 export const GlobalLabelCssSelector = "hop-Label";

--- a/packages/components/src/Spinner/src/Spinner.tsx
+++ b/packages/components/src/Spinner/src/Spinner.tsx
@@ -1,11 +1,10 @@
 import { useStyledSystem, type ResponsiveProp, useResponsiveValue, type StyledSystemProps } from "@hopper-ui/styled-system";
 import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { ProgressBar, useContextProps } from "react-aria-components";
-import { composeClassnameRenderProps, cssModule, type SizeAdapter } from "../../utils/index.ts";
-import type { BaseComponentProps } from "../../utils/src/types.ts";
+import { composeClassnameRenderProps, cssModule, type SizeAdapter, type BaseComponentProps } from "../../utils/index.ts";
 import styles from "./Spinner.module.css";
 import { SpinnerContext } from "./SpinnerContext.ts";
-import { Label, type LabelProps } from "../../Label/src/Label.tsx";
+import { Label, type LabelProps } from "../../Label/index.ts";
 
 export const GlobalSpinnerCssSelector = "hop-Spinner";
 

--- a/packages/components/src/Text/docs/Text.stories.tsx
+++ b/packages/components/src/Text/docs/Text.stories.tsx
@@ -1,7 +1,7 @@
 import { Text } from "../src/Text.tsx";
 import { TextContext } from "../src/TextContext.ts";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Stack } from "../../layout/src/Stack.tsx";
+import { Stack } from "../../layout/index.ts";
 import { Div } from "@hopper-ui/styled-system";
 import { SlotProvider } from "../../utils/index.ts";
 

--- a/packages/components/src/Text/src/Text.tsx
+++ b/packages/components/src/Text/src/Text.tsx
@@ -3,10 +3,9 @@ import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { Text as RACText, useContextProps, type TextProps as RACTextProps } from "react-aria-components";
 import clsx from "clsx";
 import styles from "./Text.module.css";
-import { cssModule } from "../../utils/src/cssModule.ts";
+import { cssModule, SlotProvider } from "../../utils/index.ts";
 import { TextContext } from "./TextContext.ts";
-import { ClearContainerSlots } from "../../utils/src/ClearSlots.tsx";
-import { SlotProvider } from "../../index.ts";
+import { ClearContainerSlots } from "../../utils/index.tsx";
 
 export const GlobalTextCssSelector = "hop-Text";
 

--- a/packages/components/src/Text/src/Text.tsx
+++ b/packages/components/src/Text/src/Text.tsx
@@ -3,9 +3,8 @@ import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
 import { Text as RACText, useContextProps, type TextProps as RACTextProps } from "react-aria-components";
 import clsx from "clsx";
 import styles from "./Text.module.css";
-import { cssModule, SlotProvider } from "../../utils/index.ts";
+import { cssModule, SlotProvider, ClearContainerSlots } from "../../utils/index.ts";
 import { TextContext } from "./TextContext.ts";
-import { ClearContainerSlots } from "../../utils/index.tsx";
 
 export const GlobalTextCssSelector = "hop-Text";
 

--- a/packages/components/src/buttons/docs/Button.stories.tsx
+++ b/packages/components/src/buttons/docs/Button.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { PlusIcon } from "@hopper-ui/icons";
 import { SlotProvider } from "../../utils/index.ts";
 import { Inline, Stack } from "../../layout/index.ts";
-import { HopperProvider } from "../../index.ts";
+import { HopperProvider } from "../../HopperProvider/index.ts";
 import { RouterProvider, createMemoryRouter, useNavigate } from "react-router-dom";
 
 /**

--- a/packages/components/src/buttons/docs/ButtonGroup.stories.tsx
+++ b/packages/components/src/buttons/docs/ButtonGroup.stories.tsx
@@ -1,7 +1,7 @@
 import { Button } from "../src/Button.tsx";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ButtonGroup } from "../src/ButtonGroup.tsx";
-import { Stack } from "../../layout/src/Stack.tsx";
+import { Stack } from "../../layout/index.ts";
 
 /**
  * ButtonGroup handles the spacing and orientation for a grouping of buttons whose actions are related to each other.

--- a/packages/components/src/buttons/src/Button.tsx
+++ b/packages/components/src/buttons/src/Button.tsx
@@ -4,17 +4,12 @@ import { useContextProps, composeRenderProps, type ButtonProps as RACButtonProps
 import { useRouter, shouldClientNavigate, filterDOMProps, chain } from "@react-aria/utils";
 import styles from "./Button.module.css";
 import { useButton, useHover, useFocusRing, mergeProps } from "react-aria";
-import { cssModule } from "../../utils/src/cssModule.ts";
-import { Text } from "../../Text/src/Text.tsx";
-import { composeClassnameRenderProps, SlotProvider } from "../../utils/index.ts";
+import { cssModule, composeClassnameRenderProps, SlotProvider, isTextOnlyChildren, useRenderProps, useSlot } from "../../utils/index.ts";
+import { Text, TextContext } from "../../Text/index.ts";
 import { IconContext } from "@hopper-ui/icons";
 import { ButtonContext, type ButtonContextValue } from "./ButtonContext.ts";
-import { TextContext } from "../../Text/index.ts";
 import { IconListContext } from "../../IconList/index.ts";
 import { Spinner } from "../../Spinner/index.ts";
-import { isTextOnlyChildren } from "../../utils/src/isTextOnlyChildren.ts";
-import { useRenderProps } from "../../utils/src/useRenderProps.ts";
-import { useSlot } from "../../utils/src/index.ts";
 import { useLocalizedString } from "../../intl/index.ts";
 
 export const GlobalButtonCssSelector = "hop-Button";

--- a/packages/components/src/utils/src/index.ts
+++ b/packages/components/src/utils/src/index.ts
@@ -6,3 +6,4 @@ export * from "./isTextOnlyChildren.ts";
 export * from "./SlotProvider.ts";
 export * from "./useSlot.ts";
 export * from "./ClearSlots.tsx";
+export * from "./useRenderProps.ts";


### PR DESCRIPTION
# Added no-restricted-imports eslint rule to fix the following: 

## Avoid drilling in the src folders of other components

Instead of 
```
import { isTextOnlyChildren } from "../../utils/src/isTextOnlyChildren.ts";
import { cssModule } from "../../utils/src/cssModule.ts";
import { composeClassnameRenderProps, SlotProvider } from "../../utils/index.ts";
```

Now it looks like this: 

```
import { cssModule, composeClassnameRenderProps, SlotProvider, isTextOnlyChildren, useRenderProps, useSlot } from "../../utils/index.ts";
```

## Avoid importing parent or sibbling index

instead of this: 

```
import { HopperProvider } from "../../index.ts"
import { TextContext } from "./index.ts"
```

Now it looks like this: 

```
import { HopperProvider } from "../../HopperProvider/index.ts"
import { TextContext } from "./TextContext.ts"
```
