### PR TITLE
moved props after all props when it made sense

### DIFF
--- a/.changeset/lovely-humans-yell.md
+++ b/.changeset/lovely-humans-yell.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Moved otherProps last to let the end user override props if needed

--- a/apps/docs/components/code/InlineCode.tsx
+++ b/apps/docs/components/code/InlineCode.tsx
@@ -10,7 +10,7 @@ export type InlineCodeProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTM
 
 const InlineCode = ({ children, variant = "default", ...props }: InlineCodeProps) => {
     return (
-        <code {...props} className={clsx("hd-code", { "hd-code--ghost": variant === "ghost" })} tabIndex={-1}>{children}</code>
+        <code className={clsx("hd-code", { "hd-code--ghost": variant === "ghost" })} tabIndex={-1} {...props}>{children}</code>
     );
 };
 

--- a/apps/docs/components/mdx/components.tsx
+++ b/apps/docs/components/mdx/components.tsx
@@ -1,34 +1,34 @@
-import type { HTMLAttributes, DetailedHTMLProps } from "react";
 import dynamic from "next/dynamic";
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
 
-import Card from "@/components/card/Card.tsx";
-import { Callout } from "@/components/callout/Callout.tsx";
-import NextImage from "@/components/image/Image.tsx";
-import Pre from "@/components/pre/Pre.tsx";
-import InlineCode from "@/components/code/InlineCode.tsx";
+import ComposedComponents from "@/app/ui/components/composedComponents/composedComponents.tsx";
+import Overview from "@/app/ui/components/overview/Overview.tsx";
+import { IconTable } from "@/app/ui/icons/iconTable/IconTable.tsx";
+import Switcher from "@/app/ui/icons/switcher/Switcher.tsx";
+import IconSpecTable from "@/app/ui/tokens/table/IconSpecTable.tsx";
 import TokenTable from "@/app/ui/tokens/table/TokenTable.tsx";
 import TypographyTable from "@/app/ui/tokens/table/TypographyTable.tsx";
 import TypographyVariantTable from "@/app/ui/tokens/table/TypographyVariantTable.tsx";
-import { IconTable } from "@/app/ui/icons/iconTable/IconTable.tsx";
-import IconSpecTable from "@/app/ui/tokens/table/IconSpecTable.tsx";
-import Tabs from "@/components/tabs/Tabs.tsx";
 import TableSection from "@/app/ui/tokens/tableSection/TableSection.tsx";
-import Switcher from "@/app/ui/icons/switcher/Switcher.tsx";
-import Overview from "@/app/ui/components/overview/Overview.tsx";
-import ComposedComponents from "@/app/ui/components/composedComponents/composedComponents.tsx";
-import Title from "@/components/title/Title.tsx";
-import MotionPreview from "@/components/motionPreview/MotionPreview.tsx";
+import { Callout } from "@/components/callout/Callout.tsx";
+import Card from "@/components/card/Card.tsx";
+import InlineCode from "@/components/code/InlineCode.tsx";
 import Footnote from "@/components/footnote/Footnote.tsx";
+import NextImage from "@/components/image/Image.tsx";
+import MotionPreview from "@/components/motionPreview/MotionPreview.tsx";
 import PackageInstallation, {
     type PackageInstallationProps
 } from "@/components/packageInstallation/PackageInstallation.tsx";
+import Pre from "@/components/pre/Pre.tsx";
+import Tabs from "@/components/tabs/Tabs.tsx";
+import Title from "@/components/title/Title.tsx";
 
+import BreakpointTable from "@/app/ui/components/breakpointTable/BreakpointTable";
+import { ComponentCodeWrapper } from "@/app/ui/components/componentExample/ComponentCodeWrapper.tsx";
+import type { ComponentExampleProps } from "@/app/ui/components/componentExample/ComponentExample.tsx";
+import ComponentPreview from "@/app/ui/components/componentExample/ComponentPreview.tsx";
 import type { MigrateGuideProps } from "@/app/ui/components/migrateGuide/MigrateGuide.tsx";
 import type { PropTableProps } from "@/app/ui/components/propTable/PropTable.tsx";
