### PR TITLE
Feature/UI doc fixes - [DS-291]

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -29,7 +29,7 @@
 }
 
 *:not([class*="hop-"]):focus-visible {
-    border-radius: var(--hd-space-05);
+    border-radius: var(--hd-border-radius-sm);
     box-shadow: var(--hd-focus-ring);
     outline: none;
 }

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -29,7 +29,9 @@
 }
 
 *:not([class*="hop-"]):focus-visible {
-    outline: var(--hd-neutral-900) auto 0.0625rem;
+    border-radius: var(--hd-space-05);
+    box-shadow: var(--hd-focus-ring);
+    outline: none;
 }
 
 ::selection {

--- a/apps/docs/app/rehype.css
+++ b/apps/docs/app/rehype.css
@@ -60,7 +60,7 @@ code[data-theme*=' '] span {
 }
 
 [data-rehype-pretty-code-figure] .word {
-    border-radius: var(--hd-space-05);
+    border-radius: var(--hd-border-radius-sm);
     background-color: var(--hd-codeblock-word-selection-background-color);
     box-shadow: 0 0 0 var(--hd-space-05) var(--hd-codeblock-word-selection-background-color);
 }

--- a/apps/docs/app/tokens.css
+++ b/apps/docs/app/tokens.css
@@ -66,7 +66,7 @@
     --hd-color-white-surface: var(--hd-white);
     --hd-color-neutral-surface: var(--hd-neutral-20);
     --hd-color-neutral-surface-weak: var(--hd-neutral-50);
-    --hd-color-surface-neutral-selection: rgb(64 86 117);
+    --hd-color-surface-neutral-selection: #405675;
     --hd-color-surface-code-selection: var(--hd-neutral-75);
     --hd-color-neutral-text: var(--hd-neutral-900);
     --hd-color-neutral-text-strong: var(--hd-neutral-0);
@@ -114,7 +114,7 @@
     --hd-color-neutral-surface: var(--hd-neutral-900);
     --hd-color-neutral-surface-weak: var(--hd-neutral-800);
     --hd-color-surface-neutral-selection: var(--hd-neutral-300);
-    --hd-color-surface-code-selection: rgb(64 86 117);
+    --hd-color-surface-code-selection: #405675;
     --hd-color-neutral-text: var(--hd-neutral-0);
     --hd-color-neutral-text-strong: var(--hd-neutral-900);
     --hd-color-neutral-text-weak: var(--hd-neutral-300);

--- a/apps/docs/app/tokens.css
+++ b/apps/docs/app/tokens.css
@@ -66,7 +66,8 @@
     --hd-color-white-surface: var(--hd-white);
     --hd-color-neutral-surface: var(--hd-neutral-20);
     --hd-color-neutral-surface-weak: var(--hd-neutral-50);
-    --hd-color-surface-neutral-selection: var(--hd-neutral-75);
+    --hd-color-surface-neutral-selection: rgb(64 86 117);
+    --hd-color-surface-code-selection: var(--hd-neutral-75);
     --hd-color-neutral-text: var(--hd-neutral-900);
     --hd-color-neutral-text-strong: var(--hd-neutral-0);
     --hd-color-neutral-text-weak: var(--hd-neutral-700);
@@ -113,6 +114,7 @@
     --hd-color-neutral-surface: var(--hd-neutral-900);
     --hd-color-neutral-surface-weak: var(--hd-neutral-800);
     --hd-color-surface-neutral-selection: var(--hd-neutral-300);
+    --hd-color-surface-code-selection: rgb(64 86 117);
     --hd-color-neutral-text: var(--hd-neutral-0);
     --hd-color-neutral-text-strong: var(--hd-neutral-900);
     --hd-color-neutral-text-weak: var(--hd-neutral-300);

--- a/apps/docs/app/ui/components/componentExample/ComponentPreviewWrapper.tsx
+++ b/apps/docs/app/ui/components/componentExample/ComponentPreviewWrapper.tsx
@@ -49,7 +49,6 @@ const ComponentPreviewWrapper = memo(({ preview, toggleButton, minHeight = "13re
                     {preview}
                 </Card>
             </HopperProvider>
-
         </div>
     );
 });

--- a/apps/docs/app/ui/components/componentExample/componentExample.css
+++ b/apps/docs/app/ui/components/componentExample/componentExample.css
@@ -30,6 +30,15 @@
     }
 }
 
+.hd-component-code ::selection {
+    background-color: var(--hd-color-surface-code-selection);
+}
+
+/* Let's prevent focusing on the copy button if it's being hidden */
+.hd-component-code:not(.hd-component-code--expanded) .hd-copy-button {
+    display: none;
+}
+
 .hd-component-example__skeleton {
     height: 13rem;
 }

--- a/apps/docs/app/ui/layout/header/header.css
+++ b/apps/docs/app/ui/layout/header/header.css
@@ -6,7 +6,7 @@
     --hd-header-shadow-1-block-color: rgba(175 182 225 / 80%);
     --hd-header-shadow-2-block-color: #FECD94;
     --hd-header-shadow-3-block-color: #A9F1D6;
-    --hd-header-shadow-1-top-position: -2.75rem;
+    --hd-header-shadow-1-top-position: -18.75rem;
     --hd-header-shadow-2-top-position: -21.25rem;
     --hd-header-shadow-3-top-position: -10.5rem;
 }

