### PR TITLE
fixed an accessibility alert due to the provider not having the right value in dark mode

### DIFF
--- a/packages/components/src/Link/docs/Link.stories.tsx
+++ b/packages/components/src/Link/docs/Link.stories.tsx
@@ -1,3 +1,4 @@
+import { useColorSchemeContext } from "@hopper-ui/components";
 import { SparklesIcon } from "@hopper-ui/icons";
 import { Div } from "@hopper-ui/styled-system";
 import type { Meta, StoryObj } from "@storybook/react";
@@ -36,6 +37,12 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+function GetColorScheme() {
+    const colorScheme = useColorSchemeContext();
+
+    return colorScheme;
+}
 
 /**
  * A default link
@@ -205,9 +212,10 @@ export const ReactRouterLink: Story = {
     render: props => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const navigate = useNavigate();
+        const { colorScheme: parentColorScheme } = GetColorScheme();
 
         return (
-            <HopperProvider colorScheme="light" navigate={navigate}>
+            <HopperProvider colorScheme={parentColorScheme} navigate={navigate}>
                 <Link {...props} />
             </HopperProvider>
         );


### PR DESCRIPTION
Since `navigate` needs an HopperProvider to work, the current story was forcing a light colorScheme instead of using the parent colorScheme, causing an accessibility issue according to the Storybook plugin. This was not the case, the issue was that the light theme was applied to the dark mode.