### PR TITLE
DS-173: Add base content files for all components

### DIFF
--- a/apps/docs/app/components/[...slug]/page.tsx
+++ b/apps/docs/app/components/[...slug]/page.tsx
@@ -26,12 +26,13 @@ export async function generateStaticParams(): Promise<PageProps["params"][]> {
 }
 
 export default async function ComponentPage({ params }: PageProps) {
-    const [section, type] = params.slug;
+    const [type] = params.slug;
 
     const component = (await getComponentDetails()).find(componentDetail => {
-        const [componentSlugSection, componentSlugType] = componentDetail.slugs;
+        // the path should be the component name, but the content files are classified by sections
+        const [, componentSlugType] = componentDetail.slugs;
 
-        return componentSlugType === type && componentSlugSection === section;
+        return componentSlugType === type ;
     });
 
     if (!component) {
@@ -39,6 +40,7 @@ export default async function ComponentPage({ params }: PageProps) {
     }
 
     const { content, frontmatter: { title, status, description, links } } = component;
+
     const componentLinks = links && [
         {
             name: "github",

--- a/apps/docs/app/components/layout.tsx
+++ b/apps/docs/app/components/layout.tsx
@@ -38,7 +38,7 @@ async function ComponentsLayout({ children }: { children: ReactNode }) {
     return (
         <SidebarProvider>
             <div className="hd-wrapper hd-flex sm:hd-flex-direction-column">
-                <Sidebar data={data} />
+                <Sidebar data={data} order={["getting-started", "concepts", "buttons"]} />
                 {children}
             </div>
         </SidebarProvider>

--- a/apps/docs/app/components/layout.tsx
+++ b/apps/docs/app/components/layout.tsx
@@ -38,7 +38,14 @@ async function ComponentsLayout({ children }: { children: ReactNode }) {
     return (
         <SidebarProvider>
             <div className="hd-wrapper hd-flex sm:hd-flex-direction-column">
-                <Sidebar data={data} order={["getting-started", "concepts", "buttons"]} />
+                <Sidebar data={data}
+                    order={[
+                        "getting-started",
+                        "concepts",
+                        "application",
+                        "buttons"
+                    ]}
+                />
                 {children}
             </div>
         </SidebarProvider>

--- a/apps/docs/app/components/layout.tsx
+++ b/apps/docs/app/components/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import Sidebar from "@/app/ui/layout/sidebar/Sidebar";
 import { SidebarProvider } from "@/context/sidebar/SidebarProvider";
 import { type ComponentData, getComponentDetails } from "@/app/lib/getComponentDetails.ts";
-import path from "path";
+import getPageLinks from "@/app/lib/getPageLinks.ts";
 
 interface Data {
     frontmatter: ComponentData;
@@ -19,13 +19,16 @@ function formatComponentData(data: Data[]) {
             section = slugs[0];
         }
 
+        // we exclude the category from the link, so we only take the last slug
+        const componentLink = slugs[slugs.length - 1];
+
         return {
             _id: `component-${index}`,
             title,
             order,
             section: section,
             _raw: {
-                flattenedPath: `components/${path.join(...slugs)}`
+                flattenedPath: `components/${componentLink}`
             }
         };
     });
@@ -34,18 +37,26 @@ function formatComponentData(data: Data[]) {
 async function ComponentsLayout({ children }: { children: ReactNode }) {
     const components = await getComponentDetails();
     const data = formatComponentData(components);
+    const links = getPageLinks(data, { order: [
+        "getting-started",
+        "concepts",
+        "application",
+        "layout",
+        "buttons",
+        "collections",
+        "forms",
+        "icons",
+        "navigation",
+        "overlays",
+        "pickers",
+        "status",
+        "content"
+    ] });
 
     return (
         <SidebarProvider>
             <div className="hd-wrapper hd-flex sm:hd-flex-direction-column">
-                <Sidebar data={data}
-                    order={[
-                        "getting-started",
-                        "concepts",
-                        "application",
-                        "buttons"
-                    ]}
-                />
+                <Sidebar links={links} />
                 {children}
             </div>
         </SidebarProvider>

--- a/apps/docs/app/getting-started/layout.tsx
+++ b/apps/docs/app/getting-started/layout.tsx
@@ -7,10 +7,12 @@ import Sidebar from "@/app/ui/layout/sidebar/Sidebar";
 import SubHeader from "@/app/ui/layout/subHeader/SubHeader";
 import getSectionLinks from "@/app/lib/getSectionLinks";
 import { SidebarProvider } from "@/context/sidebar/SidebarProvider";
+import getPageLinks from "@/app/lib/getPageLinks";
 
 export default function TokenLayout({ children }: { children: ReactNode }) {
     const slug = useSelectedLayoutSegment();
     const pageContent = allGettingStarteds.find(page => page.slug === slug);
+    const allGettingStartedsLinks = getPageLinks(allGettingStarteds);
 
     if (!pageContent) {
         return null;
@@ -23,7 +25,7 @@ export default function TokenLayout({ children }: { children: ReactNode }) {
             <SidebarProvider>
                 <SubHeader links={sectionLinks} />
                 <div className="hd-wrapper hd-flex">
-                    <Sidebar data={allGettingStarteds} />
+                    <Sidebar links={allGettingStartedsLinks} />
                     {children}
                 </div>
             </SidebarProvider>

--- a/apps/docs/app/guides/layout.tsx
+++ b/apps/docs/app/guides/layout.tsx
@@ -7,6 +7,7 @@ import Sidebar from "@/app/ui/layout/sidebar/Sidebar";
 import SubHeader from "@/app/ui/layout/subHeader/SubHeader";
 import getSectionLinks from "@/app/lib/getSectionLinks";
 import { SidebarProvider } from "@/context/sidebar/SidebarProvider";
+import getPageLinks from "@/app/lib/getPageLinks";
 
 export default function TokenLayout({ children }: { children: ReactNode }) {
     const selectedLayoutSegment = useSelectedLayoutSegment();
@@ -19,13 +20,14 @@ export default function TokenLayout({ children }: { children: ReactNode }) {
     }
 
     const sectionLinks = getSectionLinks(pageContent);
+    const allGuidesLinks = getPageLinks(allGuides);
 
     return (
         <>
             <SidebarProvider>
                 <SubHeader links={sectionLinks} />
                 <div className="hd-wrapper hd-flex">
-                    <Sidebar data={allGuides} />
+                    <Sidebar links={allGuidesLinks} />
                     {children}
                 </div>
             </SidebarProvider>

--- a/apps/docs/app/icons/layout.tsx
+++ b/apps/docs/app/icons/layout.tsx
@@ -7,6 +7,7 @@ import Sidebar from "@/app/ui/layout/sidebar/Sidebar";
 import SubHeader from "@/app/ui/layout/subHeader/SubHeader";
 import getSectionLinks from "@/app/lib/getSectionLinks";
 import { SidebarProvider } from "@/context/sidebar/SidebarProvider";
+import getPageLinks from "@/app/lib/getPageLinks";
 
 export default function TokenLayout({ children }: { children: ReactNode }) {
     const selectedLayoutSegment = useSelectedLayoutSegment();
@@ -19,13 +20,16 @@ export default function TokenLayout({ children }: { children: ReactNode }) {
     }
 
     const sectionLinks = getSectionLinks(pageContent);
+    const allIconsLinks = getPageLinks(allIcons, {
+        order: ["getting-started", "react-icons", "svg"]
+    });
 
     return (
         <>
             <SidebarProvider>
                 <SubHeader links={sectionLinks} />
                 <div className="hd-wrapper hd-flex">
-                    <Sidebar data={allIcons} order={["getting-started", "react-icons", "svg"]} />
+                    <Sidebar links={allIconsLinks} />
                     {children}
                 </div>
             </SidebarProvider>

--- a/apps/docs/app/icons/layout.tsx
+++ b/apps/docs/app/icons/layout.tsx
@@ -25,7 +25,7 @@ export default function TokenLayout({ children }: { children: ReactNode }) {
             <SidebarProvider>
                 <SubHeader links={sectionLinks} />
                 <div className="hd-wrapper hd-flex">
-                    <Sidebar data={allIcons} />
+                    <Sidebar data={allIcons} order={["getting-started", "react-icons", "svg"]} />
                     {children}
                 </div>
             </SidebarProvider>

--- a/apps/docs/app/lib/getComponentProps.ts
+++ b/apps/docs/app/lib/getComponentProps.ts
@@ -37,7 +37,7 @@ async function formatPropTable(data: ComponentDocWithGroups[]) {
 }
 
 export async function getComponentProps(component: string) {
-    const file = await fs.readFile(filePath + `/${component}.json`, "utf8");
+    const file = await fs.readFile(path.join(filePath, `${component}.json`), "utf8");
     const data = JSON.parse(file);
     const [item] = data;
 

--- a/apps/docs/app/lib/getPageLinks.ts
+++ b/apps/docs/app/lib/getPageLinks.ts
@@ -11,14 +11,14 @@ export interface Data {
     _raw: Raw;
 }
 
-interface LinkItem {
+export interface LinkItem {
     id: string;
     title: string;
     order?: number;
     path: string;
 }
 
-interface Section {
+export interface Section {
     id: string;
     title: string;
     linkItems: LinkItem[];

--- a/apps/docs/app/lib/getSectionLinks.ts
+++ b/apps/docs/app/lib/getSectionLinks.ts
@@ -6,18 +6,21 @@ type SectionLink = Pick<MDX, "raw">;
 function getSectionLinks(content: {
     body: SectionLink;
 }) {
-    const regex = /(?<=^##\s).*?(?=\n)/gm;
+    const regex = /(^#{2,3}\s).*?(?=\n)/gm;
     const body = content.body.raw;
     const matches = body.match(regex);
 
     if (matches) {
-        const links = matches.map(match => match.replace("##", "").trim());
+        return matches.map(link => {
+            const title = link.replace("###", "").replace("##", "").trim();
 
-        return links.map(link => ({
-            title: link,
-            url: `#${formattingTitleId(link.toString())}`,
-            id: link.toLowerCase().replace(/\s+/g, "-")
-        }));
+            return {
+                title: title,
+                url: `#${formattingTitleId(title.toString())}`,
+                id: title.toLowerCase().replace(/\s+/g, "-"),
+                level: link.startsWith("###") ? 3 : 2
+            };
+        });
     }
 
     return [];

--- a/apps/docs/app/tokens/layout.tsx
+++ b/apps/docs/app/tokens/layout.tsx
@@ -7,6 +7,7 @@ import Sidebar from "@/app/ui/layout/sidebar/Sidebar";
 import SubHeader from "@/app/ui/layout/subHeader/SubHeader";
 import { SidebarProvider } from "@/context/sidebar/SidebarProvider";
 import getSectionLinks from "@/app/lib/getSectionLinks";
+import getPageLinks from "@/app/lib/getPageLinks";
 
 export default function TokenLayout({ children }: { children: ReactNode }) {
     const selectedLayoutSegment = useSelectedLayoutSegment();
@@ -19,13 +20,16 @@ export default function TokenLayout({ children }: { children: ReactNode }) {
     }
 
     const sectionLinks = getSectionLinks(pageContent);
+    const allTokensLinks = getPageLinks(allTokens, {
+        order: ["getting-started", "semantic", "core"]
+    });
 
     return (
         <>
             <SidebarProvider>
                 <SubHeader links={sectionLinks} />
                 <div className="hd-wrapper hd-flex">
-                    <Sidebar data={allTokens} order={["getting-started", "semantic", "core"]} />
+                    <Sidebar links={allTokensLinks} />
                     {children}
                 </div>
             </SidebarProvider>

--- a/apps/docs/app/tokens/layout.tsx
+++ b/apps/docs/app/tokens/layout.tsx
@@ -25,7 +25,7 @@ export default function TokenLayout({ children }: { children: ReactNode }) {
             <SidebarProvider>
                 <SubHeader links={sectionLinks} />
                 <div className="hd-wrapper hd-flex">
-                    <Sidebar data={allTokens} />
+                    <Sidebar data={allTokens} order={["getting-started", "semantic", "core"]} />
                     {children}
                 </div>
             </SidebarProvider>

--- a/apps/docs/app/ui/components/overview/Overview.tsx
+++ b/apps/docs/app/ui/components/overview/Overview.tsx
@@ -5,10 +5,10 @@ import Title from "@/components/title/Title";
 
 import "./overview.css";
 
-const Overview = () => {
-    // Get unique categories
-    const categories = Array.from(new Set(allComponents.map(component => component.category)));
+const ignoreCategories = ["application"];
+const categories = Array.from(new Set(allComponents.map(component => component.category))).filter(x => x && !ignoreCategories.includes(x));
 
+const Overview = () => {
     return (
         <div className="hd-component-overview-wrapper">
             {categories.map(category => (

--- a/apps/docs/app/ui/components/propTable/PropTable.tsx
+++ b/apps/docs/app/ui/components/propTable/PropTable.tsx
@@ -11,6 +11,7 @@ import { PropTableRender } from "./PropTableRender.tsx";
 import type { Item } from "./PropTableRender.tsx";
 
 import "./propTable.css";
+import { Fragment } from "react";
 
 
 export interface PropTableProps {
@@ -57,7 +58,7 @@ export default async function PropTable({ component }: PropTableProps) {
                 const [key] = Object.keys(group);
 
                 return (
-                    <>
+                    <Fragment key={key}>
                         {key === "default" ?
                             <PropTableRender items={group[key]} /> :
                             <Collapsible className="hd-props-table__section"
@@ -69,7 +70,7 @@ export default async function PropTable({ component }: PropTableProps) {
                                 <PropTableRender items={group[key]} />
                             </Collapsible>
                         }
-                    </>
+                    </Fragment>
                 );
             })}
         </>

--- a/apps/docs/app/ui/layout/aside/Aside.tsx
+++ b/apps/docs/app/ui/layout/aside/Aside.tsx
@@ -6,7 +6,6 @@ import { useHeadsObserver } from "@/hooks/useHeadsObserver";
 import type { PropsWithoutRef } from "react";
 
 import "./aside.css";
-import Link from "next/link";
 
 interface Link {
     title: string;
@@ -54,9 +53,10 @@ const Aside = ({ title, links }: PropsWithoutRef<AsideProps>) => {
         })}
         key={link.id}
         >
-            <Link href={link.url} className="hd-aside__link">
+            {/* This has to be an a, not a link: https://github.com/vercel/next.js/issues/49612 */}
+            <a href={link.url} className="hd-aside__link">
                 {link.title}
-            </Link>
+            </a>
         </li>
     ));
 

--- a/apps/docs/app/ui/layout/aside/Aside.tsx
+++ b/apps/docs/app/ui/layout/aside/Aside.tsx
@@ -60,6 +60,10 @@ const Aside = ({ title, links }: PropsWithoutRef<AsideProps>) => {
         </li>
     ));
 
+    if (listItems.length <= 1) {
+        return null;
+    }
+
     return (
         <aside className="hd-aside">
             {links.length > 0 && (

--- a/apps/docs/app/ui/layout/aside/Aside.tsx
+++ b/apps/docs/app/ui/layout/aside/Aside.tsx
@@ -11,6 +11,7 @@ interface Link {
     title: string;
     url: string;
     id: string;
+    level?: number;
 }
 
 interface AsideProps {
@@ -54,19 +55,15 @@ const Aside = ({ title, links }: PropsWithoutRef<AsideProps>) => {
         key={link.id}
         >
             {/* This has to be an a, not a link: https://github.com/vercel/next.js/issues/49612 */}
-            <a href={link.url} className="hd-aside__link">
+            <a href={link.url} className={`hd-aside__link hd-aside__link-level-${link.level}`}>
                 {link.title}
             </a>
         </li>
     ));
 
-    if (listItems.length <= 1) {
-        return null;
-    }
-
     return (
         <aside className="hd-aside">
-            {links.length > 0 && (
+            {listItems.length > 0 && (
                 <>
                     <span className="hd-aside__title">{title}</span>
                     <button type="button" className="hd-aside__button" onClick={toggleList}>

--- a/apps/docs/app/ui/layout/aside/aside.css
+++ b/apps/docs/app/ui/layout/aside/aside.css
@@ -84,6 +84,10 @@
     color: var(--hd-color-primary-text);
 }
 
+.hd-aside__link-level-3 {
+    padding-inline-start: var(--hd-space-3);
+}
+
 .hd-aside__title {
     display: none;
     font-size: 0.875rem;

--- a/apps/docs/app/ui/layout/header/Header.tsx
+++ b/apps/docs/app/ui/layout/header/Header.tsx
@@ -13,10 +13,12 @@ import { useContext, useEffect, useState } from "react";
 import HopperLogo from "./assets/hopper-logo.svg";
 import "./header.css";
 import { type ColorScheme, ThemeContext } from "@/context/theme/ThemeProvider.tsx";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 const Header = () => {
     const { colorMode, setColorMode } = useContext(ThemeContext);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const isMobile = useIsMobile("37.5rem");
 
     useEffect(() => {
         if (isMobileMenuOpen) {
@@ -68,7 +70,7 @@ const Header = () => {
                             </svg>
                         </IconButton>
                     </div>
-                    <MobileMenuTrigger onToggle={handleMobileMenuToggle} />
+                    {isMobile && <MobileMenuTrigger onToggle={handleMobileMenuToggle} />}
                 </div>
             </header>
             {isMobileMenuOpen && <MobileMenu isOpen={isMobileMenuOpen} onClose={handleMobileMenuClose} />}

--- a/apps/docs/app/ui/layout/sectionPopover/sectionPopover.css
+++ b/apps/docs/app/ui/layout/sectionPopover/sectionPopover.css
@@ -64,6 +64,10 @@
     color: var(--hd-color-neutral-text-weakest-hover);
 }
 
+.hd-section-popover__list-link-3{
+    padding-left: var(--hd-space-3);
+}
+
 .hd-section-popover__top-section {
     display: flex;
     border-bottom: var(--hd-border-size) solid var(--hd-color-neutral-border);

--- a/apps/docs/app/ui/layout/sectionPopover/sectionPopover.tsx
+++ b/apps/docs/app/ui/layout/sectionPopover/sectionPopover.tsx
@@ -6,12 +6,12 @@ import { Button } from "react-aria-components";
 
 import ChevronIcon from "./assets/chevron-icon.svg";
 import "./sectionPopover.css";
-import Link from "next/link";
 
 interface Link {
     title: string;
     url: string;
     id: string;
+    level?: number;
 }
 
 interface SectionPopoverProps {
@@ -37,9 +37,10 @@ const SectionPopover = ({ links }: PropsWithoutRef<SectionPopoverProps>) => {
 
     const listItems = links.map(link => (
         <li className="hd-section-popover__list-item" key={link.id}>
-            <Link href={link.url} className="hd-section-popover__list-link" onClick={togglePopover}>
+            {/* This has to be an a, not a link: https://github.com/vercel/next.js/issues/49612 */}
+            <a href={link.url} className={`hd-section-popover__list-link hd-section-popover__list-link-${link.level}`} onClick={togglePopover}>
                 {link.title}
-            </Link>
+            </a>
         </li>
     ));
 
@@ -52,7 +53,7 @@ const SectionPopover = ({ links }: PropsWithoutRef<SectionPopoverProps>) => {
                         <ChevronIcon className="hd-section-popover__button-icon" />
                     </Button>
                     <div className={clsx("hd-section-popover__popover", isOpen && "hd-section-popover__popover--open")}>
-                        <Link className="hd-section-popover__top-section" href="#top" onClick={togglePopover}>Return to top</Link>
+                        <a className="hd-section-popover__top-section" href="#top" onClick={togglePopover}>Return to top</a>
                         <ul className="hd-section-popover__list">
                             {listItems}
                         </ul>

--- a/apps/docs/app/ui/layout/sidebar/Sidebar.tsx
+++ b/apps/docs/app/ui/layout/sidebar/Sidebar.tsx
@@ -7,20 +7,17 @@ import { useEffect, useRef } from "react";
 import { useSidebar } from "@/context/sidebar/SidebarProvider";
 
 import Overlay from "@/components/overlay/Overlay";
-import getPageLinks from "@/app/lib/getPageLinks";
 
-import type { Data } from "@/app/lib/getPageLinks";
+import type { Section } from "@/app/lib/getPageLinks";
 
 import "./sidebar.css";
 
 interface SidebarProps {
-    data: Data[];
-    order?: string[];
+    links: Section[];
 }
 
-const Sidebar = ({ data, order }: SidebarProps) => {
+const Sidebar = ({ links }: SidebarProps) => {
     const sidebarRef = useRef<HTMLDivElement>(null);
-    const links = getPageLinks(data, { order });
     const pathName = usePathname();
     const { toggleSidebar, isSidebarOpen } = useSidebar();
 

--- a/apps/docs/app/ui/layout/sidebar/Sidebar.tsx
+++ b/apps/docs/app/ui/layout/sidebar/Sidebar.tsx
@@ -15,11 +15,12 @@ import "./sidebar.css";
 
 interface SidebarProps {
     data: Data[];
+    order?: string[];
 }
 
-const Sidebar = ({ data }: SidebarProps) => {
+const Sidebar = ({ data, order }: SidebarProps) => {
     const sidebarRef = useRef<HTMLDivElement>(null);
-    const links = getPageLinks(data, { order: ["getting-started", "semantic", "core", "react-icons", "svg"] });
+    const links = getPageLinks(data, { order });
     const pathName = usePathname();
     const { toggleSidebar, isSidebarOpen } = useSidebar();
 

--- a/apps/docs/app/ui/layout/subHeader/SubHeader.tsx
+++ b/apps/docs/app/ui/layout/subHeader/SubHeader.tsx
@@ -12,6 +12,7 @@ interface Link {
     title: string;
     url: string;
     id: string;
+    level?: number;
 }
 
 interface SubHeaderProps {

--- a/apps/docs/components/title/Title.tsx
+++ b/apps/docs/components/title/Title.tsx
@@ -33,6 +33,7 @@ const Title = ({
             })}
             id={level > 1 ? uniqueId : undefined}
             data-section-title={level === 2 ? uniqueId : undefined}
+            data-subsection-title={level === 3 ? uniqueId : undefined}
             {...rest}
         >
             {level > 1 ? (

--- a/apps/docs/content/components/application/hopper-provider.mdx
+++ b/apps/docs/content/components/application/hopper-provider.mdx
@@ -1,0 +1,146 @@
+---
+title: HopperProvider (WIP)
+description: HopperProvider is the container for all applications using Hopper. It defines the color scheme, locale, and other application level settings. It is also used to dynamically inject CSS variables and Body styles to your application.
+order: 1
+category: "application"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/HopperProvider/src/HopperProvider.tsx
+---
+
+{/* TODO example at the top */}
+```tsx
+import { Button, HopperProvider } from "@hopper-ui/components";
+
+function App() {
+  return (
+    <HopperProvider withBodyStyle>
+      <Button variant="accent">
+        Hello!
+      </Button>
+    </HopperProvider>
+  );
+}
+```
+
+## Props (WIP)
+
+{/* TODO Prop table not working */}
+{/* <PropTable component="HopperProvider" /> */}
+
+## Application provider
+
+A HopperProvider must be the root component of your application. All other Hopper components rely on the Provider to define the color scheme, locale, and other settings that they need in order to render.
+You can also nest multiple HopperProviders to create different themes or locales for different parts of your application.
+
+### Color scheme
+
+We recommend supporting both light and dark color schemes in your app, however, if you need to override this with an application specific setting, you can use the colorScheme prop.
+
+{/* TODO example */}
+```tsx
+import { HopperProvider, Button } from "@hopper-ui/components";
+
+function Demo() {
+    return (
+        <HopperProvider colorScheme="light">
+            <Button>I'm a light button</Button>
+        </HopperProvider>
+    );
+}
+```
+
+See the [styling documentation](/components/concepts/styling) for more information about using Hopper color variables in your  app to ensure it adapts to light and dark mode properly.
+
+See the [color schemes documentation](/components/concepts/color-schemes) for more information on how to apply a color scheme to your application.
+
+### Locales
+
+Another important setting for your application is the locale. By default, Hopper chooses the locale matching the user's browser/operating system language, but this can be overridden with the locale prop if you have an application specific setting. This prop accepts a [BCP 47](https://www.ietf.org/rfc/bcp/bcp47.txt) language code.
+Hopper currently supports the following locales: `en-US`, `en-UK`, `fr-CA`, `fr-FR`.
+
+{/* TODO example */}
+```tsx
+import { HopperProvider } from "@hopper-ui/components";
+
+function Demo() {
+    return (
+        <HopperProvider locale="en-US">
+            {/* Your app here */}
+        </HopperProvider>
+    );
+}
+```
+
+{/* TODO, hopper should re-export useLocale and document it? */}
+To access the current locale anywhere in your application, see the [useLocale](https://react-spectrum.adobe.com/react-aria/useLocale.html) hook.
+
+### Client side routing
+
+The HopperProvider component accepts an optional router prop. This enables Hopper components that render links to perform client side navigation using your application or framework's client side router. See the [client side routing](/components/concepts/client-side-routing) guide for details on how to set this up.
+
+```tsx
+import { HopperProvider } from "@hopper-ui/components";
+
+function Demo() {
+    const navigate = useNavigateFromYourRouter();
+    return (
+        <HopperProvider router={{navigate}}>
+            {/* Your app here */}
+        </HopperProvider>
+    );
+}
+```
+
+### Inject body styles
+
+`withBodyStyle` determines whether you want Hopper to style the body of your application. By default, it is set to false. You should enable it on the Hopper provider at the root of your application.
+
+```tsx
+import { HopperProvider } from "@hopper-ui/components";
+
+function Demo() {
+    return (
+        <HopperProvider withBodyStyle>
+            {/* Your app here */}
+        </HopperProvider>
+    );
+}
+```
+
+`withBodyStyle` includes the following body elements styles:
+
+```css
+body {
+    -webkit-font-smoothing: antialiased;
+    font-family: var(--hop-body-md-font-family), Arial, sans-serif;
+    line-height: var(--hop-body-md-line-height);
+    font-size: var(--hop-body-md-font-size);
+    color: var(--hop-neutral-text);
+    background-color: var(--hop-neutral-surface);
+    margin: 0;
+    padding: 0;
+}
+
+@media not (prefers-reduced-motion) {
+    body {
+        scroll-behavior: smooth;
+    }
+}
+```
+
+### Inject CSS Variables
+
+`withCssVariables` determines whether Hopper's CSS variables should be added to your application. By default, it is set to true, you should not change it unless you want to manage CSS variables via .css file (Note that in this case you will need to add the tokens manually, ideally with the [`@hopper-ui/tokens` package](/tokens/getting-started/usage))
+
+{/* TODO: Make this an example */}
+```tsx
+import { HopperProvider } from "@hopper-ui/components";
+
+function Demo() {
+    return (
+        <HopperProvider withCssVariables={false}>
+            {/* Your app here */}
+        </HopperProvider>
+    );
+}
+```

--- a/apps/docs/content/components/buttons/ButtonGroup.mdx
+++ b/apps/docs/content/components/buttons/ButtonGroup.mdx
@@ -1,0 +1,48 @@
+---
+title: Button Group (WIP)
+description: TBD
+category: "buttons"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/buttons/src/ButtonGroup.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/buttons/button.mdx
+++ b/apps/docs/content/components/buttons/button.mdx
@@ -84,5 +84,6 @@ The local props and ref on the component are merged with the ones passed via con
 
 <Example src="buttons/docs/button/advancedCustomization" />
 
-## Migration Notes
+## Migration Notes (WIP)
+
 <MigrateGuide src="buttons/docs/migration-notes" />

--- a/apps/docs/content/components/collections/Listbox.mdx
+++ b/apps/docs/content/components/collections/Listbox.mdx
@@ -1,0 +1,48 @@
+---
+title: ListBox (WIP)
+description: TBD
+category: "collections"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/listbox/src/ListBox.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/collections/TagGroup.mdx
+++ b/apps/docs/content/components/collections/TagGroup.mdx
@@ -1,0 +1,48 @@
+---
+title: TagGroup (WIP)
+description: TBD
+category: "collections"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/tag/src/TagGroup.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/concepts/Forms.mdx
+++ b/apps/docs/content/components/concepts/Forms.mdx
@@ -16,4 +16,4 @@ This page will be heavily inspired by https://react-spectrum.adobe.com/react-spe
 
 ### React Hook Form
 
-react-hook-form + valibot?
+{/* TODO: react-hook-form + valibot? */}

--- a/apps/docs/content/components/concepts/Forms.mdx
+++ b/apps/docs/content/components/concepts/Forms.mdx
@@ -1,0 +1,19 @@
+---
+title: Forms (WIP)
+description: Forms allow users to enter and submit data, and provide them with feedback along the way. Hopper includes many components that integrate with HTML forms, with support for custom validation, labels, and help text.
+order: 6
+---
+
+This page will be heavily inspired by https://react-spectrum.adobe.com/react-spectrum/forms.html
+
+## Labels and help text
+
+## Submitting data
+
+## Validation
+
+## Form libraries
+
+### React Hook Form
+
+react-hook-form + valibot?

--- a/apps/docs/content/components/concepts/Layout.mdx
+++ b/apps/docs/content/components/concepts/Layout.mdx
@@ -1,0 +1,22 @@
+---
+title: Layout (WIP)
+description: This page describes how to build application layouts with Hopper using Flex or Grid.
+order: 1
+---
+
+This page will be heavily inspired by https://react-spectrum.adobe.com/react-spectrum/layout.html
+
+## Introduction
+
+## Flex
+
+## Grid
+
+
+## Responsive layout
+
+Make sure to include Link to responsive styles page
+
+## Slots
+
+Brielfy mention slots, but link to the slots concept page.

--- a/apps/docs/content/components/concepts/Layout.mdx
+++ b/apps/docs/content/components/concepts/Layout.mdx
@@ -14,8 +14,8 @@ This page will be heavily inspired by https://react-spectrum.adobe.com/react-spe
 
 ## Responsive layout
 
-Make sure to include Link to responsive styles page
+{/* TODO Make sure to include Link to responsive styles page */}
 
 ## Slots
 
-Brielfy mention slots, but link to the slots concept page.
+{/* TODO: Brielfy mention slots, but link to the slots concept page. */}

--- a/apps/docs/content/components/concepts/Layout.mdx
+++ b/apps/docs/content/components/concepts/Layout.mdx
@@ -12,7 +12,6 @@ This page will be heavily inspired by https://react-spectrum.adobe.com/react-spe
 
 ## Grid
 
-
 ## Responsive layout
 
 Make sure to include Link to responsive styles page

--- a/apps/docs/content/components/concepts/Slots.mdx
+++ b/apps/docs/content/components/concepts/Slots.mdx
@@ -9,13 +9,18 @@ This page will be inspired by https://react-spectrum.adobe.com/react-aria/advanc
 ## Introduction
 
 ## Contexts
+
 ### Default slot
 
 ### Consuming contexts
+
 #### useContextProps
+
 #### useSlottedContext
 
 ## Creating Custom Components
+
 #### using existing context
+
 #### using new contexts
 

--- a/apps/docs/content/components/concepts/Slots.mdx
+++ b/apps/docs/content/components/concepts/Slots.mdx
@@ -1,0 +1,21 @@
+---
+title: Slots (WIP)
+description: This page describes how Hopper components include pre-defined layouts that you can insert elements into via slots. Slots are named areas in a component that receive children and provide style and layout for them.
+order: 7
+---
+
+This page will be inspired by https://react-spectrum.adobe.com/react-aria/advanced.html#slots but the focus of the page should be slots, not the context like this page.
+
+## Introduction
+
+## Contexts
+### Default slot
+
+### Consuming contexts
+#### useContextProps
+#### useSlottedContext
+
+## Creating Custom Components
+#### using existing context
+#### using new contexts
+

--- a/apps/docs/content/components/concepts/Styling.mdx
+++ b/apps/docs/content/components/concepts/Styling.mdx
@@ -1,0 +1,49 @@
+---
+title: Styling (WIP)
+description: This page describes how styling works in Hopper, including how to customize spacing, sizing, and positioning, and how to create your own custom components using Spectrum styles.
+order: 2
+---
+
+this page's content will be heavily inspired by :
+-  https://wl-orbiter-website.netlify.app/?path=/docs/style-props--page
+-  https://react-spectrum.adobe.com/react-spectrum/styling.html
+
+## Introduction
+
+## Style props
+
+### Usage
+
+### Shorthands
+
+### Escape hatches using the `UNSAFE_` properties
+
+### Pseudo-classes
+
+## HTML Elements
+
+## Custom components
+
+## Properties List
+
+### Space
+
+### Color
+
+### Typography
+
+### Layout
+
+### Flex Layout
+
+### Grid Layout
+
+### Background
+
+### Border
+
+### Position
+
+### Shadow
+
+### Miscellaneous

--- a/apps/docs/content/components/concepts/Styling.mdx
+++ b/apps/docs/content/components/concepts/Styling.mdx
@@ -16,7 +16,8 @@ this page's content will be heavily inspired by :
 
 ### Shorthands
 
-### Escape hatches using the `UNSAFE_` properties
+### Escape hatches
+ using the `UNSAFE_` properties
 
 ### Pseudo-classes
 

--- a/apps/docs/content/components/concepts/Styling.mdx
+++ b/apps/docs/content/components/concepts/Styling.mdx
@@ -4,28 +4,89 @@ description: This page describes how styling works in Hopper, including how to c
 order: 2
 ---
 
-this page's content will be heavily inspired by :
--  https://wl-orbiter-website.netlify.app/?path=/docs/style-props--page
--  https://react-spectrum.adobe.com/react-spectrum/styling.html
-
 ## Introduction
+
+Hopper components are designed to be consistent across all Workleap applications. They include built-in styling that has been considered carefully, and extensively tested. In general, customizing Hopper is discouraged, but most components do offer control over layout and other aspects. In addition, you can use Hopper's tokens to ensure your application conforms to design requirements, and is adaptive across color schemes.
 
 ## Style props
 
+A Hopper style property is a mapping of a CSS property to a component property. With style props, Hopper let you easily set style values for a curated set of CSS properties like font-size, margin, padding, width and many more.
+
+All of the available style props are listed in the ["Properties List"](#Properties-List) section below.
+
 ### Usage
+
+To use a style prop on a Hopper component, pass the prop as a camelCased string to the component.
+By default, only tokens are accepted as values for style props. They help promote consistency and maintainability across your application.
+
+If you need to pass a custom value, you can use the `UNSAFE_` prefix to bypass the token system. You can refer to the ["Escape hatches"](#Escape-hatches) section for more information.
+
+{/* TODO: example */}
+```tsx
+<Div
+    fontSize="1.375rem"
+    fontWeight={680}
+    paddingTop={160}
+    paddingBottom={160}
+    marginBottom={160}
+    color="samoyed"
+    borderRadius="rounded-md"
+    backgroundColor="primary"
+>
+    Style properties are fun.
+</Div>
+```
 
 ### Shorthands
 
+Props like border and paddingX are also provided to help you save keystrokes. An exhaustive list of all the supported props is available in the ["Properties List"](#Properties-List) section.
+
+{/* TODO: example */}
+```tsx
+<Div paddingY={80} border="primary">
+    Shorthands.
+</Div>
+```
+
 ### Escape hatches
- using the `UNSAFE_` properties
+
+ TODO
+using the `UNSAFE_` properties
 
 ### Pseudo-classes
 
+Style props doesn't support every CSS pseudo-classes. [Location pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#location_pseudo-classes), [input pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#the_input_pseudo-classes), [tree-structural pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#tree-structural_pseudo-classes), ::before and ::after are not supported and will most likely never be.
+
+When a CSS pseudo-class is not supported by Hopper style props, we recommend using a CSS class.
+
+Since the following user action pseudo-classes are often used, some style props supports them. These behaves like their pseudo CSS counterparts.
+
+{/* TODO: table */}
+|Suffix | Pseudo state |
+|---|---|
+| active | :active |
+| hover | :hover |
+| focus | :focus |
+
+Not all style props supports user action pseudo-classes. Find out which props support user action pseudo-classes in the ["Properties List"](#Properties-List) section.
+
 ## HTML Elements
+
+You might wonder how will you use Hopper style props on your HTML elements?
+
+Hopper provides a set of HTML elements components already configured with Hopper styled system. You should chose these components over native HTML elements.
+
+`<A>`, `<Address>`, `<Article>`, `<Aside>`, `<HtmlButton>`, `<Div>`, `<HtmlFooter>`, `<HtmlHeader>`, `<Img>`, `<Input>`, `<List>`, `<Main>`, `<Nav>`, `<Section>`, `<Span>`, `<Table>`
+
+For text elements, prefer a `<Text>` or `<Paragraph>` component rather than `<Span>` or a `<Div>`.
 
 ## Custom components
 
+TODO
+
 ## Properties List
+
+The following tables provide a list of all available style props by category.
 
 ### Space
 

--- a/apps/docs/content/components/concepts/client-side-routing.mdx
+++ b/apps/docs/content/components/concepts/client-side-routing.mdx
@@ -1,0 +1,15 @@
+---
+title: Client Side Routing (WIP)
+description: Many Hopper components support rendering as HTML links. This page discusses how to set up your app to integrate Hopper links with your framework or client side router..
+order: 4
+---
+
+This page will be heavily inspired by https://react-spectrum.adobe.com/react-spectrum/routing.html
+
+## Introduction
+
+## Provider setup
+
+### Router options
+
+### React Router

--- a/apps/docs/content/components/concepts/color-schemes.mdx
+++ b/apps/docs/content/components/concepts/color-schemes.mdx
@@ -1,0 +1,17 @@
+---
+title: Color Schemes (WIP)
+description: This page describes how color schemes works in Hopper, including how applications adapt to operating system dark mode.
+order: 5
+---
+
+This page will be heavily inspired by :
+- https://react-spectrum.adobe.com/react-spectrum/theming.html
+- https://wl-orbiter-website.netlify.app/?path=/docs/color-schemes--page
+
+## Introduction
+
+## Apply a color scheme
+
+## Changing the color scheme
+
+## useColorSchemeValue

--- a/apps/docs/content/components/concepts/color-schemes.mdx
+++ b/apps/docs/content/components/concepts/color-schemes.mdx
@@ -4,14 +4,95 @@ description: This page describes how color schemes works in Hopper, including ho
 order: 5
 ---
 
-This page will be heavily inspired by :
-- https://react-spectrum.adobe.com/react-spectrum/theming.html
-- https://wl-orbiter-website.netlify.app/?path=/docs/color-schemes--page
-
 ## Introduction
+
+Hopper supports light and dark mode. These correspond to color schemes found in popular operating systems. By default, Hopper defaults to the light color scheme, but the `colorScheme` property on the `HopperProvider` can be used to set the color scheme to `dark` or `system` (which will follow the user's operating system setting).
+
+We recommend that all Hopper applications support both light and dark mode. It can be very jarring to use a light themed application when the rest of your applications are in dark mode, and visa versa. This can be accomplished by using Hopper color variables rather than hard coded color values. All Hopper components adapt to color scheme out of the box. See the [styling page](./styling.mdx) for details on how to use Hopper color variables in your own custom components.
 
 ## Apply a color scheme
 
+A color scheme can either be enforced by providing a specific light or dark value to a [HopperProvider](../application/hopper-provider.mdx).
+
+{/* example */}
+```tsx
+    <HopperProvider colorScheme="dark">
+        <Button variant="secondary">Button</Button>
+    </HopperProvider>
+```
+
+A color scheme can also be set to `system`, which will follow the [user's operating system setting](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
+When the `system` value is provided, an additional fallback color scheme must be specified to defaultColorScheme in case the theme provider is not able to access the user setting.
+
+{/* example */}
+```tsx
+    <HopperProvider colorScheme="system" defaultColorScheme="light">
+        <Button variant="secondary">Button</Button>
+    </HopperProvider>
+```
+
+Color schemes can also be nested. You could have a dark themed dialog inside a light themed application, for example. This might be useful for certain experiences like color scheme previews, where you want to showcase a specific color scheme, regardless of the operating system setting.
+
+```tsx
+<HopperProvider colorScheme="light">
+  <Button margin="inline-md">I'm a light button</Button>
+  <HopperProvider colorScheme="dark">
+    <Button margin="inline-md">I'm a dark button</Button>
+  </HopperProvider>
+</HopperProvider>
+```
+
 ## Changing the color scheme
 
-## useColorSchemeValue
+To manage the color scheme in your application, Hopper exposes a `ColorSchemeContext` and a `useColorSchemeContext` hook.
+
+{/* example */}
+```tsx
+function ColorSchemeToggle() {
+    const { colorScheme, setColorScheme } = useColorSchemeContext();
+
+    const handleClick = useCallback(() => {
+        setColorScheme(colorScheme === "light" ? "dark" : "light");
+    }, [colorScheme, setColorScheme]);
+
+    return (
+        <Button variant="secondary" onClick={handleClick}>
+            Toggle Color Scheme
+        </Button>
+    );
+}
+
+render(() => {
+    const { colorScheme: parentColorScheme } = useColorSchemeContext();
+
+    return (
+        <HopperProvider colorScheme={parentColorScheme}>
+            <Div backgroundColor="neutral" padding={2}>
+                <ColorSchemeToggle />
+            </Div>
+        </HopperProvider>
+    );
+});
+```
+
+## Utility Methods
+
+### useColorSchemeValue
+
+Some features requires the usage of custom colors. Those colors aren't like Hopper tokens and will not support color schemes out of the box.
+
+To help with that, Hopper offer the `useColorSchemeValue` hook which will return the value matching the current color scheme of the closest `HopperProvider`.
+
+{/* Example */}
+```tsx
+import { useColorSchemeValue } from "@hopper-ui/components";
+
+const color = useColorSchemeValue("#fff", "#000");
+const backgroundColor = useColorSchemeValue("#ff9048", "#fee2bb");
+
+return (
+    <Div UNSAFE_color={color} UNSAFE_backgroundColor={backgroundColor}>
+        Content
+    </Div>
+);
+```

--- a/apps/docs/content/components/concepts/color-schemes.mdx
+++ b/apps/docs/content/components/concepts/color-schemes.mdx
@@ -14,7 +14,7 @@ We recommend that all Hopper applications support both light and dark mode. It c
 
 A color scheme can either be enforced by providing a specific light or dark value to a [HopperProvider](../application/hopper-provider.mdx).
 
-{/* example */}
+{/* TODO: example */}
 ```tsx
     <HopperProvider colorScheme="dark">
         <Button variant="secondary">Button</Button>
@@ -24,7 +24,7 @@ A color scheme can either be enforced by providing a specific light or dark valu
 A color scheme can also be set to `system`, which will follow the [user's operating system setting](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
 When the `system` value is provided, an additional fallback color scheme must be specified to defaultColorScheme in case the theme provider is not able to access the user setting.
 
-{/* example */}
+{/* TODO: example */}
 ```tsx
     <HopperProvider colorScheme="system" defaultColorScheme="light">
         <Button variant="secondary">Button</Button>
@@ -33,6 +33,7 @@ When the `system` value is provided, an additional fallback color scheme must be
 
 Color schemes can also be nested. You could have a dark themed dialog inside a light themed application, for example. This might be useful for certain experiences like color scheme previews, where you want to showcase a specific color scheme, regardless of the operating system setting.
 
+{/* TODO: example */}
 ```tsx
 <HopperProvider colorScheme="light">
   <Button margin="inline-md">I'm a light button</Button>
@@ -46,7 +47,7 @@ Color schemes can also be nested. You could have a dark themed dialog inside a l
 
 To manage the color scheme in your application, Hopper exposes a `ColorSchemeContext` and a `useColorSchemeContext` hook.
 
-{/* example */}
+{/* TODO: example */}
 ```tsx
 function ColorSchemeToggle() {
     const { colorScheme, setColorScheme } = useColorSchemeContext();
@@ -83,7 +84,7 @@ Some features requires the usage of custom colors. Those colors aren't like Hopp
 
 To help with that, Hopper offer the `useColorSchemeValue` hook which will return the value matching the current color scheme of the closest `HopperProvider`.
 
-{/* Example */}
+{/* TODO: example */}
 ```tsx
 import { useColorSchemeValue } from "@hopper-ui/components";
 

--- a/apps/docs/content/components/concepts/internationalization.mdx
+++ b/apps/docs/content/components/concepts/internationalization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Internationalization
+title: Internationalization (WIP)
 description: This page describes how adapting components to respect languages and cultures of users around the world is an important way to help make your application accessible to the widest number of people.
 order: 8
 ---

--- a/apps/docs/content/components/concepts/internationalization.mdx
+++ b/apps/docs/content/components/concepts/internationalization.mdx
@@ -1,16 +1,29 @@
 ---
-title: Internationalization (WIP)
-description: This page describes how adapting components to respect languages and cultures of users around the world is an important way to help make your application accessible to the widest number of people. Hopper supports many aspects of localization for various components out of the box, including translations for built-in strings, localized date, and number formatting
+title: Internationalization
+description: This page describes how adapting components to respect languages and cultures of users around the world is an important way to help make your application accessible to the widest number of people.
 order: 8
 ---
 
-This page will be heavily inspired by:
-- https://react-spectrum.adobe.com/react-aria/internationalization.html#example
-
 ## Introduction
+
+Internationalization is the process of structuring your code and user interface to support localization. Hopper supports many aspects of localization for many components out of the box, including translations for builtin strings, localized date and number formatting, and more. By using Hopper to build your applications, these aspects of internationalization are handled for you.
+
+To set the locale for your application, you can follow the procedure described in the [HopperProvider documentation](../application/hopper-provider#locales).
 
 ## Supported locales
 
+Hopper currently supports translations for 2 locales. They are listed below.
+
+- English (United States) - `en-US`
+- French (Canada) - `fr-CA`
+
 ## Optimizing bundle size
 
-Mention that since React-aria is a peer dependencies, they should still do this section to reduce the bundle size
+Hopper uses React-aria for internationalization, which is a peer dependency. This means that you must install React-aria in your application. React-Aria includes translations for over 30 languages.
+This is inclusive to the most users out of the box, but comes at the cost of bundle size. Since applications using Hopper does not support all of these locales, you can use React-Aria build plugins to include only the languages that we support in your JavaScript bundle.
+
+The complete process is described in the [React-aria documentation](https://react-spectrum.adobe.com/react-aria/internationalization.html#optimizing-bundle-size).
+
+## Utility Methods
+
+React-Aria (which is a peer dependency of Hopper) provides some utility methods to help with Localization. See [useDateFormatter](https://react-spectrum.adobe.com/react-aria/useDateFormatter.html), [useNumberFormatter](https://react-spectrum.adobe.com/react-aria/useNumberFormatter.html), and [useCollator](https://react-spectrum.adobe.com/react-aria/useCollator.html) for more information. The [Internationalized](https://react-spectrum.adobe.com/internationalized/index.html) collection of libraries provides framework-agnostic utilities for representing and manipulating dates and times, and parsing and formatting numbers across many locales, calendar systems, numbering systems, and more.

--- a/apps/docs/content/components/concepts/internationalization.mdx
+++ b/apps/docs/content/components/concepts/internationalization.mdx
@@ -1,0 +1,16 @@
+---
+title: Internationalization (WIP)
+description: This page describes how adapting components to respect languages and cultures of users around the world is an important way to help make your application accessible to the widest number of people. Hopper supports many aspects of localization for various components out of the box, including translations for built-in strings, localized date, and number formatting
+order: 8
+---
+
+This page will be heavily inspired by:
+- https://react-spectrum.adobe.com/react-aria/internationalization.html#example
+
+## Introduction
+
+## Supported locales
+
+## Optimizing bundle size
+
+Mention that since React-aria is a peer dependencies, they should still do this section to reduce the bundle size

--- a/apps/docs/content/components/concepts/responsive-styles.mdx
+++ b/apps/docs/content/components/concepts/responsive-styles.mdx
@@ -16,4 +16,3 @@ This page should slightly be inspired by https://tailwindcss.com/docs/responsive
 ## Utility Methods
 
 ### useResponsiveValue
-

--- a/apps/docs/content/components/concepts/responsive-styles.mdx
+++ b/apps/docs/content/components/concepts/responsive-styles.mdx
@@ -1,0 +1,19 @@
+---
+title: Responsive Styles (WIP)
+description: This page describes how Hopper style props accept a specialized syntax to support responsive breakpoints. These responsive properties help build adaptive user interfaces.
+order: 3
+---
+
+This page will be heavily inspired by https://wl-orbiter-website.netlify.app/?path=/docs/responsive-styles--page
+This page should slightly be inspired by https://tailwindcss.com/docs/responsive-design
+
+## Introduction
+
+## Breakpoints
+
+## Working mobile-first
+
+## Utility Methods
+
+### useResponsiveValue
+

--- a/apps/docs/content/components/concepts/responsive-styles.mdx
+++ b/apps/docs/content/components/concepts/responsive-styles.mdx
@@ -4,15 +4,92 @@ description: This page describes how Hopper style props accept a specialized syn
 order: 3
 ---
 
-This page will be heavily inspired by https://wl-orbiter-website.netlify.app/?path=/docs/responsive-styles--page
-This page should slightly be inspired by https://tailwindcss.com/docs/responsive-design
-
 ## Introduction
+
+In addition to static values, all style props support object syntax to specify different values for the prop depending on the responsive breakpoint. Breakpoints are named following t-shirt sizing, and correspond to common device resolutions
+
+In this example, the `Div` has a default background color, which is overriden at each breakpoint. Resize your browser window to see this in action.
+
+{/* TODO: example and modify all the property values so it fits hopper */}
+```tsx
+<Div
+    backgroundColor={{
+        base: "moss-200",
+        xs: "sapphire-200",
+        sm: "moss-200",
+        md: "sapphire-200",
+        lg: "rock-200",
+        xl: "sunken-treasure-200"
+    }}
+    width="30rem"
+    maxWidth="100%"
+    padding={160}
+>
+    <Text>Resize to see the background color change!</Text>
+</Div>
+```
 
 ## Breakpoints
 
+There are five breakpoints available (+ the base), inspired by common device resolutions:
+
+{/* TODO: do a table here */}
+| Name | Minimum width |
+| ---- | ------------- |
+| base | 0px |
+| xs | 640px |
+| sm | 768px |
+| md | 1024px |
+| lg | 1280px |
+| xl | 1440px |
+
 ## Working mobile-first
+
+By default, Hopper uses a mobile-first breakpoint system, similar to what you might be used to in other frameworks like Bootstrap or Tailwind.
+
+{/* TODO start the sentence with a <SuccessIcon /> */}
+**Don't use `sm:` to target mobile devices**
+
+{/* TODO: convert to example */}
+```tsx
+<Div
+    // This will only center text on screens 768px and wider, not on small screens
+    textAlign={{sm: "left"}}
+    width="30rem"
+    maxWidth="100%"
+    padding={160}
+>
+    <Text>Text Content</Text>
+</Div>
+```
+
+{/* TODO start the sentence with a <SuccessIcon /> */}
+**Use `base` to target mobile, and override them at larger breakpoints**
+
+{/* TODO: covnert to example */}
+```tsx
+<Div
+    // This will center text on mobile, and left align it on screens 768px and wider
+    textAlign={{base: "center", sm: "left"}}
+    width="30rem"
+    maxWidth="100%"
+    padding={160}
+>
+    <Text>Text Content</Text>
+</Div>
+```
+
+For this reason, it's often a good idea to implement the mobile layout for a design first, then layer on any changes that make sense for sm screens, followed by md screens, etc.
 
 ## Utility Methods
 
 ### useResponsiveValue
+
+To resolve a responsive value within a React component, Hopper provides the useResponsiveValue hook.
+
+{/* TODO example */}
+```tsx
+import { useResponsiveValue } from "@hopper-ui/components";
+
+const isFluidValue = useResponsiveValue({ base: true, lg: false });
+```

--- a/apps/docs/content/components/content/Avatar.mdx
+++ b/apps/docs/content/components/content/Avatar.mdx
@@ -1,0 +1,48 @@
+---
+title: Avatar (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/TBD/src/TBD.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Content.mdx
+++ b/apps/docs/content/components/content/Content.mdx
@@ -1,0 +1,48 @@
+---
+title: Content (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/content/src/Content.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Divider.mdx
+++ b/apps/docs/content/components/content/Divider.mdx
@@ -1,0 +1,48 @@
+---
+title: Divider (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/content/src/Divider.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Footer.mdx
+++ b/apps/docs/content/components/content/Footer.mdx
@@ -1,0 +1,48 @@
+---
+title: Footer (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Footer.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Header.mdx
+++ b/apps/docs/content/components/content/Header.mdx
@@ -1,0 +1,48 @@
+---
+title: Header (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Header.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Heading.mdx
+++ b/apps/docs/content/components/content/Heading.mdx
@@ -1,0 +1,48 @@
+---
+title: Heading (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/typoegraphy/heading/src/Heading.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Label.mdx
+++ b/apps/docs/content/components/content/Label.mdx
@@ -1,0 +1,48 @@
+---
+title: Label (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/typography/Label/src/label.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/content/Text.mdx
+++ b/apps/docs/content/components/content/Text.mdx
@@ -1,0 +1,48 @@
+---
+title: Text (WIP)
+description: TBD
+category: "content"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/typoegraphy/Text/src/Text.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/Checkbox.mdx
+++ b/apps/docs/content/components/forms/Checkbox.mdx
@@ -1,0 +1,48 @@
+---
+title: Checkbox (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/checkbox/src/Checkbox.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/CheckboxGroup.mdx
+++ b/apps/docs/content/components/forms/CheckboxGroup.mdx
@@ -1,0 +1,48 @@
+---
+title: CheckboxGroup (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/checkbox/src/CheckboxGroup.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/ErrorMessage.mdx
+++ b/apps/docs/content/components/forms/ErrorMessage.mdx
@@ -1,0 +1,48 @@
+---
+title: ErrorMessage (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/errorMessage/src/ErrorMessage.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/Form.mdx
+++ b/apps/docs/content/components/forms/Form.mdx
@@ -1,0 +1,48 @@
+---
+title: Form (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/form/src/Form.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/HelpMessage.mdx
+++ b/apps/docs/content/components/forms/HelpMessage.mdx
@@ -1,0 +1,48 @@
+---
+title: HelpMessage (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/helpMessage/src/HelpMessage.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/NumberInputField.mdx
+++ b/apps/docs/content/components/forms/NumberInputField.mdx
@@ -1,0 +1,48 @@
+---
+title: NumberInputField (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/NumberInputField.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/PasswordField.mdx
+++ b/apps/docs/content/components/forms/PasswordField.mdx
@@ -1,0 +1,48 @@
+---
+title: PasswordField (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/PasswordField.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/RadioGroup.mdx
+++ b/apps/docs/content/components/forms/RadioGroup.mdx
@@ -1,0 +1,48 @@
+---
+title: RadioGroup (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/radio/src/RadioGroup.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/SearchField.mdx
+++ b/apps/docs/content/components/forms/SearchField.mdx
@@ -1,0 +1,48 @@
+---
+title: SearchField (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/SearchField.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/Switch.mdx
+++ b/apps/docs/content/components/forms/Switch.mdx
@@ -1,0 +1,48 @@
+---
+title: Switch (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/switch/src/Switch.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/TextArea.mdx
+++ b/apps/docs/content/components/forms/TextArea.mdx
@@ -1,0 +1,48 @@
+---
+title: TextArea (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/TextArea.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/forms/TextField.mdx
+++ b/apps/docs/content/components/forms/TextField.mdx
@@ -1,0 +1,48 @@
+---
+title: TextField (WIP)
+description: TBD
+category: "forms"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/TextField.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/getting-started/component-list.mdx
+++ b/apps/docs/content/components/getting-started/component-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: Components
+title: Component List
 description: TBD
 order: 2
 ---

--- a/apps/docs/content/components/getting-started/component-list.mdx
+++ b/apps/docs/content/components/getting-started/component-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: Component List
+title: Component List (WIP)
 description: TBD
 order: 2
 ---

--- a/apps/docs/content/components/getting-started/components.mdx
+++ b/apps/docs/content/components/getting-started/components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Components
 description: TBD
 order: 2
 ---

--- a/apps/docs/content/components/getting-started/installation.mdx
+++ b/apps/docs/content/components/getting-started/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: Installation (WIP)
 description: The installation proccess
 order: 1
 ---

--- a/apps/docs/content/components/icons/Icon.mdx
+++ b/apps/docs/content/components/icons/Icon.mdx
@@ -1,0 +1,48 @@
+---
+title: Icon (WIP)
+description: TBD
+category: "icons"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/icons/src/Icon.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/icons/IconList.mdx
+++ b/apps/docs/content/components/icons/IconList.mdx
@@ -1,0 +1,48 @@
+---
+title: IconList (WIP)
+description: TBD
+category: "icons"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/icons/src/IconList.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/icons/RichIcon.mdx
+++ b/apps/docs/content/components/icons/RichIcon.mdx
@@ -1,0 +1,48 @@
+---
+title: RichIcon (WIP)
+description: TBD
+category: "icons"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/icons/src/RichIcon.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/layout/Flex.mdx
+++ b/apps/docs/content/components/layout/Flex.mdx
@@ -1,0 +1,48 @@
+---
+title: Flex (WIP)
+description: TBD
+category: "layout"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Flex.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/layout/Grid.mdx
+++ b/apps/docs/content/components/layout/Grid.mdx
@@ -1,0 +1,48 @@
+---
+title: Grid (WIP)
+description: TBD
+category: "layout"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Grid.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/layout/Inline.mdx
+++ b/apps/docs/content/components/layout/Inline.mdx
@@ -1,0 +1,48 @@
+---
+title: Inline (WIP)
+description: TBD
+category: "layout"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Inline.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/layout/Stack.mdx
+++ b/apps/docs/content/components/layout/Stack.mdx
@@ -1,0 +1,48 @@
+---
+title: Stack (WIP)
+description: TBD
+category: "layout"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Stack.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/navigation/Link.mdx
+++ b/apps/docs/content/components/navigation/Link.mdx
@@ -1,0 +1,48 @@
+---
+title: TextLink (WIP)
+description: TBD
+category: "navigation"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Link/src/Link.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/overlays/Popover.mdx
+++ b/apps/docs/content/components/overlays/Popover.mdx
@@ -1,0 +1,48 @@
+---
+title: Popover (WIP)
+description: TBD
+category: "overlays"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/overlays/src/Popover.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/pickers/ComboBox.mdx
+++ b/apps/docs/content/components/pickers/ComboBox.mdx
@@ -1,0 +1,48 @@
+---
+title: ComboBox (WIP)
+description: TBD
+category: "pickers"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/TBD/src/TBD.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/pickers/Select.mdx
+++ b/apps/docs/content/components/pickers/Select.mdx
@@ -1,0 +1,48 @@
+---
+title: Select (WIP)
+description: TBD
+category: "pickers"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/TBD/src/TBD.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/status/Badge.mdx
+++ b/apps/docs/content/components/status/Badge.mdx
@@ -1,0 +1,48 @@
+---
+title: Badge (WIP)
+description: TBD
+category: "status"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/badge/src/Badge.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/status/Chip.mdx
+++ b/apps/docs/content/components/status/Chip.mdx
@@ -1,0 +1,48 @@
+---
+title: Chip (WIP)
+description: TBD
+category: "status"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/chip/src/Chip.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/components/status/Spinner.mdx
+++ b/apps/docs/content/components/status/Spinner.mdx
@@ -1,0 +1,48 @@
+---
+title: Spinner (WIP)
+description: TBD
+category: "status"
+links:
+    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Spinner/src/Spinner.tsx
+---
+
+## Props
+
+TODO: Add the props table, if we have multiple props table (ex: TagList and Tag) in the same file,  use the name of the component in ### before the each props table
+
+## Guidelines
+
+TODO: If we have some guidelines about this component's usage
+
+### Accessibility ?
+
+TODO: If we have some guidelines about this component and accessibility
+
+## Anatomy
+
+TODO: We have anatomy screenshots from the Figma, we could most likely use them here
+
+### Concepts
+
+TODO: links to related concepts
+
+### Composed Components
+
+TODO: links to related components (most likely all component which are used by the slots)
+
+## Examples
+
+## Advanced customization
+
+### Contexts
+TODO: Example of context + content about the context
+
+### Custom Children
+
+TODO: Example of passing custom childrens to the components to fake a slot
+
+### Custom Component
+
+TODO: Example of creating a custom version of this component
+
+## Migration Notes (WIP)

--- a/apps/docs/content/tokens/core/border-radius.mdx
+++ b/apps/docs/content/tokens/core/border-radius.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "borderRadius";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/color.mdx
+++ b/apps/docs/content/tokens/core/color.mdx
@@ -8,4 +8,6 @@ import tokensDark from '../../../datas/tokens-dark.json';
 
 export const categoryKey = "color";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/dimensions.mdx
+++ b/apps/docs/content/tokens/core/dimensions.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "size";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/font-family.mdx
+++ b/apps/docs/content/tokens/core/font-family.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "fontFamily";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/font-size.mdx
+++ b/apps/docs/content/tokens/core/font-size.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "fontSize";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/font-weight.mdx
+++ b/apps/docs/content/tokens/core/font-weight.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "fontWeight";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/line-height.mdx
+++ b/apps/docs/content/tokens/core/line-height.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "lineHeight";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/core/motion.mdx
+++ b/apps/docs/content/tokens/core/motion.mdx
@@ -38,30 +38,32 @@ In an animation declaration:
 }
 ```
 
-## Duration
+## Tokens
+
+### Duration
 
 Hopper exposes 5 durations, they help convey a message and makes animations smooth and responsive.
 
 <Table category={"duration"} data={tokens.core["duration"]} noPreview />
 
-## Easings
+### Easings
 
 [Easings](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function) denotes a mathematical function that describes the rate at which a numerical value changes. They adds life to motion, providing natural rests, they set the mood of an animation. Hopper provides 3 pre-defined easings, each having their use.
 
-### Productive
+#### Productive
 
 Used in animations that are not in the way, they quickly change from one state to another.
 
-### Focus
+#### Focus
 
 Used in animations that are designed to draw the user’s attention on what changed, in order to let them move on with their next task.
 
-### Expressive
+#### Expressive
 
 Used in animations that are meant to give a sense of completeness or resolution to the user. Use them wisely.
 
 <Table category={"timingFunction"} data={tokens.core["timingFunction"]} noPreview />
 
-## Playground
+### Playground
 
 <MotionPreview durations={tokens.core["duration"]} easings={tokens.core["timingFunction"]} noPreview />

--- a/apps/docs/content/tokens/core/shadow.mdx
+++ b/apps/docs/content/tokens/core/shadow.mdx
@@ -6,4 +6,6 @@ import tokens from '../../../datas/tokens.json';
 
 export const categoryKey = "shadow";
 
+## Tokens
+
 <Table category={categoryKey} data={tokens.core[categoryKey]} />

--- a/apps/docs/content/tokens/semantic/color.mdx
+++ b/apps/docs/content/tokens/semantic/color.mdx
@@ -24,7 +24,7 @@ Although we value an aesthetically pleasing use of colour, we place a higher val
 
 Each colour has assigned sentiment based on how they function within the interface. Defined colour roles make things easy to modify and customize later. Their meaning is also expanded to all Workleap verticals so that users understand that they’re in the same ecosystem and can recognize its codes.
 
-#### Deprecation notice
+## Deprecation notice
 
 Tokens with a `-active` suffix are deprecated and should not be used in new designs. They will be removed in a future release, prefer using their `-press` counterparts. In some instances `-active` tokens should be replaced with a `-selected` token, this should be documented in your Figma files, in doubt validate with a designer.
 

--- a/apps/docs/content/tokens/semantic/color.mdx
+++ b/apps/docs/content/tokens/semantic/color.mdx
@@ -28,309 +28,311 @@ Each colour has assigned sentiment based on how they function within the interfa
 
 Tokens with a `-active` suffix are deprecated and should not be used in new designs. They will be removed in a future release, prefer using their `-press` counterparts. In some instances `-active` tokens should be replaced with a `-selected` token, this should be documented in your Figma files, in doubt validate with a designer.
 
-{/* It's important to keep the Headers with ##, with no spaces on the left so that it shows up in the aside.
+## Tokens
+
+{/* It's important to keep the Headers with ###, with no spaces on the left so that it shows up in the aside.
 We do not want to do this for the dark mode, otherwise, we see double the headers in the aside. */}
 
 <Tabs tabs={tabs}>
   <div>
-## Neutral
+### Neutral
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-neutral"]
     } />
-## Primary
+### Primary
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-primary"]
     } />
-## Success
+### Success
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-success"]
     } />
-## Warning
+### Warning
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-warning"]
     } />
-## Danger
+### Danger
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-danger"]
     } />
-## Information
+### Information
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-information"]
     } />
-## Upsell
+### Upsell
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-upsell"]
     } />
 
-## Decorative
-    ### Option 1
+### Decorative
+    #### Option 1
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option1"]
     } />
-    ### Option 2
+    #### Option 2
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option2"]
     } />
-    ### Option 3
+    #### Option 3
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option3"]
     } />
-    ### Option 4
+    #### Option 4
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option4"]
     } />
-    ### Option 5
+    #### Option 5
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option5"]
     } />
-    ### Option 6
+    #### Option 6
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option6"]
     } />
-    ### Option 7
+    #### Option 7
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option7"]
     } />
-    ### Option 8
+    #### Option 8
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option8"]
     } />
-    ### Option 9
+    #### Option 9
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-decorative-option9"]
     } />
 
-## Status
+### Status
 
-    ### Neutral
+    #### Neutral
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-neutral"]
     } />
-    ### Progress
+    #### Progress
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-progress"]
     } />
-    ### Positive
+    #### Positive
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-positive"]
     } />
-    ### Caution
+    #### Caution
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-caution"]
     } />
-    ### Negative
+    #### Negative
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-negative"]
     } />
-    ### Inactive
+    #### Inactive
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-inactive"]
     } />
-    ### Option 1
+    #### Option 1
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-option1"]
     } />
-    ### Option 2
+    #### Option 2
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-option2"]
     } />
-    ### Option 3
+    #### Option 3
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-option3"]
     } />
-    ### Option 4
+    #### Option 4
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-option4"]
     } />
-    ### Option 5
+    #### Option 5
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-option5"]
     } />
-    ### Option 6
+    #### Option 6
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-status-option6"]
     } />
 
-## Data Visualization
+### Data Visualization
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-unavailable", "hop-dataviz-text"]
     } />
 
-    ### Monochromatic - Primary
+    #### Monochromatic - Primary
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-monochromatic-primary"]
     } />
 
-    ### Monochromatic - Positive
+    #### Monochromatic - Positive
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-monochromatic-positive"]
     } />
 
-    ### Monochromatic - Negative
+    #### Monochromatic - Negative
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-monochromatic-negative"]
     } />
 
-    ### Diverging Sequence 1
+    #### Diverging Sequence 1
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-diverging-sequence-1"]
     } />
 
-    ### Diverging Sequence 2
+    #### Diverging Sequence 2
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-diverging-sequence-2"]
     } />
 
-    ### Categorical - Sequences
+    #### Categorical - Sequences
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-categorical-sequence"]
     } />
 
-    ### Categorical - 2 Color Groups
+    #### Categorical - 2 Color Groups
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-categorical-2"]
     } />
 
-    ### Categorical - 3 Color Groups
+    #### Categorical - 3 Color Groups
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-categorical-3"]
     } />
 
-    ### Categorical - 4 Color Groups
+    #### Categorical - 4 Color Groups
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-categorical-4"]
     } />
 
-    ### Categorical - 5 Color Groups
+    #### Categorical - 5 Color Groups
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-categorical-5"]
     } />
 
-    ### Categorical - 6 Color Groups
+    #### Categorical - 6 Color Groups
     <TableSection categoryKey={categoryKey} tokens={tokens.semantic[categoryKey]} categories={
       ["hop-dataviz-categorical-6"]
     } />
   </div>
   <div>
-    ## Neutral
+    ### Neutral
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-neutral"]
     } />
-    ## Primary
+    ### Primary
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-primary"]
     } />
-    ## Success
+    ### Success
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-success"]
     } />
-    ## Warning
+    ### Warning
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-warning"]
     } />
-    ## Danger
+    ### Danger
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-danger"]
     } />
-    ## Information
+    ### Information
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-information"]
     } />
-    ## Upsell
+    ### Upsell
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-upsell"]
     } />
 
-    ## Decorative
-    ### Option 1
+    ### Decorative
+    #### Option 1
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option1"]
     } />
-    ### Option 2
+    #### Option 2
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option2"]
     } />
-    ### Option 3
+    #### Option 3
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option3"]
     } />
-    ### Option 4
+    #### Option 4
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option4"]
     } />
-    ### Option 5
+    #### Option 5
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option5"]
     } />
-    ### Option 6
+    #### Option 6
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option6"]
     } />
-    ### Option 7
+    #### Option 7
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option7"]
     } />
-    ### Option 8
+    #### Option 8
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option8"]
     } />
-    ### Option 9
+    #### Option 9
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-decorative-option9"]
     } />
 
-    ## Status
+    ### Status
 
-    ### Neutral
+    #### Neutral
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-neutral"]
     } />
-    ### Progress
+    #### Progress
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-progress"]
     } />
-    ### Positive
+    #### Positive
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-positive"]
     } />
-    ### Caution
+    #### Caution
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-caution"]
     } />
-    ### Negative
+    #### Negative
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-negative"]
     } />
