### PR TITLE
[DS-335] Fix export of styled-system

### DIFF
--- a/.changeset/strong-zoos-smile.md
+++ b/.changeset/strong-zoos-smile.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Remove @hopper-ui/styled-system from peerDependencies since it's already in @hopper-ui/icons


### PR DESCRIPTION
Fix export of styled-system when using @hopper-ui/components tu use anything from styled-system.

Remove @hopper-ui/styled-system from peerDependencies. It's already added in @hopper-ui/icons as peerDependencies and @hopper-ui/icons is added as dependencies in @hopper-ui/components

Important files to review: 

- eslint file
- package.json
- changeset file