### PR TITLE
lowered the icon specificity in order to prevent unwanted overriding

### DIFF
--- a/packages/icons/src/Icon.module.css
+++ b/packages/icons/src/Icon.module.css
@@ -1,4 +1,4 @@
-.hop-Icon {
+:where(.hop-Icon) {
     --hop-Icon-placeholder-primary-icon: var(--hop-primary-icon);
     --hop-Icon-placeholder-warning-icon-weak: var(--hop-warning-icon-weak);
 


### PR DESCRIPTION
- Icon color was being overridden when Icon.module.css was loaded after a component declaration, adding `:where(...)` fixes the issue as Icon declaration has now a specificity value of 0. This solution is judged the best as icons colors are often "reset" in components. 