### PR TITLE
Added label examples to checkboxGroup doc previews

### DIFF
--- a/apps/docs/content/components/forms/CheckboxGroup.mdx
+++ b/apps/docs/content/components/forms/CheckboxGroup.mdx
@@ -59,11 +59,11 @@ A checkbox group can vary in size.
 
 <Example src="checkbox/docs/checkboxgroup/size" />
 
-### Label
+### No Label
 
-A checkbox group can have a label to provide more context to the user.
+A checkbox group can be rendered without a label.
 
-<Example src="checkbox/docs/checkboxgroup/label" />
+<Example src="checkbox/docs/checkboxgroup/nolabel" />
 
 ### Description
 

--- a/apps/docs/examples/Preview.ts
+++ b/apps/docs/examples/Preview.ts
@@ -350,8 +350,8 @@ export const Previews: Record<string, Preview> = {
     "checkbox/docs/checkboxgroup/size": {
         component: lazy(() => import("@/../../packages/components/src/checkbox/docs/checkboxgroup/size.tsx"))
     },
-    "checkbox/docs/checkboxgroup/label": {
-        component: lazy(() => import("@/../../packages/components/src/checkbox/docs/checkboxgroup/label.tsx"))
+    "checkbox/docs/checkboxgroup/nolabel": {
+        component: lazy(() => import("@/../../packages/components/src/checkbox/docs/checkboxgroup/nolabel.tsx"))
     },
     "checkbox/docs/checkboxgroup/description": {
         component: lazy(() => import("@/../../packages/components/src/checkbox/docs/checkboxgroup/description.tsx"))

--- a/packages/components/src/checkbox/docs/checkboxgroup/controlled.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/controlled.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
 import { useState } from "react";
 
 export default function Example() {
@@ -11,6 +11,7 @@ export default function Example() {
             value={selected}
         >
             <CheckboxList>
+                <Label>Roles</Label>
                 <Checkbox value="developer">Developer</Checkbox>
                 <Checkbox value="designer">Designer</Checkbox>
                 <Checkbox value="manager">Manager</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/description.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/description.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, CheckboxGroup, CheckboxList, HelperMessage } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, HelperMessage, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <CheckboxGroup>
+            <Label>Roles</Label>
             <CheckboxList>
                 <Checkbox value="option1">Developer</Checkbox>
                 <Checkbox value="option2">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/disabled.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/disabled.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <CheckboxGroup isDisabled>
+            <Label>Roles</Label>
             <CheckboxList>
                 <Checkbox value="option1">Developer</Checkbox>
                 <Checkbox value="option2">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/invalid.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/invalid.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <CheckboxGroup isInvalid>
+            <Label>Roles</Label>
             <CheckboxList>
                 <Checkbox value="developer">Developer</Checkbox>
                 <Checkbox value="designer">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/nolabel.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/nolabel.tsx
@@ -1,9 +1,8 @@
-import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
 
 export default function Example() {
     return (
-        <CheckboxGroup>
-            <Label>Roles</Label>
+        <CheckboxGroup aria-label="Roles">
             <CheckboxList>
                 <Checkbox value="developer">Developer</Checkbox>
                 <Checkbox value="designer">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/orientation.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/orientation.tsx
@@ -1,15 +1,17 @@
-import { Checkbox, CheckboxGroup, CheckboxList, Inline } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Inline, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <Inline gap="inline-xl">
             <CheckboxGroup orientation="horizontal">
+                <Label>Roles</Label>
                 <CheckboxList>
                     <Checkbox value="developer">Developer</Checkbox>
                     <Checkbox value="designer">Designer</Checkbox>
                 </CheckboxList>
             </CheckboxGroup>
             <CheckboxGroup orientation="vertical">
+                <Label>Roles</Label>
                 <CheckboxList>
                     <Checkbox value="developer">Developer</Checkbox>
                     <Checkbox value="designer">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/preview.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/preview.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <CheckboxGroup>
+            <Label>Roles</Label>
             <CheckboxList>
                 <Checkbox value="developer">Developer</Checkbox>
                 <Checkbox value="designer">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/readonly.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/readonly.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <CheckboxGroup isReadOnly>
+            <Label>Roles</Label>
             <CheckboxList>
                 <Checkbox value="developer">Developer</Checkbox>
                 <Checkbox value="designer">Designer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/size.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/size.tsx
@@ -1,15 +1,17 @@
-import { Checkbox, CheckboxGroup, CheckboxList, Inline } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Inline, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <Inline gap="inline-xl">
             <CheckboxGroup size="sm">
+                <Label>Roles</Label>
                 <CheckboxList>
                     <Checkbox value="developer">Developer</Checkbox>
                     <Checkbox value="designer">Designer</Checkbox>
                 </CheckboxList>
             </CheckboxGroup>
             <CheckboxGroup size="md">
+                <Label>Roles</Label>
                 <CheckboxList>
                     <Checkbox value="developer">Designer</Checkbox>
                     <Checkbox value="designer">Developer</Checkbox>

--- a/packages/components/src/checkbox/docs/checkboxgroup/variant.tsx
+++ b/packages/components/src/checkbox/docs/checkboxgroup/variant.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, CheckboxGroup, CheckboxList } from "@hopper-ui/components";
+import { Checkbox, CheckboxGroup, CheckboxList, Label } from "@hopper-ui/components";
 
 export default function Example() {
     return (
         <CheckboxGroup variant="bordered">
+            <Label>Roles</Label>
             <CheckboxList>
                 <Checkbox value="developer">Developer</Checkbox>
                 <Checkbox value="designer">Designer</Checkbox>


### PR DESCRIPTION
Added label to checkboxGroup preview documentation as it's more accessible this way.