### PR TITLE
Fix build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
             -   name: Generate documentation
                 run: pnpm doc:generate
 
-            -   name: Build apps
-                run: pnpm build:apps
+            -   name: Build sample apps
+                run: pnpm build:samples
 
             -   name: Lint packages
                 run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
                 run: pnpm doc:generate
 
             -   name: Build sample apps
-                run: pnpm build:samples
+                run: pnpm build:apps
 
             -   name: Lint packages
                 run: pnpm lint

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pnpm doc:generate && pnpm build && pnpm doc:build"
+  command = "pnpm doc:generate && pnpm build:pkg && pnpm doc:build"
   publish = "apps/docs/.next"
   environment = { NODE_OPTIONS = "--max-old-space-size=8192" }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "build:tokens": "pnpm --filter=\"@hopper-ui/tokens\" build",
         "build:pkg": "cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm -r --filter \"{packages/**}\" build ",
         "build:apps": "pnpm -r --filter \"{apps/**}\" build ",
+        "build:samples": "pnpm -r --filter \"{apps/samples/**}\" build ",
         "changeset": "changeset",
         "ci-release": "pnpm build:pkg && changeset publish",
         "generate-icons": "pnpm --filter=\"svg-icons\" generate-icons && pnpm --filter=\"@hopper-ui/icons*\" generate-icons",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "build:tokens": "pnpm --filter=\"@hopper-ui/tokens\" build",
         "build:pkg": "cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm -r --filter \"{packages/**}\" build ",
         "build:apps": "pnpm -r --filter \"{apps/**}\" build ",
-        "build:samples": "pnpm -r --filter \"{apps/samples/**}\" build ",
         "changeset": "changeset",
         "ci-release": "pnpm build:pkg && changeset publish",
         "generate-icons": "pnpm --filter=\"svg-icons\" generate-icons && pnpm --filter=\"@hopper-ui/icons*\" generate-icons",


### PR DESCRIPTION
At the moment, we are building the documentation when we want to only check if the sample apps build
We also build the samples app when building the documentation.

This will speed up the workflows