### PR TITLE
moved props lower in the doc hierarchy

### DIFF
--- a/apps/docs/content/components/application/HopperProvider.mdx
+++ b/apps/docs/content/components/application/HopperProvider.mdx
@@ -9,10 +9,6 @@ links:
 
 <CodeOnlyExample src="HopperProvider/docs/hopper-provider/preview" />
 
-## Props
-
-<PropTable component="HopperProvider" />
-
 ## Application provider
 
 A HopperProvider must be the root component of your application. All other Hopper components rely on the Provider to define the color scheme, locale, and other settings that they need in order to render.
@@ -77,3 +73,7 @@ body {
 `withCssVariables` determines whether Hopper's CSS variables should be added to your application. By default, it is set to true and should not be changed unless you want to manage CSS variables via a CSS file. Note that in this case, you will need to add the tokens manually, ideally using the `@hopper-ui/tokens` [package](/tokens/getting-started/usage).
 
 <CodeOnlyExample src="HopperProvider/docs/hopper-provider/inject-css-var" />
+
+## Props
+
+<PropTable component="HopperProvider" />

--- a/apps/docs/content/components/buttons/Button.mdx
+++ b/apps/docs/content/components/buttons/Button.mdx
@@ -9,10 +9,6 @@ links:
 
 <Example src="buttons/docs/button/preview" isOpen />
 
-## Props
-
-<PropTable component="Button" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -122,6 +118,10 @@ A button can be rendered as a react router link when using the href property and
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Button" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/buttons/ButtonGroup.mdx
+++ b/apps/docs/content/components/buttons/ButtonGroup.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="buttons/docs/buttonGroup/preview" isOpen />
 
-## Props
-
-<PropTable component="ButtonGroup" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -78,6 +74,10 @@ A button group can be of different sizes.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="ButtonGroup" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/collections/Listbox.mdx
+++ b/apps/docs/content/components/collections/Listbox.mdx
@@ -9,15 +9,6 @@ links:
 
 <Example src="ListBox/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="ListBox" />
-
-### ListBoxItem
-
-<PropTable component="ListBoxItem" />
-
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -189,6 +180,14 @@ List box items can vary in sizes.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="ListBox" />
+
+### ListBoxItem
+
+<PropTable component="ListBoxItem" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/collections/TagGroup.mdx
+++ b/apps/docs/content/components/collections/TagGroup.mdx
@@ -9,20 +9,6 @@ links:
 
 <Example src="tag/docs/preview" />
 
-## Props
-
-### TagGroup
-
-<PropTable component="TagGroup" />
-
-### TagList
-
-<PropTable component="TagList" />
-
-### Tag
-
-<PropTable component="Tag" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -202,6 +188,20 @@ A tag can be rendered as a react router link when using the `href` prop and sett
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+### TagGroup
+
+<PropTable component="TagGroup" />
+
+### TagList
+
+<PropTable component="TagList" />
+
+### Tag
+
+<PropTable component="Tag" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/content/Avatar.mdx
+++ b/apps/docs/content/components/content/Avatar.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="Avatar/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Avatar" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -114,3 +110,7 @@ Using a custom hook to retry loading the image up to 5 times with a 250ms delay.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Avatar" />

--- a/apps/docs/content/components/content/Divider.mdx
+++ b/apps/docs/content/components/content/Divider.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="Divider/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Divider" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -54,6 +50,10 @@ A divider can have two orientations: horizontal or vertical.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Divider" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/content/Heading.mdx
+++ b/apps/docs/content/components/content/Heading.mdx
@@ -7,12 +7,6 @@ links:
 ---
 <Example src="typography/Heading/docs/preview" isOpen />
 
-## Props
-
-These props are also available for `H1`, `H2`, `H3`, `H4`, `H5` and `H6` components.
-
-<PropTable component="Heading" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -71,6 +65,12 @@ You can alter the size of a heading to match the parent element's type scale by 
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+These props are also available for `H1`, `H2`, `H3`, `H4`, `H5` and `H6` components.
+
+<PropTable component="Heading" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/content/Label.mdx
+++ b/apps/docs/content/components/content/Label.mdx
@@ -7,10 +7,6 @@ links:
 ---
 <Example src="typography/Label/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Label" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -62,3 +58,7 @@ The label component can be marked as required.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Label" />

--- a/apps/docs/content/components/content/Text.mdx
+++ b/apps/docs/content/components/content/Text.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="typography/Text/docs/text/preview" isOpen />
 
-## Props
-
-<PropTable component="Text" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -69,3 +65,7 @@ The Text component can be nested within other Text components and inherit the pa
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Text" />

--- a/apps/docs/content/components/forms/Checkbox.mdx
+++ b/apps/docs/content/components/forms/Checkbox.mdx
@@ -9,16 +9,6 @@ links:
 
 <Example src="checkbox/docs/checkbox/preview" isOpen />
 
-## Props
-
-### Checkbox
-
-<PropTable component="Checkbox" />
-
-### CheckboxField
-
-<PropTable component="CheckboxField" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -137,6 +127,16 @@ A checkbox can have a description to provide more information to the user.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+### Checkbox
+
+<PropTable component="Checkbox" />
+
+### CheckboxField
+
+<PropTable component="CheckboxField" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/CheckboxGroup.mdx
+++ b/apps/docs/content/components/forms/CheckboxGroup.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="checkbox/docs/checkboxgroup/preview" isOpen />
 
-## Props
-
-<PropTable component="CheckboxGroup" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -107,6 +103,10 @@ A checkbox group can handle value state in controlled mode.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="CheckboxGroup" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/ErrorMessage.mdx
+++ b/apps/docs/content/components/forms/ErrorMessage.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="ErrorMessage/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="ErrorMessage" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -60,3 +56,7 @@ An error message can display multiple validation errors created by a form field.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="ErrorMessage" />

--- a/apps/docs/content/components/forms/Form.mdx
+++ b/apps/docs/content/components/forms/Form.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="Form/docs/preview" />
 
-## Props
-
-<PropTable component="Form" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -99,3 +95,7 @@ Form fields can take the width of their container.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Form" />

--- a/apps/docs/content/components/forms/HelperMessage.mdx
+++ b/apps/docs/content/components/forms/HelperMessage.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="HelperMessage/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="HelperMessage" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -53,3 +49,7 @@ A helper message can hide its default icon.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="HelperMessage" />

--- a/apps/docs/content/components/forms/NumberField.mdx
+++ b/apps/docs/content/components/forms/NumberField.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="inputs/docs/numberField/preview" isOpen />
 
-## Props
-
-<PropTable component="NumberField" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -109,6 +105,10 @@ A number field can take the width of its container.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="NumberField" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/PasswordField.mdx
+++ b/apps/docs/content/components/forms/PasswordField.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="inputs/docs/passwordField/preview" isOpen />
 
-## Props
-
-<PropTable component="PasswordField" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -87,6 +83,10 @@ A password field with a helper message.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="PasswordField" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/RadioGroup.mdx
+++ b/apps/docs/content/components/forms/RadioGroup.mdx
@@ -9,16 +9,6 @@ links:
 
 <Example src="radio/docs/preview" />
 
-## Props
-
-### RadioGroup
-
-<PropTable component="RadioGroup" />
-
-### Radio
-
-<PropTable component="Radio" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -141,6 +131,16 @@ Each radio can be customized with an icon or an icon list.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+### RadioGroup
+
+<PropTable component="RadioGroup" />
+
+### Radio
+
+<PropTable component="Radio" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/RemainingCharacterCount.mdx
+++ b/apps/docs/content/components/forms/RemainingCharacterCount.mdx
@@ -7,10 +7,6 @@ links:
 ---
 <Example src="inputs/docs/remainingCharacterCount/preview" isOpen />
 
-## Props
-
-<PropTable component="RemainingCharacterCount" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -68,3 +64,7 @@ A remaining character count can have a disabled appearance. This should be used 
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="RemainingCharacterCount" />

--- a/apps/docs/content/components/forms/SearchField.mdx
+++ b/apps/docs/content/components/forms/SearchField.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="inputs/docs/searchField/preview" isOpen />
 
-## Props
-
-<PropTable component="SearchField" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -92,6 +88,10 @@ A search field with a helper message.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="SearchField" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/Switch.mdx
+++ b/apps/docs/content/components/forms/Switch.mdx
@@ -9,16 +9,6 @@ links:
 
 <Example src="switch/docs/switch/preview" isOpen />
 
-## Props
-
-### Switch
-
-<PropTable component="Switch" />
-
-### SwitchField
-
-<PropTable component="SwitchField" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -117,6 +107,16 @@ A switch field can vary in size.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+### Switch
+
+<PropTable component="Switch" />
+
+### SwitchField
+
+<PropTable component="SwitchField" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/TextArea.mdx
+++ b/apps/docs/content/components/forms/TextArea.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="inputs/docs/textArea/preview" isOpen />
 
-## Props
-
-<PropTable component="TextArea" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -117,6 +113,10 @@ The `vertical` behavior allows the user to resize the text area vertically.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="TextArea" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/forms/TextField.mdx
+++ b/apps/docs/content/components/forms/TextField.mdx
@@ -12,10 +12,6 @@ Specialized text fields are available for different scenarios:
 
 <Example src="inputs/docs/textField/preview" isOpen />
 
-## Props
-
-<PropTable component="TextField" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -125,6 +121,10 @@ A text field can take the width of its container.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="TextField" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/layout/Flex.mdx
+++ b/apps/docs/content/components/layout/Flex.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="layout/docs/flex/preview" isOpen />
 
-## Props
-
-<PropTable component="Flex" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -83,3 +79,7 @@ Flex layouts can be nested.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Flex" />

--- a/apps/docs/content/components/layout/Grid.mdx
+++ b/apps/docs/content/components/layout/Grid.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="layout/docs/grid/preview" isOpen />
 
-## Props
-
-<PropTable component="Grid" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -93,3 +89,7 @@ A custom `fit-content` function is available to support Hopper spacing scale val
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Grid" />

--- a/apps/docs/content/components/layout/Inline.mdx
+++ b/apps/docs/content/components/layout/Inline.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="layout/docs/inline/preview" isOpen />
 
-## Props
-
-<PropTable component="Inline" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -63,6 +59,10 @@ Inline items can be aligned on the vertical axis.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Inline" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/layout/Stack.mdx
+++ b/apps/docs/content/components/layout/Stack.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="layout/docs/stack/preview" isOpen />
 
-## Props
-
-<PropTable component="Stack" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -63,6 +59,10 @@ Stack items can be aligned on the vertical axis.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Stack" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/navigation/Link.mdx
+++ b/apps/docs/content/components/navigation/Link.mdx
@@ -9,10 +9,6 @@ links:
 
 <Example src="Link/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Link" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -136,6 +132,10 @@ A link's content can be an image element.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Link" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/overlays/Popover.mdx
+++ b/apps/docs/content/components/overlays/Popover.mdx
@@ -8,13 +8,6 @@ links:
 
 <Example src="overlays/Popover/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Popover" />
-
-### PopoverTrigger
-<PropTable component="PopoverTrigger" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -102,6 +95,13 @@ A Popover&apos;s open state can be handled in controlled mode.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Popover" />
+
+### PopoverTrigger
+<PropTable component="PopoverTrigger" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/pickers/ComboBox.mdx
+++ b/apps/docs/content/components/pickers/ComboBox.mdx
@@ -9,10 +9,6 @@ links:
 
 <Example src="ComboBox/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="ComboBox" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -210,3 +206,8 @@ A combo box can have a different selection indicator.
 A combo box item can have a description.
 
 <Example src="ComboBox/docs/ComboBoxOption/description" />
+
+## Props
+
+<PropTable component="ComboBox" />
+

--- a/apps/docs/content/components/pickers/Select.mdx
+++ b/apps/docs/content/components/pickers/Select.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="Select/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Select" />
-
 ## Anatomy
 
 <FeatureFlag flag="next">
@@ -212,6 +208,10 @@ A select item can have a description.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Select" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/status/Badge.mdx
+++ b/apps/docs/content/components/status/Badge.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="Badge/docs/badge/preview" isOpen />
 
-## Props
-
-<PropTable component="Badge" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -73,6 +69,10 @@ A badge can have any text content.
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="Badge" />
 
 ## Migration Notes
 

--- a/apps/docs/content/components/status/FloatingBadge.mdx
+++ b/apps/docs/content/components/status/FloatingBadge.mdx
@@ -8,10 +8,6 @@ links:
 
 <Example src="Badge/docs/floatingbadge/preview" isOpen />
 
-## Props
-
-<PropTable component="FloatingBadge" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -66,3 +62,7 @@ The position of the badge can be adjusted using the `offset` prop. This prop acc
 
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
+
+## Props
+
+<PropTable component="FloatingBadge" />

--- a/apps/docs/content/components/status/Spinner.mdx
+++ b/apps/docs/content/components/status/Spinner.mdx
@@ -7,10 +7,6 @@ links:
 ---
 <Example src="Spinner/docs/preview" isOpen />
 
-## Props
-
-<PropTable component="Spinner" />
-
 <FeatureFlag flag="next">
     ## Guidelines
 
@@ -68,6 +64,9 @@ You can change a spinner style when over a background by setting a color propert
     TODO: Example of creating a custom version of this component
 </FeatureFlag>
 
+## Props
+
+<PropTable component="Spinner" />
 
 ## Migration Notes
 


### PR DESCRIPTION
Moved Props table in the documentation near the bottom of the page, just above Migration Notes.