-import type { ComponentExampleProps } from "@/app/ui/components/componentExample/ComponentExample.tsx";
-import { ComponentCodeWrapper } from "@/app/ui/components/componentExample/ComponentCodeWrapper.tsx";
-import ComponentPreview from "@/app/ui/components/componentExample/ComponentPreview.tsx";
-import BreakpointTable from "@/app/ui/components/breakpointTable/BreakpointTable";
 import SimpleTable from "@/app/ui/components/simpleTable/SimpleTable";
 
 const MigrateGuide = dynamic(() => import("@/app/ui/components/migrateGuide/MigrateGuide.tsx"));

--- a/apps/docs/components/pre/Pre.tsx
+++ b/apps/docs/components/pre/Pre.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { DetailedHTMLProps, HTMLAttributes } from "react";
 import clsx from "clsx";
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
 
 import CopyButton from "@/components/copyButton/CopyButton.tsx";
 import LangIcon from "@/components/pre/langIcon/LangIcon";
@@ -32,7 +32,7 @@ const Pre = ({ children, className, title, "data-language": dataLanguage, raw, t
     const copyButton = raw && <CopyButton onDark={isOnDark} text={raw} />;
 
     return (
-        <pre {...props} data-theme={theme} className={classes} tabIndex={-1}>
+        <pre data-theme={theme} className={classes} tabIndex={-1} {...props}>
             {title &&
                 <div className="hd-pre-header">
                     <div className="hd-pre-header__info">

--- a/packages/components/src/Avatar/src/DeletedAvatar.tsx
+++ b/packages/components/src/Avatar/src/DeletedAvatar.tsx
@@ -69,10 +69,10 @@ function DeletedAvatar(props: DeletedAvatarProps, ref: ForwardedRef<HTMLDivEleme
 
     return (
         <RichIconAvatarImage
-            {...mergeProps(otherProps, renderProps)}
             isDisabled={isDisabled}
             ref={ref}
             size={size}
+            {...mergeProps(renderProps, otherProps)}
         >
             <DeletedUserRichIcon />
         </RichIconAvatarImage>

--- a/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
+++ b/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
@@ -76,12 +76,12 @@ function RichIconAvatarImage(props: RichIconAvatarImageProps, ref: ForwardedRef<
     });
 
     const renderProps = useRenderProps<RichIconAvatarImageRenderProps>({
-        ...props,
         className: classNames,
         style: mergedStyles,
         values: {
             isDisabled: isDisabled || false
-        }
+        },
+        ...props
     });
 
     if (!props["aria-label"] && !props["aria-labelledby"]) {

--- a/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
+++ b/packages/components/src/Avatar/src/RichIconAvatarImage.tsx
@@ -76,12 +76,12 @@ function RichIconAvatarImage(props: RichIconAvatarImageProps, ref: ForwardedRef<
     });
 
     const renderProps = useRenderProps<RichIconAvatarImageRenderProps>({
+        ...props,
         className: classNames,
         style: mergedStyles,
         values: {
             isDisabled: isDisabled || false
-        },
-        ...props
+        }
     });
 
     if (!props["aria-label"] && !props["aria-labelledby"]) {

--- a/packages/components/src/Badge/src/FloatingBadge.tsx
+++ b/packages/components/src/Badge/src/FloatingBadge.tsx
@@ -82,13 +82,13 @@ function FloatingBadge(props: FloatingBadgeProps, ref: ForwardedRef<HTMLDivEleme
                 ]}
             >
                 <div
-                    {...otherProps}
                     ref={ref}
                     className={classNames}
                     style={mergedStyles}
                     slot={slot ?? undefined}
                     data-overlap={overlap}
                     data-placement={placement}
+                    {...otherProps}
                 >
                     {children}
                 </div>

--- a/packages/components/src/Divider/src/Divider.tsx
+++ b/packages/components/src/Divider/src/Divider.tsx
@@ -1,6 +1,6 @@
 import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { Separator as RACSeparator, useContextProps, type SeparatorProps as RACSeparatorProps } from "react-aria-components";
 
 import { cssModule } from "../../utils/index.ts";
@@ -41,11 +41,11 @@ function Divider(props: DividerProps, ref: ForwardedRef<HTMLElement>) {
 
     return (
         <RACSeparator
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
             orientation={orientation}
+            {...otherProps}
         />
     );
 }

--- a/packages/components/src/ErrorMessage/src/ErrorMessage.tsx
+++ b/packages/components/src/ErrorMessage/src/ErrorMessage.tsx
@@ -79,10 +79,10 @@ const ErrorMessageInner = forwardRef((props: ErrorMessageProps, ref: ForwardedRe
 
     return (
         <Text
-            {...otherProps}
             {...renderProps}
             slot={slot}
             ref={ref}
+            {...otherProps}
         />
     );
 });

--- a/packages/components/src/Form/src/Form.tsx
+++ b/packages/components/src/Form/src/Form.tsx
@@ -169,10 +169,10 @@ function Form(props: FormProps, ref: ForwardedRef<HTMLFormElement>) {
             ]}
             >
                 <RACForm
-                    {...otherProps}
                     ref={ref}
                     className={classNames}
                     style={mergedStyles}
+                    {...otherProps}
                 >
                     {children}
                 </RACForm>

--- a/packages/components/src/Header/src/Header.tsx
+++ b/packages/components/src/Header/src/Header.tsx
@@ -35,11 +35,11 @@ function Header(props: HeaderProps, ref: ForwardedRef<HTMLElement>) {
 
     return (
         <RACHeader
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
             slot={slot || undefined}
+            {...otherProps}
         >
             {children}
         </RACHeader>

--- a/packages/components/src/HelperMessage/src/HelperMessage.tsx
+++ b/packages/components/src/HelperMessage/src/HelperMessage.tsx
@@ -1,8 +1,8 @@
 import { InfoIcon } from "@hopper-ui/icons";
 import { type StyledComponentProps, useStyledSystem } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { forwardRef, type ForwardedRef, type CSSProperties, useContext } from "react";
-import { useContextProps, FieldErrorContext as RACFieldErrorContext } from "react-aria-components";
+import { type CSSProperties, type ForwardedRef, forwardRef, useContext } from "react";
+import { FieldErrorContext as RACFieldErrorContext, useContextProps } from "react-aria-components";
 
 import { type TextProps, Text } from "../../typography/Text/index.ts";
 import { cssModule } from "../../utils/index.ts";
@@ -61,12 +61,12 @@ const HelperMessageInner = forwardRef((props: HelperMessageProps, ref: Forwarded
 
     return (
         <Text
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
             size="xs"
             slot={slot}
+            {...otherProps}
         >
             {!hideIcon && <InfoIcon size="sm" className={styles["hop-HelperMessage__icon"]} />}
             {children}

--- a/packages/components/src/IconList/src/IconList.tsx
+++ b/packages/components/src/IconList/src/IconList.tsx
@@ -40,11 +40,11 @@ function IconList(props:IconListProps, ref: ForwardedRef<HTMLSpanElement>) {
 
     return (
         <span
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
             slot={slot ?? undefined}
+            {...otherProps}
         >
             <SlotProvider values={[
                 [IconContext, {

--- a/packages/components/src/Link/src/Link.tsx
+++ b/packages/components/src/Link/src/Link.tsx
@@ -145,12 +145,12 @@ function Link(props: LinkProps, ref: ForwardedRef<HTMLAnchorElement>) {
             ]}
         >
             <RACLink
-                {...otherProps}
                 rel={rel ?? (isExternal ? "noopener noreferrer" : undefined)}
                 target={target ?? (isExternal ? "_blank" : undefined)}
                 ref={ref}
                 className={classNames}
                 style={style}
+                {...otherProps}
             >
                 {children}
             </RACLink>

--- a/packages/components/src/ListBox/src/ListBoxItem.tsx
+++ b/packages/components/src/ListBox/src/ListBoxItem.tsx
@@ -273,7 +273,6 @@ function ListBoxItem<T extends object>(props: ListBoxItemProps<T>, ref: Forwarde
 
     return (
         <RACListBoxItem
-            {...otherProps}
             ref={ref as ForwardedRef<T>} /* Needed until this bug is fixed: https://github.com/adobe/react-spectrum/issues/6799 */
             className={classNames}
             style={style}
@@ -283,6 +282,7 @@ function ListBoxItem<T extends object>(props: ListBoxItemProps<T>, ref: Forwarde
             data-loading={isLoading || undefined}
             aria-label={isLoading ? "Loading" : undefined}
             aria-live={isLoading ? "polite" : undefined}
+            {...otherProps}
         >
             {listBoxItemProps => {
                 if (isLoading) {

--- a/packages/components/src/ListBox/src/ListBoxItemSkeleton.tsx
+++ b/packages/components/src/ListBox/src/ListBoxItemSkeleton.tsx
@@ -51,11 +51,11 @@ function ListBoxItemSkeleton(props: ListBoxItemSkeletonProps, ref: ForwardedRef<
 
     return (
         <div
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={style}
             slot={slot ?? undefined}
+            {...otherProps}
         />
     );
 }

--- a/packages/components/src/Section/src/Section.tsx
+++ b/packages/components/src/Section/src/Section.tsx
@@ -1,6 +1,6 @@
 import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type CSSProperties, forwardRef, type ForwardedRef, type NamedExoticComponent } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef, type NamedExoticComponent } from "react";
 import { Section as RACSection, useContextProps, type SectionProps as RACSectionProps } from "react-aria-components";
 
 import { SectionContext } from "./SectionContext.ts";
@@ -32,10 +32,10 @@ function Section<T extends object>(props: SectionProps<T>, ref: ForwardedRef<HTM
 
     return (
         <RACSection
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
+            {...otherProps}
         >
             {children}
         </RACSection>

--- a/packages/components/src/Select/src/Select.tsx
+++ b/packages/components/src/Select/src/Select.tsx
@@ -217,19 +217,19 @@ function Select<T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLD
                 <Footer>
                     <EnsureTextWrapper>{footer}</EnsureTextWrapper>
                 </Footer>
-            
+
             </SlotProvider>
         </ClearProviders>
     ) : null;
 
     return (
         <RACSelect
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={style}
             isInvalid={isInvalid}
             isRequired={isRequired}
+            {...otherProps}
         >
             {selectRenderProps => {
                 const { isOpen } = selectRenderProps;
@@ -246,7 +246,7 @@ function Select<T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLD
                                 {label}
                             </Label>
                         )}
-                        <Popover 
+                        <Popover
                             isAutoWidth={isAutoMenuWidth}
                             isNonDialog
                             placement={`${direction} ${align}`}
@@ -259,9 +259,9 @@ function Select<T extends object>(props: SelectProps<T>, ref: ForwardedRef<HTMLD
                                 }]
                             ]}
                             >
-                                <ListBox 
-                                    size={size} 
-                                    isInvalid={isInvalid} 
+                                <ListBox
+                                    size={size}
+                                    isInvalid={isInvalid}
                                     items={items}
                                     isLoading={isLoading}
                                     onLoadMore={onLoadMore}

--- a/packages/components/src/Select/src/SelectValue.tsx
+++ b/packages/components/src/Select/src/SelectValue.tsx
@@ -76,6 +76,7 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
     }) as CSSProperties;
 
     const renderProps = useRenderProps({
+        ...otherProps,
         className: classNames,
         defaultChildren: textValue || placeholder || stringFormatter.format("Select.placeholder"),
         style,
@@ -83,8 +84,7 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
             selectedItem: state?.selectedItem?.value as T ?? null,
             selectedText: textValue ?? null,
             isPlaceholder: !selectedItem
-        },
-        ...otherProps
+        }
     });
 
     const DOMProps = filterDOMProps(ownProps);

--- a/packages/components/src/Select/src/SelectValue.tsx
+++ b/packages/components/src/Select/src/SelectValue.tsx
@@ -43,7 +43,7 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
         style: styleProp,
         ...otherProps
     } = ownProps;
-    
+
     const size = useResponsiveValue(sizeProp) ?? "sm";
 
     const textRef = useRef<HTMLSpanElement>(null);
@@ -54,7 +54,7 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
     const selectedItem = state?.selectedKey != null
         ? state.collection.getItem(state.selectedKey)
         : null;
-  
+
     const stringFormatter = useLocalizedString();
     const textValue = state?.selectedItem?.textValue;
 
@@ -74,9 +74,8 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
             ...prev
         };
     }) as CSSProperties;
-  
+
     const renderProps = useRenderProps({
-        ...otherProps,
         className: classNames,
         defaultChildren: textValue || placeholder || stringFormatter.format("Select.placeholder"),
         style,
@@ -84,14 +83,15 @@ function SelectValue<T extends object>(props: SelectValueProps<T>, ref: Forwarde
             selectedItem: state?.selectedItem?.value as T ?? null,
             selectedText: textValue ?? null,
             isPlaceholder: !selectedItem
-        }
+        },
+        ...otherProps
     });
-  
+
     const DOMProps = filterDOMProps(ownProps);
-  
+
     return (
         <ClearContainerSlots>
-            <Text 
+            <Text
                 ref={ref}
                 {...DOMProps}
                 {...renderProps}

--- a/packages/components/src/buttons/src/Button.tsx
+++ b/packages/components/src/buttons/src/Button.tsx
@@ -147,12 +147,12 @@ function Button(props: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) {
             ]}
         >
             <RACButton
-                {...otherProps}
                 ref={ref}
                 slot={props.slot || undefined}
                 className={classNames}
                 style={style}
                 isPending={isLoading}
+                {...otherProps}
             >
                 {buttonRenderProps => {
                     return <>

--- a/packages/components/src/buttons/src/LinkButton.tsx
+++ b/packages/components/src/buttons/src/LinkButton.tsx
@@ -131,11 +131,11 @@ function LinkButton(props: LinkButtonProps, ref: ForwardedRef<HTMLAnchorElement>
             ]}
         >
             <RACLink
-                {...otherProps}
                 ref={ref}
                 className={classNames}
                 style={style}
                 slot={props.slot || undefined}
+                {...otherProps}
             >
                 {children}
             </RACLink>

--- a/packages/components/src/buttons/tests/jest/ButtonGroup.test.tsx
+++ b/packages/components/src/buttons/tests/jest/ButtonGroup.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render } from "@hopper-ui/test-utils";
+import { render, screen } from "@hopper-ui/test-utils";
 import { createRef, forwardRef } from "react";
 
 import { Button } from "../../src/Button.tsx";

--- a/packages/components/src/checkbox/src/CheckboxField.tsx
+++ b/packages/components/src/checkbox/src/CheckboxField.tsx
@@ -104,10 +104,10 @@ function CheckboxField(props: CheckboxFieldProps, ref: ForwardedRef<HTMLDivEleme
                 ]}
             >
                 <div
-                    {...mergeProps(otherProps, renderProps)}
                     ref={ref}
                     slot={slot ?? undefined}
                     data-disabled={isDisabled}
+                    {...mergeProps(renderProps, otherProps)}
                 >
                     {renderProps.children}
                     {description && (

--- a/packages/components/src/checkbox/src/DecorativeCheckbox.tsx
+++ b/packages/components/src/checkbox/src/DecorativeCheckbox.tsx
@@ -103,7 +103,6 @@ function DecorativeCheckbox(props: DecorativeCheckboxProps, ref: ForwardedRef<HT
 
     return (
         <div
-            {...mergeProps(otherProps, renderProps)}
             ref={ref as ForwardedRef<HTMLDivElement>}
             slot={slot || undefined}
             data-selected={isSelected || undefined}
@@ -115,6 +114,7 @@ function DecorativeCheckbox(props: DecorativeCheckboxProps, ref: ForwardedRef<HT
             data-readonly={isReadOnly || undefined}
             data-invalid={isInvalid || undefined}
             data-required={isRequired || undefined}
+            {...mergeProps(renderProps, otherProps)}
         >
             <div className={styles["hop-DecorativeCheckbox__box"]}>{icon}</div>
             <ClearContainerSlots>

--- a/packages/components/src/inputs/src/InputGroup.tsx
+++ b/packages/components/src/inputs/src/InputGroup.tsx
@@ -131,13 +131,13 @@ function InputGroup(props: InputGroupProps, ref: ForwardedRef<HTMLDivElement>) {
         ]}
         >
             <RACGroup
-                {...otherProps}
                 isInvalid={validation?.isInvalid || isInvalid}
                 onMouseDown={handleMouseDown}
                 ref={ref}
                 className={classNames}
                 style={style}
                 data-input-type={inputType}
+                {...otherProps}
             >
                 {children}
             </RACGroup>

--- a/packages/components/src/layout/src/Content.tsx
+++ b/packages/components/src/layout/src/Content.tsx
@@ -36,11 +36,11 @@ function Content(props: ContentProps, ref: ForwardedRef<HTMLDivElement>) {
 
     return (
         <div
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
             slot={slot || undefined}
+            {...otherProps}
         >
             {children}
         </div>

--- a/packages/components/src/layout/src/Footer.tsx
+++ b/packages/components/src/layout/src/Footer.tsx
@@ -35,11 +35,11 @@ function Footer(props: FooterProps, ref: ForwardedRef<HTMLElement>) {
 
     return (
         <footer
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
             slot={slot || undefined}
+            {...otherProps}
         >
             {children}
         </footer>

--- a/packages/components/src/overlays/Popover/src/Popover.tsx
+++ b/packages/components/src/overlays/Popover/src/Popover.tsx
@@ -116,7 +116,6 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
 
     return (
         <RACPopover
-            {...otherProps}
             offset={offset}
             ref={ref}
             className={popoverClassNames}
@@ -125,6 +124,7 @@ function Popover(props: PopoverProps, ref: ForwardedRef<HTMLElement>) {
             containerPadding={containerPadding}
             style={style}
             placement={placement}
+            {...otherProps}
         >
             {state => {
                 const content = (isFunction(children) && !isNil(children)) ? children(state) : children;

--- a/packages/components/src/radio/src/DecorativeRadio.tsx
+++ b/packages/components/src/radio/src/DecorativeRadio.tsx
@@ -98,7 +98,6 @@ function DecorativeRadio(props: DecorativeRadioProps, ref: ForwardedRef<HTMLElem
 
     return (
         <div
-            {...mergeProps(otherProps, renderProps)}
             ref={ref as ForwardedRef<HTMLDivElement>}
             slot={slot || undefined}
             data-selected={isSelected || undefined}
@@ -110,6 +109,7 @@ function DecorativeRadio(props: DecorativeRadioProps, ref: ForwardedRef<HTMLElem
             data-readonly={isReadOnly || undefined}
             data-invalid={isInvalid || undefined}
             data-required={isRequired || undefined}
+            {...mergeProps(renderProps, otherProps)}
         >
             <div className={styles["hop-DecorativeRadio__box"]}>
                 <BulletIcon size={size} className={radioIconClassName} />

--- a/packages/components/src/switch/src/SwitchField.tsx
+++ b/packages/components/src/switch/src/SwitchField.tsx
@@ -79,12 +79,12 @@ function SwitchField(props: SwitchFieldProps, ref: ForwardedRef<HTMLDivElement>)
     });
 
     const renderProps = useRenderProps({
-        ...otherProps,
         className: classNames,
         style: mergedStyles,
         values: {
             isDisabled: isDisabled || false
-        }
+        },
+        ...otherProps
     });
 
     return (
@@ -104,10 +104,10 @@ function SwitchField(props: SwitchFieldProps, ref: ForwardedRef<HTMLDivElement>)
             ]}
         >
             <div
-                {...mergeProps(otherProps, renderProps)}
                 ref={ref}
                 slot={slot ?? undefined}
                 data-disabled={isDisabled}
+                {...mergeProps(renderProps, otherProps)}
             >
                 {renderProps.children}
             </div>

--- a/packages/components/src/tag/src/Tag.tsx
+++ b/packages/components/src/tag/src/Tag.tsx
@@ -135,13 +135,13 @@ function Tag(props: TagProps, ref: ForwardedRef<HTMLDivElement>) {
 
     return (
         <RACTag
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={style}
             textValue={textValue}
             data-invalid={isInvalid || undefined}
             data-loading={isLoading || undefined}
+            {...otherProps}
         >
             {tagProps => {
                 const { allowsRemoving, isDisabled, isSelected } = tagProps;

--- a/packages/components/src/tag/src/TagGroup.tsx
+++ b/packages/components/src/tag/src/TagGroup.tsx
@@ -112,10 +112,10 @@ function TagGroup(props: TagGroupProps, ref: ForwardedRef<HTMLDivElement>) {
             ]}
         >
             <RACTagGroup
-                {...otherProps}
                 ref={ref}
                 className={classNames}
                 style={style}
+                {...otherProps}
             >
                 {children}
             </RACTagGroup>

--- a/packages/components/src/tag/src/TagList.tsx
+++ b/packages/components/src/tag/src/TagList.tsx
@@ -1,6 +1,6 @@
 import { type StyledComponentProps, useStyledSystem } from "@hopper-ui/styled-system";
-import { forwardRef, type ForwardedRef } from "react";
-import { useContextProps, TagList as RACTagList, type TagListProps as RACTagListProps, composeRenderProps } from "react-aria-components";
+import { type ForwardedRef, forwardRef } from "react";
+import { TagList as RACTagList, type TagListProps as RACTagListProps, composeRenderProps, useContextProps } from "react-aria-components";
 
 import { composeClassnameRenderProps } from "../../utils/index.ts";
 
@@ -36,10 +36,10 @@ function TagList<T extends object>(props: TagListProps<T>, ref: ForwardedRef<HTM
 
     return (
         <RACTagList
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={style}
+            {...otherProps}
         >
             {children}
         </RACTagList>

--- a/packages/components/src/typography/Heading/src/Heading.tsx
+++ b/packages/components/src/typography/Heading/src/Heading.tsx
@@ -50,10 +50,10 @@ function Heading(props: HeadingProps, ref: ForwardedRef<HTMLHeadingElement>) {
 
     return (
         <RACHeading
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
+            {...otherProps}
         >
             {children}
         </RACHeading>

--- a/packages/components/src/typography/Label/src/Label.tsx
+++ b/packages/components/src/typography/Label/src/Label.tsx
@@ -66,10 +66,10 @@ function Label(props: LabelProps, ref: ForwardedRef<HTMLLabelElement>) {
 
     return (
         <RACLabel
-            {...otherProps}
             ref={ref}
             className={classNames}
             style={mergedStyles}
+            {...otherProps}
         >
             {children}
             {(necessityIndicator === "label" && !isRequired) && <span className={styles["hop-Label__label-indicator"]}> ({necessityLabel})</span>}

--- a/packages/components/src/typography/OverlineText/src/OverlineText.tsx
+++ b/packages/components/src/typography/OverlineText/src/OverlineText.tsx
@@ -1,6 +1,6 @@
-import { type StyledComponentProps, useStyledSystem } from "@hopper-ui/styled-system";
+import { useStyledSystem, type StyledComponentProps } from "@hopper-ui/styled-system";
 import clsx from "clsx";
-import { type ForwardedRef, forwardRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ForwardedRef } from "react";
 import { Text as RACText, useContextProps, type TextProps as RACTextProps } from "react-aria-components";
 
 import { cssModule } from "../../../utils/index.ts";
@@ -36,11 +36,11 @@ function OverlineText(props: OverlineTextProps, ref: ForwardedRef<HTMLSpanElemen
 
     return (
         <RACText
-            {...otherProps}
             ref={ref}
             elementType={elementType}
             className={classNames}
             style={mergedStyles}
+            {...otherProps}
         >
             <span className={styles["hop-OverlineText__text"]}>{children}</span>
         </RACText>

--- a/packages/components/src/typography/Text/src/Text.tsx
+++ b/packages/components/src/typography/Text/src/Text.tsx
@@ -52,11 +52,11 @@ function Text(props: TextProps, ref: ForwardedRef<HTMLSpanElement>) {
 
     return (
         <RACText
-            {...otherProps}
             ref={ref}
             elementType={elementType}
             className={classNames}
             style={mergedStyles}
+            {...otherProps}
         >
             <ClearContainerSlots>
                 <SlotProvider

--- a/packages/styled-system/src/html-wrappers/htmlElement.tsx
+++ b/packages/styled-system/src/html-wrappers/htmlElement.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { forwardRef, type ElementRef, type CSSProperties } from "react";
+import { forwardRef, type CSSProperties, type ElementRef } from "react";
 
 import type { StyledComponentProps } from "../styledSystemProps.ts";
 import { useStyledSystem } from "../useStyledSystem.ts";
@@ -36,7 +36,7 @@ export function htmlElement<T extends keyof JSX.IntrinsicElements>(elementType: 
             // useStyledSystem removes the styled system props, so what is remaining is valid for the elementType.
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            <As ref={ref} style={mergedStyles} {...otherProps} className={classNames} />
+            <As ref={ref} style={mergedStyles} className={classNames} {...otherProps} />
         );
     });
 }


### PR DESCRIPTION
Moved ...props and ...otherProps when possible, only applied this to components and not tests, nor chromatic. In some instances it was not possible, like here in `DeletedAvatar.tsx`:

    const renderProps = useRenderProps<DeletedAvatarRenderProps>({
        ...props,
        className: classNames,
        style: mergedStyles,
        values: {
            isDisabled: isDisabled || false
        }
    });