-    ### Inactive
+    #### Inactive
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-inactive"]
     } />
-    ### Option 1
+    #### Option 1
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-option1"]
     } />
-    ### Option 2
+    #### Option 2
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-option2"]
     } />
-    ### Option 3
+    #### Option 3
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-option3"]
     } />
-    ### Option 4
+    #### Option 4
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-option4"]
     } />
-    ### Option 5
+    #### Option 5
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-option5"]
     } />
-    ### Option 6
+    #### Option 6
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-status-option6"]
     } />
 
-    ## Data Visualization
+    ### Data Visualization
     <TableSection categoryKey={categoryKey} tokens={tokensDark.semantic[categoryKey]} categories={
       ["hop-dataviz-unavailable", "hop-dataviz-text"]
     } />

--- a/apps/docs/content/tokens/semantic/elevation.mdx
+++ b/apps/docs/content/tokens/semantic/elevation.mdx
@@ -4,7 +4,7 @@ description: Getting started with Workleap Design Tokens
 ---
 import tokens from '../../../datas/tokens.json';
 
-## Guideline
+## Guidelines
 
 ### Working with elevation
 

--- a/apps/docs/content/tokens/semantic/space.mdx
+++ b/apps/docs/content/tokens/semantic/space.mdx
@@ -4,7 +4,7 @@ description: Getting started with Workleap Design Tokens
 ---
 import tokens from '../../../datas/tokens.json';
 
