### PR TITLE
ABC Favorit Mono text crop value was not right since font update

### DIFF
--- a/.changeset/two-tomatoes-refuse.md
+++ b/.changeset/two-tomatoes-refuse.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/tokens": patch
+---
+
+Adjustment of the text crop token value for ABC Favorit Mono typeface

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -152,7 +152,7 @@ a {
 }
 
 .myBadge .hd-sample-off-centered-text.fixed::before {
-    margin-bottom: -0.125rem;
+    margin-bottom: -0.25rem;
 }
 
 .myBadge .hd-sample-off-centered-text.fixed::after {

--- a/apps/docs/app/playground/typography/typo.css
+++ b/apps/docs/app/playground/typography/typo.css
@@ -119,7 +119,7 @@ button.overline {
 
 /* Favorite Mono Overline  */
 .favorit-mono .offset::before {
-    margin-bottom: -0.125rem;
+    margin-bottom: -0.25rem;
 }
 
 .favorit-mono .offset::after {

--- a/apps/docs/datas/tokens.json
+++ b/apps/docs/datas/tokens.json
@@ -3693,7 +3693,7 @@
       },
       {
         "name": "hop-overline-bottom-offset",
-        "value": "-0.125rem"
+        "value": "-0.25rem"
       }
     ],
     "borderRadius": [

--- a/packages/styled-system/src/tokens/generated/lightSemanticTokens.ts
+++ b/packages/styled-system/src/tokens/generated/lightSemanticTokens.ts
@@ -843,7 +843,7 @@ export const SemanticTokens = {
     "--hop-overline-font-weight": "var(--hop-font-weight-400)",
     "--hop-overline-line-height": "var(--hop-line-height-1-33)",
     "--hop-overline-top-offset": "-0.25rem",
-    "--hop-overline-bottom-offset": "-0.125rem",
+    "--hop-overline-bottom-offset": "-0.25rem",
     "--hop-body-2xl-font-family": "var(--hop-font-family-secondary)",
     "--hop-body-2xl-font-size": "var(--hop-font-size-320)",
     "--hop-body-2xl-font-weight": "var(--hop-font-weight-410)",

--- a/packages/tokens/src/tokens/semantic/light/fonts.tokens.json
+++ b/packages/tokens/src/tokens/semantic/light/fonts.tokens.json
@@ -232,7 +232,7 @@
         },
         "bottom-offset": {
             "$type": "bottomOffset",
-            "$value": "-0.125rem"
+            "$value": "-0.25rem"
         }
     },
     "body": {


### PR DESCRIPTION
Since updating ABC Favorit Mono to fix the reversed 8 issue, the provided font was different enough to prevent a necessary text-crop rule fix.