### PR TITLE
add the slot function in hopper

### DIFF
--- a/packages/components/src/buttons/src/Button.tsx
+++ b/packages/components/src/buttons/src/Button.tsx
@@ -3,7 +3,8 @@ import {
     type StyledComponentProps,
     useStyledSystem,
     type ResponsiveProp,
-    useResponsiveValue
+    useResponsiveValue,
+    slot
 } from "@hopper-ui/styled-system";
 import { useRouter, shouldClientNavigate, filterDOMProps, chain } from "@react-aria/utils";
 import type { RouterOptions } from "@react-types/shared";
@@ -274,7 +275,7 @@ function Button(props: ButtonProps, ref: ForwardedRef<HTMLElement>) {
  *
  * [View Documentation](TODO)
  */
-const _Button = forwardRef(Button);
+const _Button = slot("button", forwardRef(Button));
 
 _Button.displayName = "Button";
 

--- a/packages/icons/src/createIcon.tsx
+++ b/packages/icons/src/createIcon.tsx
@@ -1,3 +1,4 @@
+import { slot } from "@hopper-ui/styled-system";
 import { forwardRef, type ComponentProps, type ElementType, type RefAttributes, type SVGProps } from "react";
 
 import { Icon, type IconProps } from "./Icon.tsx";
@@ -20,13 +21,7 @@ export function createIcon(
 
     iconComponent.displayName = displayName;
 
-    /**
-     * TODO: This line is added strictly for backward compatibility with Orbiter. Once orbiter is gone, we can remove this line
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (iconComponent as Record<string, any>)["__slot__"] = "icon";
-
-    return iconComponent;
+    return slot("icon", iconComponent);
 }
 
 export type CreatedIconProps = ComponentProps<ReturnType<typeof createIcon>>;

--- a/packages/styled-system/src/index.ts
+++ b/packages/styled-system/src/index.ts
@@ -21,6 +21,7 @@ export * from "./utils/useInsertStyleElement.ts";
 export * from "./utils/useIsomorphicInsertionEffect.ts";
 export * from "./utils/useIsomorphicLayoutEffect.ts";
 export * from "./utils/useThemeComputedStyle.ts";
+export * from "./utils/slot.ts";
 
 export * from "./StyledSystemProvider.tsx";
 export * from "./styledSystemProps.ts";

--- a/packages/styled-system/src/utils/slot.ts
+++ b/packages/styled-system/src/utils/slot.ts
@@ -1,0 +1,25 @@
+/**
+ * THIS FILE IS MEANT TO BE TEMPORARY. This function's only utility is to allow us to use Hopper components in Orbiter.
+ * TODO: Once Orbiter is gone, this file and function should be removed.
+ */
+
+const SlotKey = "__slot__";
+
+/**
+ * This methods allows us to define a slot name for a component. This is useful for Orbiter to know where to place the component.
+ * @example
+ * // In Orbiter's codebase, they load slot's content using the useSlots hook.
+ *   const { button } = useSlots(children, useMemo(() => ({
+ *       button: {
+ *           className: "o-ui-dialog-button"
+ *       },
+ *   }), [sizeValue, disabled, loading]));
+ *
+ * // In Hopper, our button component should  be wrapped in the slot function.
+ * const _Button = slot("button", forwardRef(Button));
+ */
+export function slot<P>(slotName: string, ElementType: P) {
+    (ElementType as Record<string, unknown>)[SlotKey] = slotName;
+
+    return ElementType;
+}


### PR DESCRIPTION
This PR introduce the slot function that is going to be used ONLY for interoperability between hopper and orbiter. Once orbiter is gone, we should remove this function. 

In Orbiter's codebase, they load slot's content using the useSlots hook.
```
   const { button } = useSlots(children, useMemo(() => ({
       button: {
           className: "o-ui-dialog-button"
       },
   }), [sizeValue, disabled, loading]));
```
In Hopper, our button component should  be wrapped in the slot function.
```
 const _Button = slot("button", forwardRef(Button));
```