-## Guideline
+## Guidelines
 
 ### Working with spaces
 
@@ -20,11 +20,13 @@ The more visual elements are related, the closer they should be to each other.
 
 export const categoryKey = "size";
 
-## Padding
+## Tokens
+
+### Padding
 
 Padding refers to the space within a block or container from which elements are separated from the edge.
 
-### Inset
+#### Inset
 
 Inset space refers to the space within a block or container from which elements are separated from the edge. By default, the inset is equal on all four sides. Inset is also known as padding.
 
@@ -32,7 +34,7 @@ Inset space refers to the space within a block or container from which elements 
     ["inset"]
 } excludedCategories={["inset-squish", "inset-stretch"]} />
 
-### Inset Squish
+#### Inset Squish
 
 Squish inset reduces the top and bottom padding by one space increment relative to the default inset space.
 
@@ -40,7 +42,7 @@ Squish inset reduces the top and bottom padding by one space increment relative 
     ["inset-squish"]
 } />
 
-### Inset Stretch
+#### Inset Stretch
 
 Stretch inset increases the top and bottom padding by one space increment relative to the default inset space.
 
@@ -48,11 +50,11 @@ Stretch inset increases the top and bottom padding by one space increment relati
     ["inset-stretch"]
 } />
 
-## Margin
+### Margin
 
 Margin refers to the traditional meaning of space between elements. It can be used as a margin or gap when in grid or flex layouts.
 
