### PR TITLE
Fix hovering of ListboxItem

### DIFF
--- a/packages/components/src/ListBox/src/ListBox.tsx
+++ b/packages/components/src/ListBox/src/ListBox.tsx
@@ -76,7 +76,7 @@ function ListBox<T extends object>(props: ListBoxProps<T>, ref: ForwardedRef<HTM
         size: sizeProp,
         style: styleProp,
         selectionIndicator = "check",
-        selectionMode,
+        selectionMode = "single",
         loadingListBoxItemProps,
         ...otherProps
     } = ownProps;


### PR DESCRIPTION
Set selectionMode to single by default instead of none