### PR TITLE
chore: Fix the CI by chaging the components dependencies version on icons

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,13 +44,12 @@
         "react-dom": "^18"
     },
     "dependencies": {
-        "@hopper-ui/icons": "^2.0.0",
+        "@hopper-ui/icons": "workspace:*",
         "@react-aria/utils": "^3.24.0",
         "@react-types/shared": "^3.23.0",
         "clsx": "^2.1.1"
     },
     "devDependencies": {
-        "@hopper-ui/icons": "workspace:*",
         "@hopper-ui/styled-system": "workspace:*",
         "@swc/core": "1.5.3",
         "@swc/helpers": "0.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
   packages/components:
     dependencies:
       '@hopper-ui/icons':
-        specifier: ^1.10.1
-        version: 1.10.1(@hopper-ui/styled-system@packages+styled-system)(react-aria-components@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: workspace:*
+        version: link:../icons
       '@react-aria/utils':
         specifier: ^3.24.0
         version: 3.24.0(react@18.3.1)
@@ -1876,14 +1876,6 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
-
-  '@hopper-ui/icons@1.10.1':
-    resolution: {integrity: sha512-Di6elCjPfb7u1RaNGYJq+ZOMYCm/D9Nwn1EDIpl9lLE/vnKFl/cY5CS1kViGEXr53ccnBGlf1mFPddWbZLrUbg==}
-    peerDependencies:
-      '@hopper-ui/styled-system': ^1
-      react: ^18
-      react-aria-components: ^1.1.0
-      react-dom: ^18
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -11666,15 +11658,6 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
-
-  '@hopper-ui/icons@1.10.1(@hopper-ui/styled-system@packages+styled-system)(react-aria-components@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@hopper-ui/styled-system': link:packages/styled-system
-      '@react-aria/utils': 3.24.0(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-aria-components: 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:


### PR DESCRIPTION
The changeset workflow commits new packages.json. Usually, updating the packages don't mess with the pnpm-lock, but having a loose version in the components was causing an issue