-### Stack
+#### Stack
 
 Stack is the space that separates elements or containers arranged vertically within a column. The last element of the stack should omit this space.
 
@@ -60,7 +62,7 @@ Stack is the space that separates elements or containers arranged vertically wit
     ["stack"]
 } />
 
-### Inline
+#### Inline
 
 Inline refers to the space that separates inline elements arranged horizontally and that may wrap on the right. The last element should omit this space.
 

--- a/apps/docs/content/tokens/semantic/typography.mdx
+++ b/apps/docs/content/tokens/semantic/typography.mdx
@@ -9,7 +9,7 @@ Typography tokens are composite tokens, meaning they are made up of multiple oth
 
 ## Guidelines
 
-### Working with typography
+### Centering
 
 #### Use the bounding box to align with grid
 
@@ -19,13 +19,15 @@ The bounding box is the vertical height of the text and is defined by the line h
 
 Some fonts, such as *ABC Favorit* requires a little help to look centered. In those cases, apply a [text-crop](/guides/css/text-crop) to adjust the line height. These values are available as tokens, and are documented below. Hopper Components already apply these values when necessary.
 
-### Line length should be between 40 to 60 characters.
-
-Lines of text that are too short make the eyes strain while long lines make it hard to concentrate. As a way to give users the best reading experience, aim for lines of text between 40 to 60 characters, including spaces. If your text doesn’t fit this rule, review the content length, font size or even information hierarchy.
-
-### Align text using baseline
+#### Align text using baseline
 
 When aligning different text boxes together horizontally, use their baselines as a guide instead of their true center for a more harmonious look.
