### PR TITLE
Fix: [DS-312] Fixed accessibility issue with interactive elements inside listBoxItem

### DIFF
--- a/.changeset/fresh-readers-march.md
+++ b/.changeset/fresh-readers-march.md
@@ -2,4 +2,4 @@
 "@hopper-ui/components": patch
 ---
 
-Added DecorativeCheckbox and DecorativeRadio to be used as visual checkoxes and radio buttons inside other interactive components.
+Added DecorativeCheckbox and DecorativeRadio to be used as visual checkboxes and radio buttons inside other interactive components.

--- a/.changeset/fresh-readers-march.md
+++ b/.changeset/fresh-readers-march.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Added DecorativeCheckbox and DecorativeRadio to be used as visual checkoxes and radio buttons inside other interactive components.

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -32,6 +32,18 @@ const config = {
                     {
                         "message": "Expected css variables to be kebab-case or hop-ComponentName-kebab-case"
                     }
+                ],
+                "property-no-unknown": [
+                    true,
+                    {
+                        ignoreProperties: ["/composes/"]
+                    }
+                ],
+                "value-keyword-case": [
+                    "lower",
+                    {
+                        ignoreKeywords: ["/^hop-.*$/"]
+                    }
                 ]
             }
         }

--- a/packages/components/src/ListBox/src/ListBoxItem.module.css
+++ b/packages/components/src/ListBox/src/ListBoxItem.module.css
@@ -299,7 +299,7 @@
     transition: var(--checkmark-transition);
 }
 
