### PR TITLE
Feature/ds 266

### DIFF
--- a/apps/docs/app/lib/getSectionLinks.ts
+++ b/apps/docs/app/lib/getSectionLinks.ts
@@ -12,13 +12,16 @@ function getSectionLinks(content: {
 
     if (matches) {
         return matches.map(link => {
+            console.log(link);
+
             const title = link.replace("###", "").replace("##", "").trim();
+            const level = link.startsWith("###") ? 3 : 2;
 
             return {
                 title: title,
                 url: `#${formattingTitleId(title.toString())}`,
                 id: title.toLowerCase().replace(/\s+/g, "-"),
-                level: link.startsWith("###") ? 3 : 2
+                level: level
             };
         });
     }

--- a/apps/docs/app/lib/getSectionLinks.ts
+++ b/apps/docs/app/lib/getSectionLinks.ts
@@ -5,7 +5,6 @@ type SectionLink = Pick<MDX, "raw">;
 
 function getSectionLinks(content: {
     body: SectionLink;
-    lastLevel2Title: string;
 }) {
     const regex = /(^#{2,3}\s).*?(?=\n)/gm;
     const body = content.body.raw;

--- a/apps/docs/app/lib/getSectionLinks.ts
+++ b/apps/docs/app/lib/getSectionLinks.ts
@@ -5,21 +5,30 @@ type SectionLink = Pick<MDX, "raw">;
 
 function getSectionLinks(content: {
     body: SectionLink;
+    lastLevel2Title: string;
 }) {
     const regex = /(^#{2,3}\s).*?(?=\n)/gm;
     const body = content.body.raw;
     const matches = body.match(regex);
+    let lastLevel2Title = "";
 
     if (matches) {
         return matches.map(link => {
-            console.log(link);
-
             const title = link.replace("###", "").replace("##", "").trim();
             const level = link.startsWith("###") ? 3 : 2;
 
+            if (level === 2) {
+                lastLevel2Title = title;
+            }
+
+            const url = level === 3 && lastLevel2Title
+                ? `#${formattingTitleId(lastLevel2Title.toString())}-${formattingTitleId(title.toString())}`
+                : `#${formattingTitleId(title.toString())}`;
+
+
             return {
                 title: title,
-                url: `#${formattingTitleId(title.toString())}`,
+                url: url,
                 id: title.toLowerCase().replace(/\s+/g, "-"),
                 level: level
             };

--- a/apps/docs/app/ui/layout/aside/Aside.tsx
+++ b/apps/docs/app/ui/layout/aside/Aside.tsx
@@ -22,7 +22,9 @@ interface AsideProps {
 const Aside = ({ title, links }: PropsWithoutRef<AsideProps>) => {
     const titleHeight = 28;
     const { activeId, setNextActiveId } = useHeadsObserver();
-    const activeIndex = links.findIndex(link => link.id === activeId);
+    const activeIndex = links.findIndex(link => {
+        return link.url === `#${activeId}`;
+    });
 
     useEffect(() => {
         window.addEventListener("scroll", setNextActiveId);
@@ -52,7 +54,7 @@ const Aside = ({ title, links }: PropsWithoutRef<AsideProps>) => {
         <li className={clsx("hd-aside__item", {
             "hd-aside__item--active": link.url === `#${activeId}` && "hd-aside__item--active"
         })}
-        key={link.id}
+        key={link.url}
         >
             {/* This has to be an a, not a link: https://github.com/vercel/next.js/issues/49612 */}
             <a href={link.url} className={`hd-aside__link hd-aside__link-level-${link.level}`}>

--- a/apps/docs/components/mdx/components.tsx
+++ b/apps/docs/components/mdx/components.tsx
@@ -37,6 +37,8 @@ const FeatureFlag = dynamic(() => import("@/components/featureFlag/FeatureFlag.t
 
 type HeadingProps = DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
 
+let h2Title = "";
+
 export const components = {
     Card,
     code: InlineCode,
@@ -90,10 +92,12 @@ export const components = {
         return <Title {...props} as="h1" interactive />;
     },
     h2: (props: HeadingProps) => {
+        h2Title = props.children as string;
+
         return <Title {...props} as="h2" interactive level={2} />;
     },
     h3: (props: HeadingProps) => {
-        return <Title {...props} as="h3" interactive level={3} />;
+        return <Title {...props} as="h3" parentHeading={h2Title} interactive level={3} />;
     },
     h4: (props: HeadingProps) => {
         return <Title {...props} as="h4" interactive level={4} />;

--- a/apps/docs/components/title/Title.tsx
+++ b/apps/docs/components/title/Title.tsx
@@ -9,6 +9,7 @@ export interface TitleProps {
     as?: "h1" | "h2" | "h3" | "h4" | "h5";
     level?: 1 | 2 | 3 | 4 | 5;
     interactive?: boolean;
+    parentHeading?: string;
     className?: string;
 }
 
@@ -18,6 +19,7 @@ const Title = ({
     interactive = false,
     className,
     children,
+    parentHeading,
     ...rest
 }: PropsWithChildren<TitleProps>) => {
     const Component = as;
@@ -27,19 +29,21 @@ const Title = ({
     }
 
     const uniqueId = formattingTitleId(children.toString());
+    const uniqueParentId = parentHeading ? formattingTitleId(parentHeading.toString()) : "";
+    const uniqueConcatId = uniqueParentId ? `${uniqueParentId}-${uniqueId}` : uniqueId ;
 
     return (
         <Component
             className={clsx("hd-title", className, {
                 [`hd-title--level${level}`]: level
             })}
-            id={level > 1 ? uniqueId : undefined}
+            id={level > 1 ? uniqueConcatId : undefined}
             data-section-title={level === 2 ? uniqueId : undefined}
             data-subsection-title={level === 3 ? uniqueId : undefined}
             {...rest}
         >
             {interactive ? (
-                <Link href={`#${uniqueId}`} className="hd-title-link">
+                <Link href={`#${uniqueConcatId}`} className="hd-title-link">
                     {children}
                 </Link>
             ) : (

--- a/apps/docs/content/components/content/Heading.mdx
+++ b/apps/docs/content/components/content/Heading.mdx
@@ -37,7 +37,7 @@ These props are also available for `H1`, `H2`, `H3`, `H4`, `H5` and `H6` compone
 
 ### Sizes
 You can alter the size of the heading by specifying a `size` prop.
-The available sizes match Hopper Typography Type Scale (a type scale is a set of [font-size and line-height](https://hopper.workleap.design/tokens/semantic/typography#heading) pairs).
+The available sizes match Hopper Typography Type Scale (a type scale is a set of [font-size and line-height](https://hopper.workleap.design/tokens/semantic/typography#tokens-heading) pairs).
 
 <Example src="typography/Heading/docs/sizes" />
 
@@ -56,7 +56,7 @@ You can alter the size to match the parent element's type scale by using the `in
     ## Advanced customization
 
     ### Contexts
-    
+
     All Hopper Components export a corresponding context that can be used to send props to them from a parent element.
     You can send any prop or ref via context that you could pass to the corresponding component.
     The local props and ref on the component are merged with the ones passed via context, with the local props taking precedence

--- a/apps/docs/content/components/content/Text.mdx
+++ b/apps/docs/content/components/content/Text.mdx
@@ -41,7 +41,7 @@ links:
 
 ### Sizes
 You can alter the size of the text by specifying a `size` prop.
-The available sizes match the Hopper Typography Type Scale (a type scale is a set of [font-size and line-height](https://hopper.workleap.design/tokens/semantic/typography#body) pairs).
+The available sizes match the Hopper Typography Type Scale (a type scale is a set of [font-size and line-height](https://hopper.workleap.design/tokens/semantic/typography#tokens-body) pairs).
 
 <Example src="typography/Text/docs/text/size" />
 

--- a/apps/docs/content/components/forms/Checkbox.mdx
+++ b/apps/docs/content/components/forms/Checkbox.mdx
@@ -49,7 +49,7 @@ links:
 
 #### CheckboxField
 
-- [Checkbox](#checkbox)
+- [Checkbox](#props-checkbox)
 - [Text](./Text)
 
 ## Checkbox Examples

--- a/apps/docs/content/components/forms/Switch.mdx
+++ b/apps/docs/content/components/forms/Switch.mdx
@@ -53,7 +53,7 @@ A `Switch` uses the following components.
 
 A `SwitchField` uses the following components.
 
-- [Switch](#switch)
+- [Switch](#props-switch)
 - [Text](./Text)
 
 ## Switch Examples


### PR DESCRIPTION
Fixed an issue where if a page had twice the same title aside would fail to work and complain about duplicate keys as well.

- Added the parent section to all level 3 titles.
- Swapped the key to link url to make sure no duplicate keys exists ever.
- Added a notion of parentHeading to generate a unique link for all titles.
- Adjusted the Aside marker code in consequence.