+
+### Content
+
+#### Line length should be between 40 to 60 characters.
+
+Lines of text that are too short make the eyes strain while long lines make it hard to concentrate. As a way to give users the best reading experience, aim for lines of text between 40 to 60 characters, including spaces. If your text doesn’t fit this rule, review the content length, font size or even information hierarchy.
 
 ## Tokens
 

--- a/apps/docs/content/tokens/semantic/typography.mdx
+++ b/apps/docs/content/tokens/semantic/typography.mdx
@@ -27,17 +27,19 @@ Lines of text that are too short make the eyes strain while long lines make it h
 
 When aligning different text boxes together horizontally, use their baselines as a guide instead of their true center for a more harmonious look.
 
-## Heading
+## Tokens
+
+### Heading
 
 Headings are used to create a hierarchy of content. They are used to help users scan and understand the content on a page.
 
 <TypographyTable type="heading" data={tokens.semantic} />
 
-### Variations
+#### Variations
 
 <TypographyVariantTable type="heading" data={tokens.semantic} />
 
-## Overline
+### Overline
 
 Used to introduce a headline.
 
@@ -45,17 +47,17 @@ _Adding a text-transform of uppercase is necessary in order to render overline a
 
 <TypographyTable type="overline" data={tokens.semantic} />
 