-.hop-ListBoxItem__radio-group,
+.hop-ListBoxItem__radio,
 .hop-ListBoxItem__checkbox {
     pointer-events: none;
     user-select: none;

--- a/packages/components/src/ListBox/src/ListBoxItem.tsx
+++ b/packages/components/src/ListBox/src/ListBoxItem.tsx
@@ -13,10 +13,9 @@ import {
 
 import { AvatarContext, type AvatarProps } from "../../Avatar/index.ts";
 import { BadgeContext } from "../../Badge/index.ts";
-import { Checkbox } from "../../checkbox/index.ts";
-import { useLocalizedString } from "../../i18n/index.ts";
+import { DecorativeCheckbox } from "../../checkbox/index.ts";
 import { IconListContext } from "../../IconList/index.ts";
-import { Radio, RadioGroup, RadioList } from "../../radio/index.ts";
+import { DecorativeRadio } from "../../radio/index.ts";
 import { Text, TextContext, type TextProps } from "../../typography/Text/index.ts";
 import { composeClassnameRenderProps, type SizeAdapter, SlotProvider, cssModule, isTextOnlyChildren } from "../../utils/index.ts";
 
@@ -95,7 +94,6 @@ const ListBoxItemToAvatarSizeAdapter = {
 } as const satisfies SizeAdapter<ListBoxItemSize, AvatarProps["size"]>;
 
 function ListBoxItemInner(props: ListBoxItemInnerProps) {
-    const stringFormatter = useLocalizedString();
     const listStateContext = useContext(ListStateContext);
     
     const { selectionMode, 
@@ -131,30 +129,21 @@ function ListBoxItemInner(props: ListBoxItemInnerProps) {
             onTransitionEnd={handleTransitionEnd}
         >
             {isRadio && (
-                <RadioGroup 
+                <DecorativeRadio
+                    className={styles["hop-ListBoxItem__radio"]}
+                    value="radio"
                     size="sm"
-                    aria-hidden="true"
-                    aria-label={stringFormatter.format("ListBoxItem.indicatorAriaLabel")}
-                    value={isSelected ? "radio" : null} 
-                    className={styles["hop-ListBoxItem__radio-group"]}
+                    isDisabled={isDisabled}
+                    isHovered={isHovered || isFocusVisible}
+                    isPressed={isPressed}
+                    isSelected={isSelected}
                     isInvalid={isInvalid}
-                >
-                    <RadioList>
-                        <Radio
-                            className={styles["hop-ListBoxItem__radio"]}
-                            value="radio"
-                            isDisabled={isDisabled}
-                            isHovered={isHovered || isFocusVisible}
-                            isPressed={isPressed}
-                        />
-                    </RadioList>
-                </RadioGroup>
+                />
             )}
             {isCheckbox && (
-                <Checkbox
+                <DecorativeCheckbox
                     size="sm"
                     value="checkbox"
-                    aria-hidden="true"
                     className={styles["hop-ListBoxItem__checkbox"]}
                     isDisabled={isDisabled}
                     isHovered={isHovered || isFocusVisible}

--- a/packages/components/src/checkbox/src/Checkbox.module.css
+++ b/packages/components/src/checkbox/src/Checkbox.module.css
@@ -96,8 +96,7 @@
     max-inline-size: 100%;
 }
 
-.hop-Checkbox[data-focus-visible],
-.hop-Checkbox--focused {
+.hop-Checkbox[data-focus-visible] {
     --box-background-color: var(--hop-Checkbox-box-background-color-focused);
     --box-border-color: var(--hop-Checkbox-box-border-color-focused);
     --box-outline: var(--hop-Checkbox-box-outline-size) solid var(--hop-Checkbox-box-outline-color);
@@ -105,16 +104,14 @@
     --icon-color: var(--hop-Checkbox-icon-color-focused);
 }
 
-.hop-Checkbox[data-hovered],
-.hop-Checkbox--hovered {
+.hop-Checkbox[data-hovered] {
     --box-background-color: var(--hop-Checkbox-box-background-color-hovered);
     --box-border-color: var(--hop-Checkbox-box-border-color-hovered);
     --text-color: var(--hop-Checkbox-text-color-hovered);
     --icon-color: var(--hop-Checkbox-icon-color-hovered);
 }
 
-.hop-Checkbox[data-pressed],
-.hop-Checkbox--pressed {
+.hop-Checkbox[data-pressed] {
     --box-background-color: var(--hop-Checkbox-box-background-color-pressed);
     --box-border-color: var(--hop-Checkbox-box-border-color-pressed);
     --text-color: var(--hop-Checkbox-text-color-pressed);
@@ -137,19 +134,19 @@
     --icon-color: var(--hop-Checkbox-icon-color-invalid);
 }
 
-.hop-Checkbox[data-invalid]:where([data-focus-visible], .hop-Checkbox--focused) {
+.hop-Checkbox[data-invalid]:where([data-focus-visible]) {
     --box-background-color: var(--hop-Checkbox-box-background-color-focused-invalid);
     --box-border-color: var(--hop-Checkbox-box-border-color-focused-invalid);
 }
 
-.hop-Checkbox[data-invalid]:where([data-hovered], .hop-Checkbox--hovered) {
+.hop-Checkbox[data-invalid]:where([data-hovered]) {
     --box-background-color: var(--hop-Checkbox-box-background-color-hovered-invalid);
     --box-border-color: var(--hop-Checkbox-box-border-color-hovered-invalid);
     --text-color: var(--hop-Checkbox-text-color-hovered-invalid);
     --icon-color: var(--hop-Checkbox-icon-color-hovered-invalid);
 }
 
-.hop-Checkbox[data-invalid]:where([data-pressed], .hop-Checkbox--pressed){
+.hop-Checkbox[data-invalid]:where([data-pressed]){
     --box-background-color: var(--hop-Checkbox-box-background-color-pressed-invalid);
     --box-border-color: var(--hop-Checkbox-box-border-color-pressed-invalid);
     --text-color: var(--hop-Checkbox-text-color-pressed-invalid);

--- a/packages/components/src/checkbox/src/Checkbox.tsx
+++ b/packages/components/src/checkbox/src/Checkbox.tsx
@@ -20,8 +20,7 @@ import {
     SlotProvider,
     cssModule,
     isTextOnlyChildren,
-    ClearContainerSlots,
-    type InteractionProps
+    ClearContainerSlots
 } from "../../utils/index.ts";
 
 import { CheckboxContext } from "./CheckboxContext.ts";
@@ -30,7 +29,7 @@ import styles from "./Checkbox.module.css";
 
 export const GlobalCheckboxCssSelector = "hop-Checkbox";
 
-export interface CheckboxProps extends StyledComponentProps<RACCheckboxProps>, InteractionProps {
+export interface CheckboxProps extends StyledComponentProps<RACCheckboxProps> {
     /**
      * A checkbox can vary in size.
      * @default "md"
@@ -46,9 +45,6 @@ function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) {
         children: childrenProp,
         size: sizeProp = "md",
         style: styleProp,
-        isPressed,
-        isHovered,
-        isFocused,
         ...otherProps
     } = ownProps;
 
@@ -60,10 +56,7 @@ function Checkbox(props: CheckboxProps, ref: ForwardedRef<HTMLLabelElement>) {
         cssModule(
             styles,
             "hop-Checkbox",
-            size,
-            isPressed && "pressed",
-            isHovered && "hovered",
-            isFocused && "focused"
+            size
         ),
         stylingProps.className
     );

--- a/packages/components/src/checkbox/src/DecorativeCheckbox.module.css
+++ b/packages/components/src/checkbox/src/DecorativeCheckbox.module.css
@@ -1,0 +1,34 @@
+/* stylelint-disable value-keyword-case */
+
+.hop-DecorativeCheckbox {
+    composes: hop-Checkbox from "./Checkbox.module.css";
+}
+
+.hop-DecorativeCheckbox--sm {
+    composes: hop-Checkbox--sm from "./Checkbox.module.css";
+}
+
+.hop-DecorativeCheckbox--md {
+    composes: hop-Checkbox--md from "./Checkbox.module.css";
+}
+
+/* Icons */
+.hop-DecorativeCheckbox__icon,
+.hop-DecorativeCheckbox__icon-list {
+    composes: hop-Checkbox__icon from "./Checkbox.module.css";
+}
+
+/* Box */
+.hop-DecorativeCheckbox__box {
+    composes: hop-Checkbox__box from "./Checkbox.module.css";
+}
+
+/* Check */
+.hop-DecorativeCheckbox__check {
+    composes: hop-Checkbox__check from "./Checkbox.module.css";
+}
+
+/* Text */
+.hop-DecorativeCheckbox__text {    
+    composes: hop-Checkbox__text from "./Checkbox.module.css";
+}

--- a/packages/components/src/checkbox/src/DecorativeCheckbox.module.css
+++ b/packages/components/src/checkbox/src/DecorativeCheckbox.module.css
@@ -1,6 +1,3 @@
-/* stylelint-disable property-no-unknown */
-/* stylelint-disable value-keyword-case */
-
 .hop-DecorativeCheckbox {
     composes: hop-Checkbox from "./Checkbox.module.css";
 }

--- a/packages/components/src/checkbox/src/DecorativeCheckbox.module.css
+++ b/packages/components/src/checkbox/src/DecorativeCheckbox.module.css
@@ -1,3 +1,4 @@
+/* stylelint-disable property-no-unknown */
 /* stylelint-disable value-keyword-case */
 
 .hop-DecorativeCheckbox {

--- a/packages/components/src/checkbox/src/DecorativeCheckbox.tsx
+++ b/packages/components/src/checkbox/src/DecorativeCheckbox.tsx
@@ -1,0 +1,156 @@
+import { IconContext, MinusIcon, CheckmarkIcon } from "@hopper-ui/icons";
+import {
+    useStyledSystem,
+    useResponsiveValue
+} from "@hopper-ui/styled-system";
+import { forwardRef, type ForwardedRef } from "react";
+import { mergeProps } from "react-aria";
+import {
+    composeRenderProps,
+    useContextProps
+} from "react-aria-components";
+
+import { IconListContext } from "../../IconList/index.ts";
+import { Text, TextContext } from "../../typography/Text/index.ts";
+import {
+    SlotProvider,
+    cssModule,
+    isTextOnlyChildren,
+    ClearContainerSlots,
+    type InteractionProps,
+    useRenderProps,
+    composeClassnameRenderProps
+} from "../../utils/index.ts";
+
+import type { CheckboxProps } from "./Checkbox.tsx";
+import { CheckboxContext } from "./CheckboxContext.ts";
+
+import styles from "./DecorativeCheckbox.module.css";
+
+export const GlobalDecorativeCheckboxCssSelector = "hop-DecorativeCheckbox";
+
+export interface DecorativeCheckboxProps extends Omit<CheckboxProps, "onChange">, InteractionProps {}
+
+function DecorativeCheckbox(props: DecorativeCheckboxProps, ref: ForwardedRef<HTMLElement>) {
+    [props, ref] = useContextProps(props, ref as ForwardedRef<HTMLLabelElement>, CheckboxContext);
+    const { stylingProps, ...ownProps } = useStyledSystem(props);
+    const {
+        className,
+        children: childrenProp,
+        size: sizeProp = "md",
+        slot,
+        style: styleProp,
+        isSelected,
+        isPressed,
+        isHovered,
+        isFocused,
+        isFocusVisible,
+        isDisabled,
+        isReadOnly,
+        isInvalid,
+        isRequired,
+        isIndeterminate,
+        ...otherProps
+    } = ownProps;
+
+    const size = useResponsiveValue(sizeProp) ?? "md";
+
+    const children = composeRenderProps(childrenProp, prev => {
+        if (prev && isTextOnlyChildren(prev)) {
+            return <Text>{prev}</Text>;
+        }
+
+        return prev;
+    });
+    
+    const classNames = composeClassnameRenderProps(
+        className,
+        GlobalDecorativeCheckboxCssSelector,
+        cssModule(
+            styles,
+            "hop-DecorativeCheckbox",
+            size
+        ),
+        stylingProps.className
+    );
+
+    const style = composeRenderProps(styleProp, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
+
+    const renderProps = useRenderProps({
+        ...props,
+        className: classNames,
+        style,
+        children: children,
+        values: {
+            isSelected: isSelected || false,
+            isPressed: isPressed || false,
+            isHovered: isHovered || false,
+            isFocused: isFocused || false,
+            isFocusVisible: isFocusVisible || false,
+            isDisabled: isDisabled || false,
+            isReadOnly: isReadOnly || false,
+            isInvalid: isInvalid || false,
+            isRequired: isRequired || false,
+            isIndeterminate: isIndeterminate || false
+        }
+    });
+    
+    const checkboxIconClassName = styles["hop-DecorativeCheckbox__check"];
+    const icon = isIndeterminate ?
+        <MinusIcon size="sm" className={checkboxIconClassName} /> :
+        <CheckmarkIcon size="sm" className={checkboxIconClassName} />;
+
+    return (
+        <div
+            {...mergeProps(otherProps, renderProps)}
+            ref={ref as ForwardedRef<HTMLDivElement>}
+            slot={slot || undefined}
+            data-selected={isSelected || undefined}
+            data-pressed={isPressed || undefined}
+            data-hovered={isHovered || undefined}
+            data-focused={isFocused || undefined}
+            data-focus-visible={isFocusVisible || undefined}
+            data-disabled={isDisabled || undefined}
+            data-readonly={isReadOnly || undefined}
+            data-invalid={isInvalid || undefined}
+            data-required={isRequired || undefined}
+        >
+            <div className={styles["hop-DecorativeCheckbox__box"]}>{icon}</div>
+            <ClearContainerSlots>
+                <SlotProvider
+                    values={[
+                        [TextContext, {
+                            className: styles["hop-DecorativeCheckbox__text"],
+                            size: size
+                        }],
+                        [IconListContext, {
+                            className: styles["hop-DecorativeCheckbox__icon-list"],
+                            size: size
+                        }],
+                        [IconContext, {
+                            className: styles["hop-DecorativeCheckbox__icon"],
+                            size: size
+                        }]
+                    ]}
+                >
+                    {renderProps.children}
+                </SlotProvider>
+            </ClearContainerSlots>
+        </div>
+    );
+}
+
+/**
+ * The DecorativeCheckbox component indicates the selection state of an option without using a native radio input. To be used for visual purposes only.
+ *
+ * [View Documentation](TODO)
+ */
+const _DecorativeCheckbox = forwardRef<HTMLElement, DecorativeCheckboxProps>(DecorativeCheckbox);
+_DecorativeCheckbox.displayName = "DecorativeCheckbox";
+
+export { _DecorativeCheckbox as DecorativeCheckbox };

--- a/packages/components/src/checkbox/src/index.ts
+++ b/packages/components/src/checkbox/src/index.ts
@@ -6,3 +6,4 @@ export * from "./CheckboxGroup.tsx";
 export * from "./CheckboxGroupContext.ts";
 export * from "./CheckboxList.tsx";
 export * from "./CheckboxListContext.ts";
+export * from "./DecorativeCheckbox.tsx";

--- a/packages/components/src/radio/src/DecorativeRadio.module.css
+++ b/packages/components/src/radio/src/DecorativeRadio.module.css
@@ -1,0 +1,34 @@
+/* stylelint-disable value-keyword-case */
+
+.hop-DecorativeRadio {
+    composes: hop-Radio from "./Radio.module.css";
+}
+
+.hop-DecorativeRadio--sm {
+    composes: hop-Radio--sm from "./Radio.module.css";
+}
+
+.hop-DecorativeRadio--md {
+    composes: hop-Radio--md from "./Radio.module.css";
+}
+
+/* Icons */
+.hop-DecorativeRadio__icon,
+.hop-DecorativeRadio__icon-list {
+    composes: hop-Radio__icon from "./Radio.module.css";
+}
+
+/* Box */
+.hop-DecorativeRadio__box {
+    composes: hop-Radio__box from "./Radio.module.css";
+}
+
+/* Check */
+.hop-DecorativeRadio__bullet {
+    composes: hop-Radio__bullet from "./Radio.module.css";
+}
+
+/* Text */
+.hop-DecorativeRadio__text {    
+    composes: hop-Radio__text from "./Radio.module.css";
+}

--- a/packages/components/src/radio/src/DecorativeRadio.module.css
+++ b/packages/components/src/radio/src/DecorativeRadio.module.css
@@ -1,6 +1,3 @@
-/* stylelint-disable property-no-unknown */
-/* stylelint-disable value-keyword-case */
-
 .hop-DecorativeRadio {
     composes: hop-Radio from "./Radio.module.css";
 }

--- a/packages/components/src/radio/src/DecorativeRadio.module.css
+++ b/packages/components/src/radio/src/DecorativeRadio.module.css
@@ -1,3 +1,4 @@
+/* stylelint-disable property-no-unknown */
 /* stylelint-disable value-keyword-case */
 
 .hop-DecorativeRadio {

--- a/packages/components/src/radio/src/DecorativeRadio.tsx
+++ b/packages/components/src/radio/src/DecorativeRadio.tsx
@@ -1,0 +1,153 @@
+import { IconContext, BulletIcon } from "@hopper-ui/icons";
+import {
+    useStyledSystem,
+    useResponsiveValue
+} from "@hopper-ui/styled-system";
+import { forwardRef, type ForwardedRef } from "react";
+import { mergeProps } from "react-aria";
+import {
+    composeRenderProps,
+    useContextProps
+} from "react-aria-components";
+
+import { IconListContext } from "../../IconList/index.ts";
+import { Text, TextContext } from "../../typography/Text/index.ts";
+import {
+    SlotProvider,
+    cssModule,
+    isTextOnlyChildren,
+    ClearContainerSlots,
+    type InteractionProps,
+    useRenderProps,
+    composeClassnameRenderProps
+} from "../../utils/index.ts";
+
+import type { RadioProps } from "./Radio.tsx";
+import { RadioContext } from "./RadioContext.ts";
+
+import styles from "./DecorativeRadio.module.css";
+
+export const GlobalDecorativeRadioCssSelector = "hop-DecorativeRadio";
+
+export interface DecorativeRadioProps extends RadioProps, InteractionProps {}
+
+function DecorativeRadio(props: DecorativeRadioProps, ref: ForwardedRef<HTMLElement>) {
+    [props, ref] = useContextProps(props, ref as ForwardedRef<HTMLLabelElement>, RadioContext);
+    const { stylingProps, ...ownProps } = useStyledSystem(props);
+    const {
+        className,
+        children: childrenProp,
+        size: sizeProp = "md",
+        slot,
+        style: styleProp,
+        isSelected,
+        isPressed,
+        isHovered,
+        isFocused,
+        isFocusVisible,
+        isDisabled,
+        isReadOnly,
+        isInvalid,
+        isRequired,
+        ...otherProps
+    } = ownProps;
+
+    const size = useResponsiveValue(sizeProp) ?? "md";
+
+    const children = composeRenderProps(childrenProp, prev => {
+        if (prev && isTextOnlyChildren(prev)) {
+            return <Text>{prev}</Text>;
+        }
+
+        return prev;
+    });
+    
+    const classNames = composeClassnameRenderProps(
+        className,
+        GlobalDecorativeRadioCssSelector,
+        cssModule(
+            styles,
+            "hop-DecorativeRadio",
+            size
+        ),
+        stylingProps.className
+    );
+
+    const style = composeRenderProps(styleProp, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
+
+    const renderProps = useRenderProps({
+        ...props,
+        className: classNames,
+        style,
+        children: children,
+        values: {
+            isSelected: isSelected || false,
+            isPressed: isPressed || false,
+            isHovered: isHovered || false,
+            isFocused: isFocused || false,
+            isFocusVisible: isFocusVisible || false,
+            isDisabled: isDisabled || false,
+            isReadOnly: isReadOnly || false,
+            isInvalid: isInvalid || false,
+            isRequired: isRequired || false
+        }
+    });
+    
+    const radioIconClassName = styles["hop-DecorativeRadio__bullet"];
+
+    return (
+        <div
+            {...mergeProps(otherProps, renderProps)}
+            ref={ref as ForwardedRef<HTMLDivElement>}
+            slot={slot || undefined}
+            data-selected={isSelected || undefined}
+            data-pressed={isPressed || undefined}
+            data-hovered={isHovered || undefined}
+            data-focused={isFocused || undefined}
+            data-focus-visible={isFocusVisible || undefined}
+            data-disabled={isDisabled || undefined}
+            data-readonly={isReadOnly || undefined}
+            data-invalid={isInvalid || undefined}
+            data-required={isRequired || undefined}
+        >
+            <div className={styles["hop-DecorativeRadio__box"]}>
+                <BulletIcon size={size} className={radioIconClassName} />
+            </div>
+            <ClearContainerSlots>
+                <SlotProvider
+                    values={[
+                        [TextContext, {
+                            className: styles["hop-DecorativeRadio__text"],
+                            size: size
+                        }],
+                        [IconListContext, {
+                            className: styles["hop-DecorativeRadio__icon-list"],
+                            size: size
+                        }],
+                        [IconContext, {
+                            className: styles["hop-DecorativeRadio__icon"],
+                            size: size
+                        }]
+                    ]}
+                >
+                    {renderProps.children}
+                </SlotProvider>
+            </ClearContainerSlots>
+        </div>
+    );
+}
+
+/**
+ * The DecorativeRadio component indicates the selection state of an option without using a native radio input. To be used for visual purposes only.
+ *
+ * [View Documentation](TODO)
+ */
+const _DecorativeRadio = forwardRef<HTMLElement, DecorativeRadioProps>(DecorativeRadio);
+_DecorativeRadio.displayName = "DecorativeRadio";
+
+export { _DecorativeRadio as DecorativeRadio };

--- a/packages/components/src/radio/src/Radio.module.css
+++ b/packages/components/src/radio/src/Radio.module.css
@@ -95,8 +95,7 @@
     max-inline-size: 100%;
 }
 
-.hop-Radio[data-focus-visible],
-.hop-Radio--focused {
+.hop-Radio[data-focus-visible] {
     --box-background-color: var(--hop-Radio-box-background-color-focused);
     --box-border-color: var(--hop-Radio-box-border-color-focused);
     --box-outline: var(--hop-Radio-box-outline-size) solid var(--hop-Radio-box-outline-color);
@@ -104,16 +103,14 @@
     --icon-color: var(--hop-Radio-icon-color-focused);
 }
 
-.hop-Radio[data-hovered],
-.hop-Radio--hovered {
+.hop-Radio[data-hovered] {
     --box-background-color: var(--hop-Radio-box-background-color-hovered);
     --box-border-color: var(--hop-Radio-box-border-color-hovered);
     --text-color: var(--hop-Radio-text-color-hovered);
     --icon-color: var(--hop-Radio-icon-color-hovered);
 }
 
-.hop-Radio[data-pressed],
-.hop-Radio--pressed {
+.hop-Radio[data-pressed] {
     --box-background-color: var(--hop-Radio-box-background-color-pressed);
     --box-border-color: var(--hop-Radio-box-border-color-pressed);
     --text-color: var(--hop-Radio-text-color-pressed);

--- a/packages/components/src/radio/src/Radio.tsx
+++ b/packages/components/src/radio/src/Radio.tsx
@@ -20,8 +20,7 @@ import {
     SlotProvider,
     cssModule,
     isTextOnlyChildren,
-    ClearContainerSlots,
-    type InteractionProps
+    ClearContainerSlots
 } from "../../utils/index.ts";
 
 import { RadioContext } from "./RadioContext.ts";
@@ -30,7 +29,7 @@ import styles from "./Radio.module.css";
 
 export const GlobalRadioCssSelector = "hop-Radio";
 
-export interface RadioProps extends StyledComponentProps<RACRadioProps>, InteractionProps {
+export interface RadioProps extends StyledComponentProps<RACRadioProps> {
     /**
      * A radio can vary in size.
      * @default "md"
@@ -46,9 +45,6 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) {
         children: childrenProp,
         size: sizeProp = "md",
         style: styleProp,
-        isPressed,
-        isHovered,
-        isFocused,
         ...otherProps
     } = ownProps;
 
@@ -60,10 +56,7 @@ function Radio(props: RadioProps, ref: ForwardedRef<HTMLLabelElement>) {
         cssModule(
             styles,
             "hop-Radio",
-            size,
-            isPressed && "pressed",
-            isHovered && "hovered",
-            isFocused && "focused"
+            size
         ),
         stylingProps.className
     );

--- a/packages/components/src/radio/src/index.ts
+++ b/packages/components/src/radio/src/index.ts
@@ -6,3 +6,4 @@ export * from "./RadioGroup.tsx";
 export * from "./RadioGroupContext.ts";
 export * from "./RadioList.tsx";
 export * from "./RadioListContext.ts";
+export * from "./DecorativeRadio.tsx";

--- a/packages/components/src/utils/src/types.ts
+++ b/packages/components/src/utils/src/types.ts
@@ -45,15 +45,39 @@ export interface BaseComponentProps extends DOMProps, AriaLabelingProps, SlotPro
 /** Added these for when we need to force an interactive state like for radios inside list box items */
 export interface InteractionProps {
     /**
-     * @ignore
+     * Whether or not the component is currently pressed.
      */
     isPressed?: boolean;
     /**
-     * @ignore
+     * Whether or not the component is currently focused.
      */
     isFocused?: boolean;
     /**
-     * @ignore
+     * Whether or not the component is currently focus visible.
+     */
+    isFocusVisible?: boolean;
+    /**
+     * Whether or not the component is currently hovered.
      */
     isHovered?: boolean;
+    /**
+     * Whether or not the component is currently selected.
+     */
+    isSelected?: boolean;
+    /**
+     * Whether or not the component is currently disabled.
+     */
+    isDisabled?: boolean;
+    /**
+     * Whether or not the component is currently read-only.
+     */
+    isReadOnly?: boolean;
+    /**
+     * Whether or not the component is currently invalid.
+     */
+    isInvalid?: boolean;
+    /**
+     * Whether or not the component is currently required.
+     */
+    isRequired?: boolean;
 }


### PR DESCRIPTION
Added DecorativeCheckbox and DecorativeRadio components that are used for visual purposes only. Such as inside a ListBoxItem when the `selectionIndicator` is set to `input`.