### PR TITLE
[DS-330] Simplify import of css files for components

### DIFF
--- a/.changeset/slimy-guests-move.md
+++ b/.changeset/slimy-guests-move.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Simplify import of CSS

--- a/apps/docs/content/getting-started/react.mdx
+++ b/apps/docs/content/getting-started/react.mdx
@@ -41,15 +41,7 @@ root.render(
 Add Hopper styles to your project by importing the following CSS files:
 
 ```css
-@import "@hopper-ui/styled-system/index.css";
 @import "@hopper-ui/components/index.css";
-@import "@hopper-ui/icons/index.css";
-```
-
-Add Hopper fonts to your project by importing the following CSS file:
-
-```css
-@import "@hopper-ui/tokens/fonts.css";
 ```
 
 Font-face declarations are now imported in your project.

--- a/packages/components/src/index.css
+++ b/packages/components/src/index.css
@@ -1,0 +1,3 @@
+@import url("@hopper-ui/icons/index.css");
+@import url("@hopper-ui/tokens/fonts.css");
+@import url("@hopper-ui/styled-system/index.css");

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -26,7 +26,9 @@ export * from "./typography/OverlineText/index.ts";
 export * from "./typography/Text/index.ts";
 export * from "./utils/index.ts";
 
-export { Collection, type Selection, type Key } from "react-aria-components";
+export { Collection, type Key, type Selection } from "react-aria-components";
 export { useAsyncList } from "react-stately";
 
 export * from "@hopper-ui/styled-system";
+
+import "./index.css";


### PR DESCRIPTION
This adds these imports directly in the built `index.css` of the components package.

```css
@import url("@hopper-ui/icons/index.css");
@import url("@hopper-ui/tokens/fonts.css");
@import url("@hopper-ui/styled-system/index.css");
```

![index css](https://github.com/user-attachments/assets/a7785306-3fc7-4e90-82af-b359ec45a72f)
![index css 2](https://github.com/user-attachments/assets/dcb00fd0-53b6-4462-82a6-6f6a398bdea6)