### PR TITLE
Added hop-dataviz-categorical-sequence-category11-hover token

### DIFF
--- a/.changeset/odd-laws-fetch.md
+++ b/.changeset/odd-laws-fetch.md
@@ -1,0 +1,6 @@
+---
+"@hopper-ui/styled-system": minor
+"@hopper-ui/tokens": minor
+---
+
+Added hop-dataviz-categorical-sequence-category11-hover token

--- a/apps/docs/datas/tokens.json
+++ b/apps/docs/datas/tokens.json
@@ -3630,6 +3630,10 @@
         "value": "#ffac70"
       },
       {
+        "name": "hop-dataviz-categorical-sequence-category11-hover",
+        "value": "#ffac70"
+      },
+      {
         "name": "hop-dataviz-categorical-sequence-category12",
         "value": "#a0b8fa"
       },

--- a/packages/styled-system/src/tokens/generated/lightSemanticTokens.ts
+++ b/packages/styled-system/src/tokens/generated/lightSemanticTokens.ts
@@ -926,7 +926,7 @@ export const SemanticTokens = {
     "--hop-dataviz-categorical-sequence-category10": "#aecdd5",
     "--hop-dataviz-categorical-sequence-category10-hover": "#93bdc8",
     "--hop-dataviz-categorical-sequence-category11": "#ffbf92",
-    "--hop-dataviz-categorical-sequence-category-11-hover": "#ffac70",
+    "--hop-dataviz-categorical-sequence-category11-hover": "#ffac70",
     "--hop-dataviz-categorical-sequence-category12": "#a0b8fa",
     "--hop-dataviz-categorical-sequence-category12-hover": "#779af8",
     "--hop-dataviz-categorical-sequence-category13": "#69bfa0",

--- a/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
+++ b/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
@@ -861,7 +861,7 @@ export const DataVizColors = {
     "dataviz_categorical-sequence-category10": "dataviz-categorical-sequence-category10",
     "dataviz_categorical-sequence-category10-hover": "dataviz-categorical-sequence-category10-hover",
     "dataviz_categorical-sequence-category11": "dataviz-categorical-sequence-category11",
-    "dataviz_categorical-sequence-category-11-hover": "dataviz-categorical-sequence-category-11-hover",
+    "dataviz_categorical-sequence-category11-hover": "dataviz-categorical-sequence-category11-hover",
     "dataviz_categorical-sequence-category12": "dataviz-categorical-sequence-category12",
     "dataviz_categorical-sequence-category12-hover": "dataviz-categorical-sequence-category12-hover",
     "dataviz_categorical-sequence-category13": "dataviz-categorical-sequence-category13",

--- a/packages/tokens/src/tokens/semantic/light/dataViz.tokens.json
+++ b/packages/tokens/src/tokens/semantic/light/dataViz.tokens.json
@@ -700,7 +700,7 @@
                     "$type": "color",
                     "$value": "#ffbf92"
                 },
-                "category-11-hover": {
+                "category11-hover": {
                     "$type": "color",
                     "$value": "#ffac70"
                 },


### PR DESCRIPTION
- Added `hop-dataviz-categorical-sequence-category11-hover` token.
- `hop-dataviz-categorical-sequence-category-11-hover` will be deprecated in the next major release.