-## Body
+### Body
 
 Body text is used to communicate the main content of a page.
 
 <TypographyTable type="body" data={tokens.semantic} />
 
-### Variations
+#### Variations
 
 <TypographyVariantTable type="body" data={tokens.semantic} />
 
-## Accent
+### Accent
 
 Accent text is used to highlight important information on a page.
 

--- a/apps/docs/hooks/useHeadsObserver.ts
+++ b/apps/docs/hooks/useHeadsObserver.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 
-const ELEMENTS = "[data-section-title]";
+const ELEMENTS = "[data-section-title], [data-subsection-title]";
 
 function findAllFullyVisibleElements() {
     const elements = document.querySelectorAll(ELEMENTS);


### PR DESCRIPTION
URL to test: /components/installation


List of changes: 
- Added Concepts files (with all the headings + a lot of content taken from what we had)
- Added Component files (with all the headings)
- The aside now list the H3 headers
- Fixed a bug that was always showing the mobile menu button in the header.
- Fixed the paths of the components to remove the "category" from the url. It's not a lot easier to access the component documentation (  hopper.workleap.com/components/ComponentName ). The users don't have to remember the category to access the doc.
- Fixed the sorting that was all nested in the sidebar. The sidebar should not know how to fetch the links and sort them, it should receive the links via props
- Renamed the Overview page to "Component List" to better reflect the page's content
- Added (WIP) to every page to better reflect the progression of the documentation. We'll remove the WIP once the page is done