--- a/apps/docs/app/ui/layout/header/header.css
+++ b/apps/docs/app/ui/layout/header/header.css
@@ -41,7 +41,7 @@
 .hd-product__menu [role="dialog"]:focus-visible {
     outline: 0;
     box-shadow: var(--hd-focus-ring);
-    border-radius: var(--hd-space-05);
+    border-radius: var(--hd-border-radius-sm);
 }
 
 .hd-product__items {
@@ -123,7 +123,7 @@
 .hd-brand:focus-visible {
     outline: 0;
     box-shadow: var(--hd-focus-ring);
-    border-radius: var(--hd-space-05);
+    border-radius: var(--hd-border-radius-sm);
 }
 
 .hd-brand__logo {

--- a/apps/docs/components/card/card.css
+++ b/apps/docs/components/card/card.css
@@ -37,7 +37,6 @@
 }
 
 .hd-card--ghost {
-    border-color: transparent;
     padding: 0;
 }
 

--- a/apps/docs/components/code/InlineCode.tsx
+++ b/apps/docs/components/code/InlineCode.tsx
@@ -10,7 +10,7 @@ export type InlineCodeProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTM
 
 const InlineCode = ({ children, variant = "default", ...props }: InlineCodeProps) => {
     return (
-        <code {...props} className={clsx("hd-code", { "hd-code--ghost": variant === "ghost" })}>{children}</code>
+        <code {...props} className={clsx("hd-code", { "hd-code--ghost": variant === "ghost" })} tabIndex={-1}>{children}</code>
     );
 };
 

--- a/apps/docs/components/copyButton/copyButton.css
+++ b/apps/docs/components/copyButton/copyButton.css
@@ -5,7 +5,7 @@
     justify-content: center;
     border: none;
     aspect-ratio: 1/1;
-    border-radius: var(--hd-space-05);
+    border-radius: var(--hd-border-radius-sm);
     width: var(--hd-space-4);
     background-color: transparent;
 }

--- a/apps/docs/components/copyButton/copyButton.css
+++ b/apps/docs/components/copyButton/copyButton.css
@@ -18,6 +18,11 @@
     background-color: var(--hd-neutral-800);
 }
 
+.hd-copy-button:not([disabled]):focus-visible {
+    box-shadow: var(--hd-focus-ring);
+    outline: none;
+}
+
 .hd-copy-button__icon {
     stroke: currentcolor;
 }

--- a/apps/docs/components/iconButton/iconButton.css
+++ b/apps/docs/components/iconButton/iconButton.css
@@ -3,7 +3,7 @@
     --hd-icon-button-color: var(--hd-color-neutral-icon);
     --hd-icon-button-background-color: transparent;
     --hd-icon-button-background-color-hover: var(--hd-color-neutral-surface-weak);
-    --hd-icon-button-border-radius: var(--hd-space-05);
+    --hd-icon-button-border-radius: var(--hd-border-radius-sm);
     --hd-icon-button-fill: var(--hd-color-neutral-icon);
     --hd-icon-button-fill-hover: var(--hd-color-neutral-icon-hover);
 }

--- a/apps/docs/components/popover/popover.css
+++ b/apps/docs/components/popover/popover.css
@@ -12,5 +12,5 @@
 .hd-popover:focus-visible {
     outline: 0;
     box-shadow: var(--hd-focus-ring);
-    border-radius: var(--hd-space-05);
+    border-radius: var(--hd-border-radius-sm);
 }

--- a/apps/docs/components/pre/Pre.tsx
+++ b/apps/docs/components/pre/Pre.tsx
@@ -32,7 +32,7 @@ const Pre = ({ children, className, title, "data-language": dataLanguage, raw, t
     const copyButton = raw && <CopyButton onDark={isOnDark} text={raw} />;
 
     return (
-        <pre {...props} data-theme={theme} className={classes}>
+        <pre {...props} data-theme={theme} className={classes} tabIndex={-1}>
             {title &&
                 <div className="hd-pre-header">
                     <div className="hd-pre-header__info">

--- a/apps/docs/components/pre/pre.css
+++ b/apps/docs/components/pre/pre.css
@@ -38,6 +38,10 @@
     background-color: transparent;
 }
 
+.hd-pre__code code ::selection {
+    background-color: var(--hd-color-surface-code-selection);
+}
+
 /* !* pre HEADER *! */
 .hd-pre-header {
     display: flex;

--- a/packages/components/src/buttons/docs/migration-notes.md
+++ b/packages/components/src/buttons/docs/migration-notes.md
@@ -1,6 +1,6 @@
 Coming from Orbiter, you should be aware of the following changes:
 
-- `onClick` has been renamed to `onPress`.
+- `onClick` has been renamed to `onPress`to be closer to the [React Aria API](https://react-spectrum.adobe.com/react-aria/Button.html#events).
 - `Counter` is no longer allowed as a specialized slot.
 - `ButtonAsLink` is now integrated into the Button component.
 - `IconButton` is now integrated into the Button component.

--- a/packages/components/src/buttons/docs/migration-notes.md
+++ b/packages/components/src/buttons/docs/migration-notes.md
@@ -1,6 +1,6 @@
 Coming from Orbiter, you should be aware of the following changes:
 
-- `onClick` has been renamed to `onPress`to be closer to the [React Aria API](https://react-spectrum.adobe.com/react-aria/Button.html#events).
+- `onClick` has been renamed to `onPress` to be closer to the [React Aria API](https://react-spectrum.adobe.com/react-aria/Button.html#events).
 - `Counter` is no longer allowed as a specialized slot.
 - `ButtonAsLink` is now integrated into the Button component.
 - `IconButton` is now integrated into the Button component.


### PR DESCRIPTION
- Fixed tabbing issue where the copy code button was being focused even though it was not visible.
- Adjusted the code selection color.
- Fixed an issue where in some situations the focus color was not right in dark mode.
- Fixed an issue where the sidenav scroll bar would show behind the header gradient.
- Fixed an issue where you could focus on the `code` DOM element.
- Ghost cards should also feature a border as in some situations they were hard to read.
- Added the specific reason as to why the button `onClick` prop has been renamed to `onPress`.

