### PR TITLE
[DS-283] Standardizing className, style and children Props for BaseComponentProps

### DIFF
--- a/packages/components/src/Avatar/src/AnonymousAvatar.tsx
+++ b/packages/components/src/Avatar/src/AnonymousAvatar.tsx
@@ -4,7 +4,7 @@ import { type ForwardedRef, forwardRef } from "react";
 import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { type BaseComponentRenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
+import { type AccessibleSlotProps, type RenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -19,7 +19,7 @@ interface AnonymousAvatarRenderProps {
     isDisabled?: boolean;
 }
 
-export interface AnonymousAvatarProps extends StyledSystemProps, Omit<BaseComponentRenderProps<AnonymousAvatarRenderProps>, "children"> {
+export interface AnonymousAvatarProps extends StyledSystemProps, AccessibleSlotProps, Omit<RenderProps<AnonymousAvatarRenderProps>, "children"> {
     /**
      * Whether or not the avatar is disabled.
      */

--- a/packages/components/src/Avatar/src/AnonymousAvatar.tsx
+++ b/packages/components/src/Avatar/src/AnonymousAvatar.tsx
@@ -4,7 +4,7 @@ import { type ForwardedRef, forwardRef } from "react";
 import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { composeClassnameRenderProps, type TempBaseComponentProps, useRenderProps } from "../../utils/index.ts";
+import { type BaseComponentRenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -19,7 +19,7 @@ interface AnonymousAvatarRenderProps {
     isDisabled?: boolean;
 }
 
-export interface AnonymousAvatarProps extends StyledSystemProps, Omit<TempBaseComponentProps<AnonymousAvatarRenderProps>, "children"> {
+export interface AnonymousAvatarProps extends StyledSystemProps, Omit<BaseComponentRenderProps<AnonymousAvatarRenderProps>, "children"> {
     /**
      * Whether or not the avatar is disabled.
      */

--- a/packages/components/src/Avatar/src/AnonymousAvatar.tsx
+++ b/packages/components/src/Avatar/src/AnonymousAvatar.tsx
@@ -1,10 +1,10 @@
 import { AnonymousRichIcon } from "@hopper-ui/icons";
-import { type ResponsiveProp, useStyledSystem, type StyledSystemProps, useResponsiveValue } from "@hopper-ui/styled-system";
-import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
-import { useContextProps } from "react-aria-components";
+import { type ResponsiveProp, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
+import { type ForwardedRef, forwardRef } from "react";
+import { mergeProps } from "react-aria";
+import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, type TempBaseComponentProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -12,7 +12,14 @@ import { RichIconAvatarImage } from "./RichIconAvatarImage.tsx";
 
 export const GlobalAnonymousAvatarCssSelector = "hop-AnonymousAvatar";
 
-export interface AnonymousAvatarProps extends StyledSystemProps, BaseComponentProps {
+interface AnonymousAvatarRenderProps {
+    /**
+     * Whether or not the avatar is disabled.
+     */
+    isDisabled?: boolean;
+}
+
+export interface AnonymousAvatarProps extends StyledSystemProps, Omit<TempBaseComponentProps<AnonymousAvatarRenderProps>, "children"> {
     /**
      * Whether or not the avatar is disabled.
      */
@@ -29,31 +36,41 @@ function AnonymousAvatar(props: AnonymousAvatarProps, ref: ForwardedRef<HTMLDivE
     const { stylingProps, ...ownProps } = useStyledSystem(props);
     const {
         className,
-        size: sizeValue,
         style,
+        size: sizeValue,
         ...otherProps
     } = ownProps;
 
     const size = useResponsiveValue(sizeValue) ?? "md";
 
-    const classNames = clsx(
+    const classNames = composeClassnameRenderProps(
         className,
         GlobalAnonymousAvatarCssSelector,
         stylingProps.className
     );
 
-    const mergedStyles: CSSProperties = {
-        ...stylingProps.style,
-        ...style
-    };
+    const mergedStyles = composeRenderProps(style, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
 
-    return (        
+    const renderProps = useRenderProps({
+        ...otherProps,
+        className: classNames,
+        style: mergedStyles,
+        values: {
+            isDisabled: props.isDisabled || false
+        }
+    });
+
+
+    return (
         <RichIconAvatarImage
-            {...otherProps}
-            className={classNames}
+            {...mergeProps(otherProps, renderProps)}
             ref={ref}
             size={size}
-            style={mergedStyles}
         >
             <AnonymousRichIcon />
         </RichIconAvatarImage>

--- a/packages/components/src/Avatar/src/Avatar.tsx
+++ b/packages/components/src/Avatar/src/Avatar.tsx
@@ -5,7 +5,7 @@ import { type ForwardedRef, forwardRef, type HTMLProps, type ReactElement, useMe
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { Text, type TextProps } from "../../typography/Text/index.ts";
-import { type BaseComponentRenderProps, composeClassnameRenderProps, cssModule, type SizeAdapter, useRenderProps } from "../../utils/index.ts";
+import { type AccessibleSlotProps, composeClassnameRenderProps, cssModule, type RenderProps, type SizeAdapter, useRenderProps } from "../../utils/index.ts";
 
 import { AvatarContext } from "./AvatarContext.ts";
 import { RichIconAvatarImage } from "./RichIconAvatarImage.tsx";
@@ -25,7 +25,7 @@ interface AvatarRenderProps {
     isDisabled?: boolean;
 }
 
-export interface AvatarProps extends StyledSystemProps, Omit<BaseComponentRenderProps<AvatarRenderProps>, "children"> {
+export interface AvatarProps extends StyledSystemProps, AccessibleSlotProps, Omit<RenderProps<AvatarRenderProps>, "children"> {
     /**
     * The src of the image to display if the image fails to load. If set to null, the initials will be displayed instead.
     * * @default "BrokenImageRichIcon"

--- a/packages/components/src/Avatar/src/Avatar.tsx
+++ b/packages/components/src/Avatar/src/Avatar.tsx
@@ -5,7 +5,7 @@ import { type ForwardedRef, forwardRef, type HTMLProps, type ReactElement, useMe
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { Text, type TextProps } from "../../typography/Text/index.ts";
-import { composeClassnameRenderProps, cssModule, type SizeAdapter, type TempBaseComponentProps, useRenderProps } from "../../utils/index.ts";
+import { type BaseComponentRenderProps, composeClassnameRenderProps, cssModule, type SizeAdapter, useRenderProps } from "../../utils/index.ts";
 
 import { AvatarContext } from "./AvatarContext.ts";
 import { RichIconAvatarImage } from "./RichIconAvatarImage.tsx";
@@ -25,7 +25,7 @@ interface AvatarRenderProps {
     isDisabled?: boolean;
 }
 
-export interface AvatarProps extends StyledSystemProps, Omit<TempBaseComponentProps<AvatarRenderProps>, "children"> {
+export interface AvatarProps extends StyledSystemProps, Omit<BaseComponentRenderProps<AvatarRenderProps>, "children"> {
     /**
     * The src of the image to display if the image fails to load. If set to null, the initials will be displayed instead.
     * * @default "BrokenImageRichIcon"

--- a/packages/components/src/Avatar/src/Avatar.tsx
+++ b/packages/components/src/Avatar/src/Avatar.tsx
@@ -1,12 +1,11 @@
 import { BrokenImageRichIcon } from "@hopper-ui/icons";
-import { type ResponsiveProp, useStyledSystem, type StyledSystemProps, useResponsiveValue } from "@hopper-ui/styled-system";
-import { filterDOMProps } from "@react-aria/utils";
-import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef, useMemo, type HTMLProps, type ReactElement } from "react";
-import { useContextProps } from "react-aria-components";
+import { type ResponsiveProp, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
+import { filterDOMProps, mergeProps } from "@react-aria/utils";
+import { type ForwardedRef, forwardRef, type HTMLProps, type ReactElement, useMemo } from "react";
+import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { Text, type TextProps } from "../../typography/Text/index.ts";
-import { type SizeAdapter, cssModule, type BaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, type SizeAdapter, type TempBaseComponentProps, useRenderProps } from "../../utils/index.ts";
 
 import { AvatarContext } from "./AvatarContext.ts";
 import { RichIconAvatarImage } from "./RichIconAvatarImage.tsx";
@@ -18,7 +17,15 @@ export const GlobalAvatarCssSelector = "hop-Avatar";
 export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
 
 type AvatarImageBaseProps = HTMLProps<HTMLImageElement>;
-export interface AvatarProps extends StyledSystemProps, BaseComponentProps {
+
+interface AvatarRenderProps {
+    /**
+     * Whether or not the avatar is disabled.
+     */
+    isDisabled?: boolean;
+}
+
+export interface AvatarProps extends StyledSystemProps, Omit<TempBaseComponentProps<AvatarRenderProps>, "children"> {
     /**
     * The src of the image to display if the image fails to load. If set to null, the initials will be displayed instead.
     * * @default "BrokenImageRichIcon"
@@ -87,11 +94,11 @@ export interface AvatarInitialsProps {
 }
 
 function AvatarInitials(props: AvatarInitialsProps) {
-    const { 
+    const {
         name,
         size: sizeValue
     } = props;
-    
+
     const size = useResponsiveValue(sizeValue) ?? "md";
 
     const initials = useMemo(() => {
@@ -119,7 +126,6 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
     const { stylingProps, ...ownProps } = useStyledSystem(props);
     const {
         "aria-label": ariaLabel,
-        className,
         fallbackSrc,
         imageProps,
         isDisabled,
@@ -127,11 +133,12 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
         size: sizeValue,
         slot,
         src,
+        className,
         style,
         ...otherProps
     } = ownProps;
     const domProps = filterDOMProps(otherProps);
-    
+
     const { onError, onLoad, ...otherImageProps } = imageProps ?? {};
     const { imageUrl, status } = useImageFallback({ src, fallbackSrc, onError, onLoad });
     const imageLoaded = status === "loaded";
@@ -142,7 +149,7 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
     const isImage = src && !imageFailed;
     const isInitials = !src || (src && imageFailed && fallbackSrc === null);
 
-    const classNames = clsx(
+    const classNames = composeClassnameRenderProps(
         className,
         GlobalAvatarCssSelector,
         cssModule(
@@ -156,22 +163,31 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
         stylingProps.className
     );
 
-    const mergedStyles: CSSProperties = {
-        ...stylingProps.style,
-        ...style
-    };
+    const mergedStyles = composeRenderProps(style, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
+
+    const renderProps = useRenderProps<AvatarRenderProps>({
+        ...props,
+        className: classNames,
+        style: mergedStyles,
+        values: {
+            isDisabled: isDisabled || false
+        }
+    });
 
     if (imageFailed && fallbackSrc !== null) {
         return (
             <RichIconAvatarImage
-                {...domProps}
+                {...mergeProps(domProps, renderProps)}
                 aria-label={ariaLabel ?? name}
-                className={classNames}
                 isDisabled={isDisabled}
                 ref={ref}
                 size={size}
                 slot={slot}
-                style={mergedStyles}
             >
                 <BrokenImageRichIcon />
             </RichIconAvatarImage>
@@ -187,7 +203,7 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
             size={size}
         />;
     }
-    
+
     if (imageLoaded) {
         content = <img
             {...filterDOMProps(otherImageProps)}
@@ -198,17 +214,15 @@ function Avatar(props: AvatarProps, ref: ForwardedRef<HTMLDivElement>) {
             src={imageUrl}
         />;
     }
-    
+
     return (
         <div
-            {...domProps}
+            {...mergeProps(domProps, renderProps)}
             aria-label={ariaLabel ?? name}
-            className={classNames}
             data-disabled={isDisabled || undefined}
             role="img"
             slot={slot ?? undefined}
             ref={ref}
-            style={mergedStyles}
         >
             {content}
         </div>

--- a/packages/components/src/Avatar/src/DeletedAvatar.tsx
+++ b/packages/components/src/Avatar/src/DeletedAvatar.tsx
@@ -4,7 +4,7 @@ import { type ForwardedRef, forwardRef } from "react";
 import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { type BaseComponentRenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
+import { type AccessibleSlotProps, type RenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -20,7 +20,7 @@ interface DeletedAvatarRenderProps {
 }
 
 
-export interface DeletedAvatarProps extends StyledSystemProps, Omit<BaseComponentRenderProps<DeletedAvatarRenderProps>, "children"> {
+export interface DeletedAvatarProps extends StyledSystemProps, AccessibleSlotProps, Omit<RenderProps<DeletedAvatarRenderProps>, "children"> {
     /**
      * Whether or not the avatar is disabled.
      */

--- a/packages/components/src/Avatar/src/DeletedAvatar.tsx
+++ b/packages/components/src/Avatar/src/DeletedAvatar.tsx
@@ -4,7 +4,7 @@ import { type ForwardedRef, forwardRef } from "react";
 import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { composeClassnameRenderProps, type TempBaseComponentProps, useRenderProps } from "../../utils/index.ts";
+import { type BaseComponentRenderProps, composeClassnameRenderProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -20,7 +20,7 @@ interface DeletedAvatarRenderProps {
 }
 
 
-export interface DeletedAvatarProps extends StyledSystemProps, Omit<TempBaseComponentProps<DeletedAvatarRenderProps>, "children"> {
+export interface DeletedAvatarProps extends StyledSystemProps, Omit<BaseComponentRenderProps<DeletedAvatarRenderProps>, "children"> {
     /**
      * Whether or not the avatar is disabled.
      */

--- a/packages/components/src/Avatar/src/DeletedAvatar.tsx
+++ b/packages/components/src/Avatar/src/DeletedAvatar.tsx
@@ -1,10 +1,10 @@
 import { DeletedUserRichIcon } from "@hopper-ui/icons";
-import { type ResponsiveProp, useStyledSystem, type StyledSystemProps, useResponsiveValue } from "@hopper-ui/styled-system";
-import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
-import { useContextProps } from "react-aria-components";
+import { type ResponsiveProp, type StyledSystemProps, useResponsiveValue, useStyledSystem } from "@hopper-ui/styled-system";
+import { type ForwardedRef, forwardRef } from "react";
+import { mergeProps } from "react-aria";
+import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, type TempBaseComponentProps, useRenderProps } from "../../utils/index.ts";
 
 import type { AvatarSize } from "./Avatar.tsx";
 import { AvatarContext } from "./AvatarContext.ts";
@@ -12,7 +12,15 @@ import { RichIconAvatarImage } from "./RichIconAvatarImage.tsx";
 
 export const GlobalDeletedAvatarCssSelector = "hop-DeletedAvatar";
 
-export interface DeletedAvatarProps extends StyledSystemProps, BaseComponentProps {
+interface DeletedAvatarRenderProps {
+    /**
+     * Whether or not the avatar is disabled.
+     */
+    isDisabled?: boolean;
+}
+
+
+export interface DeletedAvatarProps extends StyledSystemProps, Omit<TempBaseComponentProps<DeletedAvatarRenderProps>, "children"> {
     /**
      * Whether or not the avatar is disabled.
      */
@@ -31,29 +39,40 @@ function DeletedAvatar(props: DeletedAvatarProps, ref: ForwardedRef<HTMLDivEleme
         className,
         size: sizeValue,
         style,
+        isDisabled,
         ...otherProps
     } = ownProps;
 
     const size = useResponsiveValue(sizeValue) ?? "md";
 
-    const classNames = clsx(
+    const classNames = composeClassnameRenderProps(
         className,
         GlobalDeletedAvatarCssSelector,
         stylingProps.className
     );
 
-    const mergedStyles: CSSProperties = {
-        ...stylingProps.style,
-        ...style
-    };
+    const mergedStyles = composeRenderProps(style, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
 
-    return (        
+    const renderProps = useRenderProps<DeletedAvatarRenderProps>({
+        ...props,
+        className: classNames,
+        style: mergedStyles,
+        values: {
+            isDisabled: isDisabled || false
+        }
+    });
+
+    return (
         <RichIconAvatarImage
-            {...otherProps}
-            className={classNames}
+            {...mergeProps(otherProps, renderProps)}
+            isDisabled={isDisabled}
             ref={ref}
             size={size}
-            style={mergedStyles}
         >
             <DeletedUserRichIcon />
         </RichIconAvatarImage>

--- a/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
+++ b/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type ForwardedRef, type HTMLAttributes } from "react";
 import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { SlotProvider, composeClassnameRenderProps, cssModule, useRenderProps, type BaseComponentRenderProps, type SizeAdapter } from "../../utils/index.ts";
+import { SlotProvider, composeClassnameRenderProps, cssModule, useRenderProps, type AccessibleSlotProps, type RenderProps, type SizeAdapter } from "../../utils/index.ts";
 
 import type { AvatarProps, AvatarSize } from "./Avatar.tsx";
 import { RichIconAvatarImageContext } from "./RichIconAvatarImageContext.ts";
@@ -22,7 +22,7 @@ interface RichIconAvatarImageRenderProps {
 
 type OmittedDivProps = "slot" | "content" | "color" | "children" | "className" | "style";
 
-export interface RichIconAvatarImageProps extends StyledSystemProps, BaseComponentRenderProps<RichIconAvatarImageRenderProps>, Omit<HTMLAttributes<HTMLDivElement>, OmittedDivProps> {
+export interface RichIconAvatarImageProps extends StyledSystemProps, AccessibleSlotProps, RenderProps<RichIconAvatarImageRenderProps>, Omit<HTMLAttributes<HTMLDivElement>, OmittedDivProps> {
     /**
      * Whether or not the avatar image is disabled.
      */

--- a/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
+++ b/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type ForwardedRef, type HTMLAttributes } from "react";
 import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
-import { SlotProvider, composeClassnameRenderProps, cssModule, useRenderProps, type SizeAdapter, type TempBaseComponentProps } from "../../utils/index.ts";
+import { SlotProvider, composeClassnameRenderProps, cssModule, useRenderProps, type BaseComponentRenderProps, type SizeAdapter } from "../../utils/index.ts";
 
 import type { AvatarProps, AvatarSize } from "./Avatar.tsx";
 import { RichIconAvatarImageContext } from "./RichIconAvatarImageContext.ts";
@@ -22,7 +22,7 @@ interface RichIconAvatarImageRenderProps {
 
 type OmittedDivProps = "slot" | "content" | "color" | "children" | "className" | "style";
 
-export interface RichIconAvatarImageProps extends StyledSystemProps, TempBaseComponentProps<RichIconAvatarImageRenderProps>, Omit<HTMLAttributes<HTMLDivElement>, OmittedDivProps> {
+export interface RichIconAvatarImageProps extends StyledSystemProps, BaseComponentRenderProps<RichIconAvatarImageRenderProps>, Omit<HTMLAttributes<HTMLDivElement>, OmittedDivProps> {
     /**
      * Whether or not the avatar image is disabled.
      */

--- a/packages/components/src/Avatar/tests/chromatic/AnonymousAvatar.stories.tsx
+++ b/packages/components/src/Avatar/tests/chromatic/AnonymousAvatar.stories.tsx
@@ -28,3 +28,13 @@ export const Default = {
     }
 } satisfies Story;
 
+export const AccessToDisabledState: Story = {
+    render: props => (
+        <AnonymousAvatar
+            {...props}
+            isDisabled
+            style={({ isDisabled }) => isDisabled ? { border: "1px solid red" } : {}}
+        />
+    )
+};
+

--- a/packages/components/src/Avatar/tests/chromatic/Avatar.stories.tsx
+++ b/packages/components/src/Avatar/tests/chromatic/Avatar.stories.tsx
@@ -154,3 +154,16 @@ export const Initials = {
     }
 } satisfies Story;
 
+export const AccessToDisabledState = {
+    render: props => (
+        <Avatar
+            {...props}
+            isDisabled
+            style={({ isDisabled }) => isDisabled ? { border: "1px solid red" } : {}}
+        />
+    ),
+    args: {
+        name: "Gab Seguin"
+    }
+} satisfies Story;
+

--- a/packages/components/src/Avatar/tests/chromatic/DeletedAvatar.stories.tsx
+++ b/packages/components/src/Avatar/tests/chromatic/DeletedAvatar.stories.tsx
@@ -28,3 +28,16 @@ export const Default = {
     }
 } satisfies Story;
 
+export const AccessToDisabledState = {
+    render: props => (
+        <DeletedAvatar
+            {...props}
+            isDisabled
+            style={({ isDisabled }) => isDisabled ? { border: "1px solid red" } : {}}
+        />
+    ),
+    args: {
+        "aria-label": "deleted"
+    }
+} satisfies Story;
+

--- a/packages/components/src/Avatar/tests/jest/AnonymousAvatar.test.tsx
+++ b/packages/components/src/Avatar/tests/jest/AnonymousAvatar.test.tsx
@@ -58,10 +58,10 @@ describe("AnonymousAvatar", () => {
         render(
             <AnonymousAvatar aria-label="Maye Musk" />
         );
-    
+
         expect(await screen.findByLabelText("Maye Musk")).not.toBeNull();
     });
-    
+
     it("should support refs", () => {
         const ref = createRef<HTMLDivElement>();
         render(<AnonymousAvatar aria-label="John Doe" ref={ref} />);
@@ -72,12 +72,17 @@ describe("AnonymousAvatar", () => {
         expect(ref.current instanceof HTMLDivElement).toBeTruthy();
         expect(ref.current?.tagName.toUpperCase()).toBe("DIV");
     });
-    
-    it("should add data-disabled when isDisabled is true", () => {
-        render(<AnonymousAvatar aria-label="John Doe" isDisabled />);
+
+    it("should support disabled state", () => {
+        render(<AnonymousAvatar
+            aria-label="John Doe"
+            isDisabled
+            className={({ isDisabled }) => (isDisabled ? "disabled" : "")}
+        />);
 
         const element = screen.getByRole("img", { name: "John Doe" });
 
         expect(element).toHaveAttribute("data-disabled");
+        expect(element).toHaveClass("disabled");
     });
 });

--- a/packages/components/src/Avatar/tests/jest/Avatar.test.tsx
+++ b/packages/components/src/Avatar/tests/jest/Avatar.test.tsx
@@ -58,18 +58,18 @@ describe("Avatar", () => {
         render(
             <Avatar name="Elon Musk" aria-label="Maye Musk" />
         );
-    
+
         expect(await screen.findByLabelText("Maye Musk")).not.toBeNull();
     });
-    
+
     it("should have the name as the aria-label if no aria-label is provided", async () => {
         render(
             <Avatar name="Elon Musk" />
         );
-    
+
         expect(await screen.findByLabelText("Elon Musk")).not.toBeNull();
     });
-    
+
     it("should support refs", () => {
         const ref = createRef<HTMLDivElement>();
         render(<Avatar name="John Doe" ref={ref} />);
@@ -80,8 +80,8 @@ describe("Avatar", () => {
         expect(ref.current instanceof HTMLDivElement).toBeTruthy();
         expect(ref.current?.tagName.toUpperCase()).toBe("DIV");
     });
-    
-    
+
+
     it("should render the correct initials when no src is set", () => {
         const initials = "JD";
         render(<Avatar name="John Doe" />);
@@ -100,12 +100,17 @@ describe("Avatar", () => {
         expect(element).toHaveTextContent(initials);
     });
 
-    it("should add data-disabled when isDisabled is true", () => {
-        render(<Avatar name="John Doe" isDisabled />);
+    it("should support disabled state", () => {
+        render(<Avatar
+            name="John Doe"
+            isDisabled
+            className={({ isDisabled }) => (isDisabled ? "disabled" : "")}
+        />);
 
         const element = screen.getByRole("img", { name: "John Doe" });
 
         expect(element).toHaveAttribute("data-disabled");
+        expect(element).toHaveClass("disabled");
     });
 });
 
@@ -113,7 +118,7 @@ describe("Avatar - fallback + loading strategy", () => {
     beforeEach(() => {
         jest.useFakeTimers();
     });
-  
+
     afterEach(() => {
         jest.useRealTimers();
         mocks.image().restore();
@@ -123,7 +128,7 @@ describe("Avatar - fallback + loading strategy", () => {
         const mock = mocks.image();
         mock.simulate(["error"]);
         const ref = createRef<HTMLDivElement>();
-        
+
         const src = "https://example.com/image.jpg";
         const name = "John Doe";
         const onErrorFn = jest.fn();

--- a/packages/components/src/Avatar/tests/jest/DeletedAvatar.test.tsx
+++ b/packages/components/src/Avatar/tests/jest/DeletedAvatar.test.tsx
@@ -58,10 +58,10 @@ describe("DeletedAvatar", () => {
         render(
             <DeletedAvatar aria-label="Maye Musk" />
         );
-    
+
         expect(await screen.findByLabelText("Maye Musk")).not.toBeNull();
     });
-    
+
     it("should support refs", () => {
         const ref = createRef<HTMLDivElement>();
         render(<DeletedAvatar aria-label="John Doe" ref={ref} />);
@@ -72,12 +72,17 @@ describe("DeletedAvatar", () => {
         expect(ref.current instanceof HTMLDivElement).toBeTruthy();
         expect(ref.current?.tagName.toUpperCase()).toBe("DIV");
     });
-    
-    it("should add data-disabled when isDisabled is true", () => {
-        render(<DeletedAvatar aria-label="John Doe" isDisabled />);
+
+    it("should support disabled state", () => {
+        render(<DeletedAvatar
+            aria-label="John Doe"
+            isDisabled
+            className={({ isDisabled }) => (isDisabled ? "disabled" : "")}
+        />);
 
         const element = screen.getByRole("img", { name: "John Doe" });
 
         expect(element).toHaveAttribute("data-disabled");
+        expect(element).toHaveClass("disabled");
     });
 });

--- a/packages/components/src/Badge/src/Badge.tsx
+++ b/packages/components/src/Badge/src/Badge.tsx
@@ -1,10 +1,10 @@
 import { useStyledSystem, type StyledSystemProps } from "@hopper-ui/styled-system";
-import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
-import { useContextProps } from "react-aria-components";
+import { forwardRef, type ForwardedRef } from "react";
+import { mergeProps } from "react-aria";
+import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { OverlineText } from "../../typography/OverlineText/index.ts";
-import { ClearContainerSlots, cssModule, type BaseComponentProps } from "../../utils/index.ts";
+import { ClearContainerSlots, composeClassnameRenderProps, cssModule, useRenderProps, type TempBaseComponentProps } from "../../utils/index.ts";
 
 import { BadgeContext, type BadgeContextValue } from "./BadgeContext.ts";
 
@@ -12,7 +12,30 @@ import styles from "./Badge.module.css";
 
 export const GlobalBadgeCssSelector = "hop-Badge";
 
-export interface BadgeProps extends StyledSystemProps, BaseComponentProps {
+interface BadgeRenderProps {
+    /**
+     * Whether or not the badge is disabled.
+     */
+    isDisabled?: boolean;
+    /**
+     * Whether or not the badge is indeterminate and should just be a dot. This will ignore any children.
+    */
+    isIndeterminate?: boolean;
+    /**
+     * Whether or not the badge is hovered.
+     */
+    isHovered?: boolean;
+    /**
+     * Whether or not the badge is pressed.
+     */
+    isPressed?: boolean;
+    /**
+     * Whether or not the badge is selected.
+     */
+    isSelected?: boolean;
+}
+
+export interface BadgeProps extends StyledSystemProps, TempBaseComponentProps<BadgeRenderProps> {
     /**
      * The visual style of the badge.
      * @default "primary"
@@ -34,7 +57,6 @@ function Badge(props: BadgeProps, ref: ForwardedRef<HTMLSpanElement>) {
 
     const { stylingProps, ...ownProps } = useStyledSystem(props);
     const {
-        children,
         className,
         isDisabled,
         isIndeterminate,
@@ -44,9 +66,8 @@ function Badge(props: BadgeProps, ref: ForwardedRef<HTMLSpanElement>) {
         ...otherProps
     } = ownProps;
 
-    const isDot = isIndeterminate || !children;
 
-    const classNames = clsx(
+    const classNames = composeClassnameRenderProps(
         className,
         GlobalBadgeCssSelector,
         cssModule(
@@ -56,19 +77,34 @@ function Badge(props: BadgeProps, ref: ForwardedRef<HTMLSpanElement>) {
         stylingProps.className
     );
 
-    const mergedStyles: CSSProperties = {
-        ...stylingProps.style,
-        ...style
-    };
+    const mergedStyles = composeRenderProps(style, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
+
+    const renderProps = useRenderProps<BadgeRenderProps>({
+        ...props,
+        className: classNames,
+        style: mergedStyles,
+        values: {
+            isDisabled: isDisabled || false,
+            isIndeterminate: isIndeterminate || false,
+            isHovered: isHovered || false,
+            isPressed: isPressed || false,
+            isSelected: isSelected || false
+        }
+    });
+
+    const isDot = isIndeterminate || !renderProps.children;
 
     return (
-        
+
         <ClearContainerSlots>
             <OverlineText
-                {...otherProps}
+                {...mergeProps(otherProps, renderProps)}
                 ref={ref}
-                className={classNames}
-                style={mergedStyles}
                 slot={slot ?? undefined}
                 data-disabled={isDisabled || undefined}
                 aria-disabled={isDisabled || undefined}
@@ -78,7 +114,7 @@ function Badge(props: BadgeProps, ref: ForwardedRef<HTMLSpanElement>) {
                 data-selected={isSelected || undefined}
                 data-variant={variant}
             >
-                {!isDot && children}
+                {!isDot && renderProps.children}
             </OverlineText>
         </ClearContainerSlots>
     );

--- a/packages/components/src/Badge/src/Badge.tsx
+++ b/packages/components/src/Badge/src/Badge.tsx
@@ -4,7 +4,7 @@ import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { OverlineText } from "../../typography/OverlineText/index.ts";
-import { ClearContainerSlots, composeClassnameRenderProps, cssModule, useRenderProps, type BaseComponentRenderProps } from "../../utils/index.ts";
+import { ClearContainerSlots, composeClassnameRenderProps, cssModule, useRenderProps, type AccessibleSlotProps, type RenderProps } from "../../utils/index.ts";
 
 import { BadgeContext, type BadgeContextValue } from "./BadgeContext.ts";
 
@@ -35,7 +35,7 @@ interface BadgeRenderProps {
     isSelected?: boolean;
 }
 
-export interface BadgeProps extends StyledSystemProps, BaseComponentRenderProps<BadgeRenderProps> {
+export interface BadgeProps extends StyledSystemProps, AccessibleSlotProps, RenderProps<BadgeRenderProps> {
     /**
      * The visual style of the badge.
      * @default "primary"

--- a/packages/components/src/Badge/src/Badge.tsx
+++ b/packages/components/src/Badge/src/Badge.tsx
@@ -4,7 +4,7 @@ import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { OverlineText } from "../../typography/OverlineText/index.ts";
-import { ClearContainerSlots, composeClassnameRenderProps, cssModule, useRenderProps, type TempBaseComponentProps } from "../../utils/index.ts";
+import { ClearContainerSlots, composeClassnameRenderProps, cssModule, useRenderProps, type BaseComponentRenderProps } from "../../utils/index.ts";
 
 import { BadgeContext, type BadgeContextValue } from "./BadgeContext.ts";
 
@@ -35,7 +35,7 @@ interface BadgeRenderProps {
     isSelected?: boolean;
 }
 
-export interface BadgeProps extends StyledSystemProps, TempBaseComponentProps<BadgeRenderProps> {
+export interface BadgeProps extends StyledSystemProps, BaseComponentRenderProps<BadgeRenderProps> {
     /**
      * The visual style of the badge.
      * @default "primary"

--- a/packages/components/src/Badge/src/FloatingBadge.tsx
+++ b/packages/components/src/Badge/src/FloatingBadge.tsx
@@ -1,9 +1,9 @@
-import { type ResponsiveProp, useStyledSystem, type StyledSystemProps } from "@hopper-ui/styled-system";
+import { useStyledSystem, type ResponsiveProp, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import { ClearContainerSlots, cssModule, SlotProvider, type BaseComponentProps } from "../../utils/index.ts";
+import { ClearContainerSlots, cssModule, SlotProvider, type BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { BadgeContext } from "./BadgeContext.ts";
 import { FloatingBadgeContext } from "./FloatingBadgeContext.ts";
@@ -15,7 +15,7 @@ export const GlobalFloatingBadgeCssSelector = "hop-FloatingBadge";
 export type FloatingBadgePlacement = "top right" | "bottom right" | "bottom left" | "top left";
 export type FloatingBadgeOverlap = "circular" | "rectangular";
 
-export interface FloatingBadgeProps extends StyledSystemProps, BaseComponentProps {
+export interface FloatingBadgeProps extends StyledSystemProps, BaseComponentDOMProps {
     /**
      * The offset of the badge from the anchor component. [horizontal, vertical]
      */

--- a/packages/components/src/Badge/tests/chromatic/Badge.stories.tsx
+++ b/packages/components/src/Badge/tests/chromatic/Badge.stories.tsx
@@ -73,3 +73,30 @@ export const Styling = {
         </Inline>
     )
 } satisfies Story;
+
+export const AccessToDisabledState = {
+    render: props => (
+        <Inline>
+            <Badge
+                {...props}
+                isDisabled
+                style={({ isDisabled }) => isDisabled ? { border: "1px solid red" } : {}}
+            />
+            <Badge {...props} isDisabled>
+                {({ isDisabled }) => (
+                    isDisabled ? "Disabled" : ""
+                )}
+            </Badge>
+        </Inline>
+    )
+} satisfies Story;
+
+export const AccessToIndeterminateState = {
+    render: props => (
+        <Badge
+            {...props}
+            isIndeterminate
+            style={({ isIndeterminate }) => isIndeterminate ? { border: "1px solid red" } : {}}
+        />
+    )
+} satisfies Story;

--- a/packages/components/src/Badge/tests/jest/Badge.test.tsx
+++ b/packages/components/src/Badge/tests/jest/Badge.test.tsx
@@ -54,11 +54,30 @@ describe("Badge", () => {
         expect(ref.current instanceof HTMLSpanElement).toBeTruthy();
     });
 
-    it("should add proper attributes when disabled", () => {
-        render(<Badge data-testid="badge" isDisabled>12</Badge>);
+    it("should support disabled state", () => {
+        render(<Badge
+            data-testid="badge"
+            isDisabled
+            className={({ isDisabled }) => (isDisabled ? "disabled" : "")}
+        >12</Badge>);
 
         const element = screen.getByTestId("badge");
+
         expect(element).toHaveAttribute("data-disabled");
         expect(element).toHaveAttribute("aria-disabled");
+        expect(element).toHaveClass("disabled");
+    });
+
+    it("should support indeterminate state", () => {
+        render(<Badge
+            data-testid="badge"
+            isIndeterminate
+            className={({ isIndeterminate }) => (isIndeterminate ? "indeterminate" : "")}
+        >12</Badge>);
+
+        const element = screen.getByTestId("badge");
+
+        expect(element).toHaveAttribute("data-indeterminate");
+        expect(element).toHaveClass("indeterminate");
     });
 });

--- a/packages/components/src/Header/src/Header.tsx
+++ b/packages/components/src/Header/src/Header.tsx
@@ -1,15 +1,15 @@
 import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { Header as RACHeader, useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import type { BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { HeaderContext } from "./HeaderContext.ts";
 
 export const GlobalHeaderCssSelector = "hop-Header";
 
-export interface HeaderProps extends StyledComponentProps<BaseComponentProps> {}
+export interface HeaderProps extends StyledComponentProps<BaseComponentDOMProps> {}
 
 function Header(props: HeaderProps, ref: ForwardedRef<HTMLElement>) {
     [props, ref] = useContextProps(props, ref, HeaderContext);

--- a/packages/components/src/IconList/src/IconList.tsx
+++ b/packages/components/src/IconList/src/IconList.tsx
@@ -1,10 +1,10 @@
 import { IconContext } from "@hopper-ui/icons";
-import { useStyledSystem, type StyledSystemProps, type ResponsiveProp } from "@hopper-ui/styled-system";
+import { useStyledSystem, type ResponsiveProp, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import type { BaseComponentDOMProps } from "../../utils/index.ts";
 import { SlotProvider } from "../../utils/index.ts";
 
 import { IconListContext } from "./IconListContext.ts";
@@ -13,7 +13,7 @@ import styles from "./IconList.module.css";
 
 export const GlobalIconListCssSelector = "hop-IconList";
 
-export interface IconListProps extends StyledSystemProps, BaseComponentProps {
+export interface IconListProps extends StyledSystemProps, BaseComponentDOMProps {
     /**
     * The size of the icon.
     */

--- a/packages/components/src/ListBox/src/ListBoxItemSkeleton.tsx
+++ b/packages/components/src/ListBox/src/ListBoxItemSkeleton.tsx
@@ -1,9 +1,9 @@
-import { useStyledSystem, type ResponsiveProp, useResponsiveValue, type StyledSystemProps } from "@hopper-ui/styled-system";
+import { useResponsiveValue, useStyledSystem, type ResponsiveProp, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import { cssModule, type BaseComponentProps } from "../../utils/index.ts";
+import { cssModule, type BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { ListBoxItemSkeletonContext } from "./ListBoxItemSkeletonContext.ts";
 
@@ -13,7 +13,7 @@ export const GlobalListBoxItemSkeletonCssSelector = "hop-ListBoxItemSkeleton";
 
 export type ListBoxItemSize = "xs" | "sm" | "md" | "lg";
 
-export interface ListBoxItemSkeletonProps extends StyledSystemProps, BaseComponentProps {
+export interface ListBoxItemSkeletonProps extends StyledSystemProps, BaseComponentDOMProps {
     /**
      * A ListBoxItem can vary in size.
      * @default "sm"

--- a/packages/components/src/Spinner/src/Spinner.tsx
+++ b/packages/components/src/Spinner/src/Spinner.tsx
@@ -1,15 +1,15 @@
 import {
+    useResponsiveValue,
     useStyledSystem,
     type ResponsiveProp,
-    useResponsiveValue,
     type StyledSystemProps
 } from "@hopper-ui/styled-system";
-import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useId } from "react-aria";
 import { ProgressBar, useContextProps } from "react-aria-components";
 
 import { Text, type TextProps } from "../../typography/Text/index.ts";
-import { composeClassnameRenderProps, cssModule, type SizeAdapter, type BaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, type BaseComponentDOMProps, type SizeAdapter } from "../../utils/index.ts";
 
 import { SpinnerContext } from "./SpinnerContext.ts";
 
@@ -18,7 +18,7 @@ import styles from "./Spinner.module.css";
 export const GlobalSpinnerCssSelector = "hop-Spinner";
 
 // We don't extends RACProgressBarProps here, since we don't want to expose any of the progress bar props.
-export interface SpinnerProps extends StyledSystemProps, BaseComponentProps {
+export interface SpinnerProps extends StyledSystemProps, BaseComponentDOMProps {
     /**
      * What the Spinner's diameter should be.
      * @default "md"
@@ -60,7 +60,7 @@ const Spinner = (props: SpinnerProps, ref: ForwardedRef<HTMLDivElement>) => {
         ...stylingProps.style,
         ...style
     };
-    
+
     const labelId = useId();
 
     const labelMarkup = children && (

--- a/packages/components/src/checkbox/src/CheckboxField.tsx
+++ b/packages/components/src/checkbox/src/CheckboxField.tsx
@@ -9,7 +9,7 @@ import { mergeProps, useId } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { TextContext, type TextProps } from "../../typography/Text/index.ts";
-import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type SizeAdapter, type TempBaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type BaseComponentRenderProps, type SizeAdapter } from "../../utils/index.ts";
 
 import { CheckboxContext } from "./CheckboxContext.ts";
 import { CheckboxFieldContext } from "./CheckboxFieldContext.ts";
@@ -30,7 +30,7 @@ interface CheckboxFieldRenderProps {
     isDisabled?: boolean;
 }
 
-export interface CheckboxFieldProps extends StyledSystemProps, TempBaseComponentProps<CheckboxFieldRenderProps> {
+export interface CheckboxFieldProps extends StyledSystemProps, BaseComponentRenderProps<CheckboxFieldRenderProps> {
     /**
      * Whether the checkbox field is disabled.
      */

--- a/packages/components/src/checkbox/src/CheckboxField.tsx
+++ b/packages/components/src/checkbox/src/CheckboxField.tsx
@@ -1,16 +1,15 @@
 import {
-    type StyledSystemProps,
+    useResponsiveValue,
     useStyledSystem,
     type ResponsiveProp,
-    useResponsiveValue
+    type StyledSystemProps
 } from "@hopper-ui/styled-system";
-import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
-import { useId } from "react-aria";
-import { useContextProps } from "react-aria-components";
+import { forwardRef, type ForwardedRef } from "react";
+import { mergeProps, useId } from "react-aria";
+import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { TextContext, type TextProps } from "../../typography/Text/index.ts";
-import { SlotProvider, type SizeAdapter, cssModule, type BaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type SizeAdapter, type TempBaseComponentProps } from "../../utils/index.ts";
 
 import { CheckboxContext } from "./CheckboxContext.ts";
 import { CheckboxFieldContext } from "./CheckboxFieldContext.ts";
@@ -24,7 +23,14 @@ const CheckboxToDescriptionSizeAdapter: SizeAdapter<CheckboxFieldProps["size"], 
     md: "sm"
 };
 
-export interface CheckboxFieldProps extends StyledSystemProps, BaseComponentProps {
+interface CheckboxFieldRenderProps {
+    /**
+     * Whether the checkbox field is disabled.
+     */
+    isDisabled?: boolean;
+}
+
+export interface CheckboxFieldProps extends StyledSystemProps, TempBaseComponentProps<CheckboxFieldRenderProps> {
     /**
      * Whether the checkbox field is disabled.
      */
@@ -41,7 +47,6 @@ function CheckboxField(props: CheckboxFieldProps, ref: ForwardedRef<HTMLDivEleme
     const { stylingProps, ...ownProps } = useStyledSystem(props);
     const {
         className,
-        children,
         isDisabled,
         size: sizeProp = "md",
         style,
@@ -51,7 +56,7 @@ function CheckboxField(props: CheckboxFieldProps, ref: ForwardedRef<HTMLDivEleme
 
     const size = useResponsiveValue(sizeProp) ?? "md";
 
-    const classNames = clsx(
+    const classNames = composeClassnameRenderProps(
         className,
         GlobalCheckboxFieldCssSelector,
         cssModule(
@@ -62,10 +67,21 @@ function CheckboxField(props: CheckboxFieldProps, ref: ForwardedRef<HTMLDivEleme
         stylingProps.className
     );
 
-    const mergedStyles: CSSProperties = {
-        ...stylingProps.style,
-        ...style
-    };
+    const mergedStyles = composeRenderProps(style, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
+
+    const renderProps = useRenderProps<CheckboxFieldRenderProps>({
+        ...props,
+        className: classNames,
+        style: mergedStyles,
+        values: {
+            isDisabled: isDisabled || false
+        }
+    });
 
     const descriptionId = useId();
 
@@ -86,14 +102,12 @@ function CheckboxField(props: CheckboxFieldProps, ref: ForwardedRef<HTMLDivEleme
             ]}
         >
             <div
-                {...otherProps}
+                {...mergeProps(otherProps, renderProps)}
                 ref={ref}
-                className={classNames}
-                style={mergedStyles}
                 slot={slot ?? undefined}
                 data-disabled={isDisabled}
             >
-                {children}
+                {renderProps.children}
             </div>
         </SlotProvider>
     );

--- a/packages/components/src/checkbox/src/CheckboxField.tsx
+++ b/packages/components/src/checkbox/src/CheckboxField.tsx
@@ -9,7 +9,7 @@ import { mergeProps, useId } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { TextContext, type TextProps } from "../../typography/Text/index.ts";
-import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type BaseComponentRenderProps, type SizeAdapter } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type AccessibleSlotProps, type RenderProps, type SizeAdapter } from "../../utils/index.ts";
 
 import { CheckboxContext } from "./CheckboxContext.ts";
 import { CheckboxFieldContext } from "./CheckboxFieldContext.ts";
@@ -30,7 +30,7 @@ interface CheckboxFieldRenderProps {
     isDisabled?: boolean;
 }
 
-export interface CheckboxFieldProps extends StyledSystemProps, BaseComponentRenderProps<CheckboxFieldRenderProps> {
+export interface CheckboxFieldProps extends StyledSystemProps, AccessibleSlotProps, RenderProps<CheckboxFieldRenderProps> {
     /**
      * Whether the checkbox field is disabled.
      */

--- a/packages/components/src/checkbox/src/CheckboxList.tsx
+++ b/packages/components/src/checkbox/src/CheckboxList.tsx
@@ -1,15 +1,15 @@
-import { type StyledSystemProps, useStyledSystem } from "@hopper-ui/styled-system";
+import { useStyledSystem, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import type { BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { CheckboxListContext } from "./CheckboxListContext.ts";
 
 export const GlobalCheckboxListCssSelector = "hop-CheckboxList";
 
-export interface CheckboxListProps extends StyledSystemProps, BaseComponentProps {}
+export interface CheckboxListProps extends StyledSystemProps, BaseComponentDOMProps {}
 
 function CheckboxList(props:CheckboxListProps, ref: ForwardedRef<HTMLDivElement>) {
     [props, ref] = useContextProps(props, ref, CheckboxListContext);

--- a/packages/components/src/checkbox/tests/chromatic/CheckboxField.stories.tsx
+++ b/packages/components/src/checkbox/tests/chromatic/CheckboxField.stories.tsx
@@ -105,3 +105,30 @@ export const Zoom: Story = {
         </Stack>
     )
 };
+
+export const AccessToDisabledState: Story = {
+    render: props => (
+        <Inline alignY="end">
+            <CheckboxField {...props} isDisabled>
+                {({ isDisabled }) => (
+                    <>
+                        <Checkbox>
+                            <Text>Value should be true</Text>
+                        </Checkbox>
+                        <Text slot="description">Is disabled: {String(isDisabled)}</Text>
+                    </>
+                )}
+            </CheckboxField>
+            <CheckboxField
+                {...props}
+                isDisabled
+                style={({ isDisabled }) => isDisabled ? { border: "1px solid red" } : {}}
+            >
+                <Checkbox>
+                    <Text>Disabled</Text>
+                </Checkbox>
+                <Text slot="description">Border should be red</Text>
+            </CheckboxField>
+        </Inline>
+    )
+};

--- a/packages/components/src/checkbox/tests/jest/CheckboxField.test.tsx
+++ b/packages/components/src/checkbox/tests/jest/CheckboxField.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable testing-library/no-node-access */
 /* Using closest to get the label is the best way, even react-aria does this. */
-import { screen, render } from "@hopper-ui/test-utils";
+import { render, screen } from "@hopper-ui/test-utils";
 import { createRef } from "react";
 
 import { Text } from "../../../typography/Text/src/Text.tsx";
@@ -97,15 +97,23 @@ describe("Checkbox", () => {
         expect(checkbox).toHaveAttribute("aria-describedby", descriptionId);
     });
 
-    it("should be disabled and pass it to the checkbox", () => {
-        render(<CheckboxField data-testid={testId} isDisabled><Checkbox>option 1</Checkbox><Text
-            slot="description"
-        >description</Text></CheckboxField>);
+    it("should support disabled state", () => {
+        render(
+            <CheckboxField
+                data-testid={testId}
+                isDisabled
+                className={({ isDisabled }) => (isDisabled ? "disabled" : "")}
+            >
+                <Checkbox>option 1</Checkbox>
+                <Text slot="description">description</Text>
+            </CheckboxField>
+        );
 
         const element = screen.getByTestId(testId);
         const checkbox = screen.getByRole("checkbox");
 
         expect(element).toHaveAttribute("data-disabled", "true");
+        expect(element).toHaveClass("disabled");
         expect(checkbox).toBeDisabled();
     });
 });

--- a/packages/components/src/layout/src/Content.tsx
+++ b/packages/components/src/layout/src/Content.tsx
@@ -1,15 +1,15 @@
 import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import type { BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { ContentContext } from "./ContentContext.ts";
 
 export const GlobalContentCssSelector = "hop-Content";
 
-export interface ContentProps extends StyledComponentProps<BaseComponentProps> {
+export interface ContentProps extends StyledComponentProps<BaseComponentDOMProps> {
 }
 
 function Content(props: ContentProps, ref: ForwardedRef<HTMLDivElement>) {

--- a/packages/components/src/layout/src/Footer.tsx
+++ b/packages/components/src/layout/src/Footer.tsx
@@ -1,15 +1,15 @@
 import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import type { BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { FooterContext } from "./FooterContext.ts";
 
 export const GlobalFooterCssSelector = "hop-Footer";
 
-export interface FooterProps extends StyledComponentProps<BaseComponentProps> {}
+export interface FooterProps extends StyledComponentProps<BaseComponentDOMProps> {}
 
 function Footer(props: FooterProps, ref: ForwardedRef<HTMLElement>) {
     [props, ref] = useContextProps(props, ref, FooterContext);

--- a/packages/components/src/overlays/Popover/src/Popover.tsx
+++ b/packages/components/src/overlays/Popover/src/Popover.tsx
@@ -1,27 +1,29 @@
 import {
-    composeClassnameRenderProps,
-    SlotProvider,
-    cssModule,
     ButtonContext,
     ButtonGroupContext,
+    composeClassnameRenderProps,
     ContentContext,
+    cssModule,
     FooterContext,
     HeadingContext,
+    HopperProvider,
+    isFunction,
+    isNil,
     LinkContext,
-    HopperProvider, isNil, isFunction,
     ListBoxContext,
-    type BaseComponentProps
+    SlotProvider,
+    type BaseComponentDOMProps
 } from "@hopper-ui/components";
-import { type StyledComponentProps, useStyledSystem, useColorSchemeContext, type StyledSystemProps, type ResponsiveProp, useResponsiveValue } from "@hopper-ui/styled-system";
+import { useColorSchemeContext, useResponsiveValue, useStyledSystem, type ResponsiveProp, type StyledComponentProps, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
 import { forwardRef, type ForwardedRef } from "react";
 import type { Placement } from "react-aria";
 import {
-    useContextProps,
-    type PopoverProps as RACPopoverProps,
-    Popover as RACPopover,
+    composeRenderProps,
     Dialog,
-    composeRenderProps
+    Popover as RACPopover,
+    useContextProps,
+    type PopoverProps as RACPopoverProps
 } from "react-aria-components";
 
 import { PopoverContext } from "./PopoverContext.ts";
@@ -29,7 +31,7 @@ import { PopoverContext } from "./PopoverContext.ts";
 import styles from "./Popover.module.css";
 
 export const GlobalPopoverCssSelector = "hop-Popover";
-export type PopoverContainerProps = BaseComponentProps & StyledSystemProps;
+export type PopoverContainerProps = BaseComponentDOMProps & StyledSystemProps;
 export type PopoverPlacement = Placement;
 export type PopoverPlacementProp = ResponsiveProp<PopoverPlacement>;
 
@@ -73,7 +75,7 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
         style: styleProp,
         ...otherProps
     } = ownProps;
-    
+
     const placement = useResponsiveValue(placementProp) ?? "bottom";
     const { stylingProps: containerStylingProps, ...containerOwnProps } = useStyledSystem(containerProps ?? {});
     const {
@@ -127,11 +129,11 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
         >
             {state => {
                 const content = (isFunction(children) && !isNil(children)) ? children(state) : children;
-                
+
                 if (isNonDialog) {
                     return (
                         <HopperProvider colorScheme={colorScheme} className={styles["hop-Popover__wrapper"]}>
-                            <div 
+                            <div
                                 {...containerOtherProps}
                                 className={containerClassNames}
                                 style={containerStyle}

--- a/packages/components/src/radio/src/RadioField.tsx
+++ b/packages/components/src/radio/src/RadioField.tsx
@@ -15,8 +15,8 @@ import {
     cssModule,
     SlotProvider,
     useRenderProps,
-    type SizeAdapter,
-    type TempBaseComponentProps
+    type BaseComponentRenderProps,
+    type SizeAdapter
 } from "../../utils/index.ts";
 
 import { RadioContext } from "./RadioContext.ts";
@@ -38,7 +38,7 @@ interface RadioFieldRenderProps {
     isDisabled?: boolean;
 }
 
-export interface RadioFieldProps extends StyledSystemProps, TempBaseComponentProps<RadioFieldRenderProps> {
+export interface RadioFieldProps extends StyledSystemProps, BaseComponentRenderProps<RadioFieldRenderProps> {
     /**
      * Whether the radio field is disabled.
      */

--- a/packages/components/src/radio/src/RadioField.tsx
+++ b/packages/components/src/radio/src/RadioField.tsx
@@ -15,7 +15,8 @@ import {
     cssModule,
     SlotProvider,
     useRenderProps,
-    type BaseComponentRenderProps,
+    type AccessibleSlotProps,
+    type RenderProps,
     type SizeAdapter
 } from "../../utils/index.ts";
 
@@ -38,7 +39,7 @@ interface RadioFieldRenderProps {
     isDisabled?: boolean;
 }
 
-export interface RadioFieldProps extends StyledSystemProps, BaseComponentRenderProps<RadioFieldRenderProps> {
+export interface RadioFieldProps extends StyledSystemProps, AccessibleSlotProps, RenderProps<RadioFieldRenderProps> {
     /**
      * Whether the radio field is disabled.
      */

--- a/packages/components/src/radio/src/RadioField.tsx
+++ b/packages/components/src/radio/src/RadioField.tsx
@@ -1,21 +1,22 @@
 import {
-    type StyledSystemProps,
+    useResponsiveValue,
     useStyledSystem,
     type ResponsiveProp,
-    useResponsiveValue
+    type StyledSystemProps
 } from "@hopper-ui/styled-system";
-import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
-import { useId } from "react-aria";
-import { useContextProps } from "react-aria-components";
+import { forwardRef, type ForwardedRef } from "react";
+import { mergeProps, useId } from "react-aria";
+import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { TextContext, type TextProps } from "../../typography/Text/index.ts";
 import {
-    SlotProvider,
-    type SizeAdapter,
+    ClearContainerSlots,
+    composeClassnameRenderProps,
     cssModule,
-    type BaseComponentProps,
-    ClearContainerSlots
+    SlotProvider,
+    useRenderProps,
+    type SizeAdapter,
+    type TempBaseComponentProps
 } from "../../utils/index.ts";
 
 import { RadioContext } from "./RadioContext.ts";
@@ -30,7 +31,14 @@ const RadioToDescriptionSizeAdapter: SizeAdapter<RadioFieldProps["size"], TextPr
     md: "sm"
 };
 
-export interface RadioFieldProps extends StyledSystemProps, BaseComponentProps {
+interface RadioFieldRenderProps {
+    /**
+     * Whether the radio field is disabled.
+     */
+    isDisabled?: boolean;
+}
+
+export interface RadioFieldProps extends StyledSystemProps, TempBaseComponentProps<RadioFieldRenderProps> {
     /**
      * Whether the radio field is disabled.
      */
@@ -47,7 +55,6 @@ function RadioField(props: RadioFieldProps, ref: ForwardedRef<HTMLDivElement>) {
     const { stylingProps, ...ownProps } = useStyledSystem(props);
     const {
         className,
-        children,
         isDisabled,
         size: sizeProp = "md",
         style,
@@ -57,7 +64,7 @@ function RadioField(props: RadioFieldProps, ref: ForwardedRef<HTMLDivElement>) {
 
     const size = useResponsiveValue(sizeProp) ?? "md";
 
-    const classNames = clsx(
+    const classNames = composeClassnameRenderProps(
         className,
         GlobalRadioFieldCssSelector,
         cssModule(
@@ -68,10 +75,21 @@ function RadioField(props: RadioFieldProps, ref: ForwardedRef<HTMLDivElement>) {
         stylingProps.className
     );
 
-    const mergedStyles: CSSProperties = {
-        ...stylingProps.style,
-        ...style
-    };
+    const mergedStyles = composeRenderProps(style, prev => {
+        return {
+            ...stylingProps.style,
+            ...prev
+        };
+    });
+
+    const renderProps = useRenderProps<RadioFieldRenderProps>({
+        ...props,
+        className: classNames,
+        style: mergedStyles,
+        values: {
+            isDisabled: isDisabled || false
+        }
+    });
 
     const descriptionId = useId();
 
@@ -93,14 +111,12 @@ function RadioField(props: RadioFieldProps, ref: ForwardedRef<HTMLDivElement>) {
                 ]}
             >
                 <div
-                    {...otherProps}
+                    {...mergeProps(otherProps, renderProps)}
                     ref={ref}
-                    className={classNames}
-                    style={mergedStyles}
                     slot={slot ?? undefined}
                     data-disabled={isDisabled}
                 >
-                    {children}
+                    {renderProps.children}
                 </div>
             </SlotProvider>
         </ClearContainerSlots>

--- a/packages/components/src/radio/src/RadioList.tsx
+++ b/packages/components/src/radio/src/RadioList.tsx
@@ -1,15 +1,15 @@
-import { type StyledSystemProps, useStyledSystem } from "@hopper-ui/styled-system";
+import { useStyledSystem, type StyledSystemProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { useContextProps } from "react-aria-components";
 
-import type { BaseComponentProps } from "../../utils/index.ts";
+import type { BaseComponentDOMProps } from "../../utils/index.ts";
 
 import { RadioListContext } from "./RadioListContext.ts";
 
 export const GlobalRadioListCssSelector = "hop-RadioList";
 
-export interface RadioListProps extends StyledSystemProps, BaseComponentProps {}
+export interface RadioListProps extends StyledSystemProps, BaseComponentDOMProps {}
 
 function RadioList(props:RadioListProps, ref: ForwardedRef<HTMLDivElement>) {
     [props, ref] = useContextProps(props, ref, RadioListContext);

--- a/packages/components/src/switch/src/SwitchField.tsx
+++ b/packages/components/src/switch/src/SwitchField.tsx
@@ -9,7 +9,7 @@ import { mergeProps, useId } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { TextContext, type TextProps } from "../../typography/Text/index.ts";
-import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type BaseComponentRenderProps, type SizeAdapter } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type AccessibleSlotProps, type RenderProps, type SizeAdapter } from "../../utils/index.ts";
 
 import { SwitchContext } from "./SwitchContext.ts";
 import { SwitchFieldContext } from "./SwitchFieldContext.ts";
@@ -30,7 +30,7 @@ interface SwitchFieldRenderProps {
     isDisabled?: boolean;
 }
 
-export interface SwitchFieldProps extends BaseComponentRenderProps<SwitchFieldRenderProps>, StyledSystemProps {
+export interface SwitchFieldProps extends RenderProps<SwitchFieldRenderProps>, StyledSystemProps, AccessibleSlotProps {
     /**
      * A switch field can vary in size.
      * @default "md"

--- a/packages/components/src/switch/src/SwitchField.tsx
+++ b/packages/components/src/switch/src/SwitchField.tsx
@@ -9,7 +9,7 @@ import { mergeProps, useId } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { TextContext, type TextProps } from "../../typography/Text/index.ts";
-import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type SizeAdapter, type TempBaseComponentProps } from "../../utils/index.ts";
+import { composeClassnameRenderProps, cssModule, SlotProvider, useRenderProps, type BaseComponentRenderProps, type SizeAdapter } from "../../utils/index.ts";
 
 import { SwitchContext } from "./SwitchContext.ts";
 import { SwitchFieldContext } from "./SwitchFieldContext.ts";
@@ -30,7 +30,7 @@ interface SwitchFieldRenderProps {
     isDisabled?: boolean;
 }
 
-export interface SwitchFieldProps extends TempBaseComponentProps<SwitchFieldRenderProps>, StyledSystemProps {
+export interface SwitchFieldProps extends BaseComponentRenderProps<SwitchFieldRenderProps>, StyledSystemProps {
     /**
      * A switch field can vary in size.
      * @default "md"

--- a/packages/components/src/switch/tests/chromatic/SwitchField.stories.tsx
+++ b/packages/components/src/switch/tests/chromatic/SwitchField.stories.tsx
@@ -94,7 +94,7 @@ export const AccessToDisabledState: Story = {
                 {({ isDisabled }) => (
                     <>
                         <Switch>
-                            <Text>Disabled</Text>
+                            <Text>Should be true</Text>
                         </Switch>
                         <Text slot="description">Is disabled: {String(isDisabled)}</Text>
                     </>
@@ -109,7 +109,7 @@ export const AccessToDisabledState: Story = {
                 <Switch>
                     <Text>Disable and red border</Text>
                 </Switch>
-                <Text slot="description">Border is red when disabled</Text>
+                <Text slot="description">Border should be red</Text>
             </SwitchField>
         </Inline>
     )

--- a/packages/components/src/utils/src/types.ts
+++ b/packages/components/src/utils/src/types.ts
@@ -38,12 +38,11 @@ export interface RenderPropsHookOptions<T> extends RenderProps<T>, SharedDOMProp
 }
 
 // TODO: i added this, not sure if it will make sense
-export interface BaseComponentProps extends DOMProps, AriaLabelingProps, SlotProps {
+export interface BaseComponentDOMProps extends DOMProps, AriaLabelingProps, SlotProps {
 
 }
 
-// TODO: For a incremental transition, we can start with TempBaseComponentProps, will rename to BaseComponentProps when migration is complete
-export interface TempBaseComponentProps<T> extends RenderProps<T>, AriaLabelingProps, SlotProps {
+export interface BaseComponentRenderProps<T> extends RenderProps<T>, AriaLabelingProps, SlotProps {
 
 }
 

--- a/packages/components/src/utils/src/types.ts
+++ b/packages/components/src/utils/src/types.ts
@@ -39,7 +39,6 @@ export interface RenderPropsHookOptions<T> extends RenderProps<T>, SharedDOMProp
     defaultStyle?: CSSProperties;
 }
 
-// TODO: i added this, not sure if it will make sense
 export type BaseComponentDOMProps = DOMProps & AccessibleSlotProps;
 
 /** Added these for when we need to force an interactive state like for radios inside list box items */

--- a/packages/components/src/utils/src/types.ts
+++ b/packages/components/src/utils/src/types.ts
@@ -18,6 +18,8 @@ export interface DOMProps extends StyleProps, SharedDOMProps {
     children?: ReactNode;
 }
 
+export type AccessibleSlotProps = AriaLabelingProps & SlotProps;
+
 export interface StyleRenderProps<T> {
     /** The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state. */
     className?: string | ((values: T & { defaultClassName: string | undefined }) => string);
@@ -38,13 +40,7 @@ export interface RenderPropsHookOptions<T> extends RenderProps<T>, SharedDOMProp
 }
 
 // TODO: i added this, not sure if it will make sense
-export interface BaseComponentDOMProps extends DOMProps, AriaLabelingProps, SlotProps {
-
-}
-
-export interface BaseComponentRenderProps<T> extends RenderProps<T>, AriaLabelingProps, SlotProps {
-
-}
+export type BaseComponentDOMProps = DOMProps & AccessibleSlotProps;
 
 /** Added these for when we need to force an interactive state like for radios inside list box items */
 export interface InteractionProps {


### PR DESCRIPTION
Standardizing className, style and children Props for BaseComponentProps.

Renamed BaseComponentProps to BaseComponentDOMProps when it uses DOMProps 
When a component needs to use RenderProps instead, we should use BaseComponentRenderProps