### PR TITLE
changed ABC Favorit / Mono font for the alternative one with a standard 8

### DIFF
--- a/.changeset/twenty-carrots-sit.md
+++ b/.changeset/twenty-carrots-sit.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/tokens": patch
+---
+
+Swapped the ABC Favorit font for an alternate version

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -7,14 +7,14 @@
 />
 <link
     rel="preload"
-    href="https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/ABCFavoritMono-Regular.woff2"
+    href="https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/alternative/ABCFavoritMono-Regular.woff2"
     as="font"
     type="font/woff2"
     crossorigin="anonymous"
 />
 <link
     rel="preload"
-    href="https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/ABCFavoritVariable.woff2"
+    href="https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/alternative/ABCFavoritVariable.woff2"
     as="font"
     type="font/woff2"
     crossorigin="anonymous"

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -5,7 +5,7 @@
 	font-family: "ABC Favorit Mono";
 	font-style: normal;
 	font-weight: 400;
-	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/ABCFavoritMono-Regular.woff2") format("woff2-variations");
+	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/alternative/ABCFavoritMono-Regular.woff2") format("woff2-variations");
 	font-display: fallback;
 }
 
@@ -13,7 +13,7 @@
 	font-family: "ABC Favorit";
 	font-style: normal;
 	font-weight: 100 900;
-	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/ABCFavoritVariable.woff2") format("woff2-variations");
+	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/alternative/ABCFavoritVariable.woff2") format("woff2-variations");
 	font-display: fallback;
 }
 

--- a/apps/docs/app/playground/typography/page.tsx
+++ b/apps/docs/app/playground/typography/page.tsx
@@ -24,7 +24,7 @@ export default function CodeBlockPage() {
                         consistency,
                         simplicity and excellence.
                     </p>
-                    <span className="number">0123456789</span>
+                    <span className="number">0123456789 - 8888888888</span>
                 </div>
                 <h5>Inter Variable</h5>
                 <div className="font-sample inter">
@@ -64,7 +64,7 @@ export default function CodeBlockPage() {
                         consistency,
                         simplicity and excellence.
                     </p>
-                    <span className="number">0123456789</span>
+                    <span className="number">0123456789 - 8888888888</span>
                 </div>
                 <h2 className="">Centering</h2>
                 <h3>Contained</h3>

--- a/apps/docs/app/playground/typography/typo.css
+++ b/apps/docs/app/playground/typography/typo.css
@@ -10,7 +10,7 @@
 	font-family: "ABC Favorit Mono";
 	font-style: normal;
 	font-weight: 400;
-	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/ABCFavoritMono-Regular.woff2") format("woff2-variations");
+	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/alternative/ABCFavoritMono-Regular.woff2") format("woff2-variations");
 	font-display: fallback;
 }
 
@@ -18,7 +18,7 @@
 	font-family: "ABC Favorit";
 	font-style: normal;
 	font-weight: 100 900;
-	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/ABCFavoritVariable.woff2") format("woff2-variations");
+	src: url("https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/alternative/ABCFavoritVariable.woff2") format("woff2-variations");
 	font-display: fallback;
 }
 

--- a/packages/tokens/src/tokens/asset/fonts.tokens.json
+++ b/packages/tokens/src/tokens/asset/fonts.tokens.json
@@ -12,7 +12,7 @@
             "ABC Favorit Mono": {
                 "normal": {
                     "400": {
-                        "value": "https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/ABCFavoritMono-Regular.woff2",
+                        "value": "https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/mono/alternative/ABCFavoritMono-Regular.woff2",
                         "formats": ["woff2-variations"]
                     }
                 }
@@ -20,7 +20,7 @@
             "ABC Favorit": {
                 "normal": {
                     "100 900": {
-                        "value": "https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/ABCFavoritVariable.woff2",
+                        "value": "https://cdn.platform.workleap.com/hopper/fonts/abc-favorit/alternative/ABCFavoritVariable.woff2",
                         "formats": ["woff2-variations"]
                     }
                 }


### PR DESCRIPTION
- Replaced references to ABC Favorit and ABC Favorit Mono to a modified version that has a "standard" 8 as opposed to a vertically flipped 8.