### PR TITLE
Reorganized grouping of props to follow RAC

### DIFF
--- a/apps/docs/components/tag/tag.css
+++ b/apps/docs/components/tag/tag.css
@@ -1,3 +1,9 @@
+@property --font-size {
+    syntax: '<length>';
+    inherits: false;
+    initial-value: 1rem;
+}
+
 :root {
     --hd-tag-font-family: var(--hd-default-font-family);
     --hd-tag-font-size: 0.875rem;

--- a/apps/docs/scripts/generateComponentData.ts
+++ b/apps/docs/scripts/generateComponentData.ts
@@ -119,7 +119,7 @@ function getFormattedData(data: ComponentDoc[]): ComponentDocWithGroups[] {
         ],
         Background: [
             "background", "backgroundColor", "backgroundImage", "backgroundSize", "backgroundPosition", "backgroundRepeat",
-            "opacity" // ???
+            "opacity"
         ],
         Borders: [
             "border",
@@ -207,7 +207,7 @@ function getFormattedData(data: ComponentDoc[]): ComponentDocWithGroups[] {
                 if (Array.isArray(terms)) {
                     terms.forEach(term => {
                         if (
-                            (typeof term === "string" && prop.name.includes(term)) ||
+                            (typeof term === "string" && prop.name === term) ||
                             (term instanceof RegExp && term.test(prop.name))
                         ) {
                             groups[group][key] = prop;

--- a/apps/docs/scripts/generateComponentData.ts
+++ b/apps/docs/scripts/generateComponentData.ts
@@ -191,15 +191,15 @@ function getFormattedData(data: ComponentDoc[]): ComponentDocWithGroups[] {
             // Special handling for the "id" prop
             if (key === "id") {
                 if (prop.type?.name === "string") {
-                    groups.Accessibility[key] = prop; // Group under Accessibility if the type is string
+                    groups.Accessibility[key] = prop;
                     added = true;
                 } else {
-                    groups.default[key] = prop; // Group under default for non-string types
+                    groups.default[key] = prop;
                     added = true;
                 }
-                delete props[key]; // Remove it from the props to prevent further processing
+                delete props[key];
 
-                return; // Skip to the next prop
+                return;
             }
 
             // Check each group to see if the prop should be added to it

--- a/apps/docs/scripts/generateComponentData.ts
+++ b/apps/docs/scripts/generateComponentData.ts
@@ -154,9 +154,6 @@ function getFormattedData(data: ComponentDoc[]): ComponentDocWithGroups[] {
         ],
         Accessibility: [
             "role", "id", "tabIndex", "excludeFromTabOrder", "preventFocusOnPress", /^aria-/
-        ],
-        Advanced: [
-            "UNSAFE_className", "UNSAFE_style"
         ]
     };
 


### PR DESCRIPTION
Grouping of props in the documentation props table was flaky, in some instances isDisabled was considered an accessibility prop, where in other place it was not. This PR follows RAC ways of grouping props, while making sure than an id? string is considered an accessibility prop and an id? key is considered exposed in the "default" props.