### PR TITLE
Feature/ds 532 missing props

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,5 +166,37 @@ only a few strings to be used in the library. If we see that the bundle size is 
 into a file per component.
 
 
+## Exporting a component
 
+> [!IMPORTANT]
+> Avoid exporting multiple components in a single export statement for a single component file.
 
+Doing so can cause issues with tools like `react-docgen-typescript`, which may incorrectly parse and assign props from one component to another, leading to inaccurate documentation.
+
+Issue: When exporting multiple items in a single export statement for a component file, react-docgen-typescript can misinterpret the file structure. This often results in props from one component being incorrectly associated with another, creating confusion in the generated documentation.
+
+### Problem example
+
+Here’s an example of an incorrect approach:
+```tsx
+// File: ComboBox.tsx
+
+// ❌ Incorrect Export
+// This results in `react-docgen-typescript` associating the props of `ListBoxItem` with `ComboBox` in the documentation.
+export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem };
+```
+
+### Recommended approach
+
+To ensure proper parsing and accurate documentation, separate your exports:
+```tsx
+// File: ComboBox.tsx
+
+// ✅ Correct Export
+// Explicitly assign and export components individually to avoid parsing issues.
+export const ComboBoxItem = ListBoxItem;
+export const ComboBoxSection = ListBoxSection;
+
+// Export the main component separately
+export { _ComboBox as ComboBox };
+```

--- a/packages/components/src/ComboBox/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox/src/ComboBox.tsx
@@ -22,8 +22,8 @@ import { ErrorMessage } from "../../ErrorMessage/index.ts";
 import { useFormProps } from "../../Form/index.ts";
 import { HelperMessage } from "../../HelperMessage/index.ts";
 import { Footer } from "../../layout/index.ts";
-import { ListBox, ListBoxItem, type ListBoxProps, type SelectionIndicator } from "../../ListBox/index.ts";
-import { ListBoxSection } from "../../ListBoxSection/index.ts";
+import { ListBox, ListBoxItem, type ListBoxItemProps, type ListBoxProps, type SelectionIndicator } from "../../ListBox/index.ts";
+import { ListBoxSection, type ListBoxSectionProps } from "../../ListBoxSection/index.ts";
 import { Popover, type PopoverProps } from "../../overlays/index.ts";
 import { ToggleArrow } from "../../ToggleArrow/index.ts";
 import { Label, TextContext } from "../../typography/index.ts";
@@ -384,6 +384,8 @@ const _ComboBox = forwardRef(ComboBox) as <T extends object>(
 (_ComboBox as NamedExoticComponent).displayName = "ComboBox";
 
 export const ComboBoxItem = ListBoxItem;
+export type ComboBoxItemProps<T> = ListBoxItemProps<T>;
 export const ComboBoxSection = ListBoxSection;
+export type ComboBoxSectionProps<T> = ListBoxSectionProps<T>;
 
 export { _ComboBox as ComboBox };

--- a/packages/components/src/ComboBox/src/ComboBox.tsx
+++ b/packages/components/src/ComboBox/src/ComboBox.tsx
@@ -383,4 +383,7 @@ const _ComboBox = forwardRef(ComboBox) as <T extends object>(
 ) => ReturnType<typeof ComboBox>;
 (_ComboBox as NamedExoticComponent).displayName = "ComboBox";
 
-export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem, ListBoxSection as ComboBoxSection };
+export const ComboBoxItem = ListBoxItem;
+export const ComboBoxSection = ListBoxSection;
+
+export { _ComboBox as ComboBox };

--- a/packages/components/src/Select/src/Select.tsx
+++ b/packages/components/src/Select/src/Select.tsx
@@ -8,6 +8,7 @@ import {
     Select as RACSelect,
     TextContext as RACTextContext,
     useContextProps,
+    type ListBoxSectionProps,
     type ButtonProps as RACButtonProps,
     type SelectProps as RACSelectProps,
     type SelectValueRenderProps
@@ -18,7 +19,7 @@ import { ErrorMessage } from "../../ErrorMessage/index.ts";
 import { useFormProps } from "../../Form/index.ts";
 import { HelperMessage } from "../../HelperMessage/index.ts";
 import { Footer } from "../../layout/index.ts";
-import { ListBox, ListBoxItem, type ListBoxProps, type SelectionIndicator } from "../../ListBox/index.ts";
+import { ListBox, ListBoxItem, type ListBoxItemProps, type ListBoxProps, type SelectionIndicator } from "../../ListBox/index.ts";
 import { ListBoxSection } from "../../ListBoxSection/index.ts";
 import { Popover, type PopoverProps } from "../../overlays/index.ts";
 import { ToggleArrow } from "../../ToggleArrow/index.ts";
@@ -314,6 +315,8 @@ const _Select = forwardRef(Select) as <T extends object>(
 (_Select as NamedExoticComponent).displayName = "Select";
 
 export const SelectItem = ListBoxItem;
+export type SelectItemProps<T> = ListBoxItemProps<T>;
 export const SelectSection = ListBoxSection;
+export type SelectSectionProps<T> = ListBoxSectionProps<T>;
 
 export { _Select as Select };

--- a/packages/components/src/Select/src/Select.tsx
+++ b/packages/components/src/Select/src/Select.tsx
@@ -313,4 +313,7 @@ const _Select = forwardRef(Select) as <T extends object>(
 ) => ReturnType<typeof Select>;
 (_Select as NamedExoticComponent).displayName = "Select";
 
-export { _Select as Select, ListBoxItem as SelectItem, ListBoxSection as SelectSection };
+export const SelectItem = ListBoxItem;
+export const SelectSection = ListBoxSection;
+
+export { _Select as Select };


### PR DESCRIPTION
Fix an issue where the wrong props were assigned to a component in the documentation. Adding this section in CONTRIBUTING.md to exaplin the issue for future problems.

## Exporting a component

> [!IMPORTANT]
> Avoid exporting multiple components in a single export statement for a single component file.

Doing so can cause issues with tools like `react-docgen-typescript`, which may incorrectly parse and assign props from one component to another, leading to inaccurate documentation.

Issue: When exporting multiple items in a single export statement for a component file, react-docgen-typescript can misinterpret the file structure. This often results in props from one component being incorrectly associated with another, creating confusion in the generated documentation.

### Problem example

Here’s an example of an incorrect approach:
```tsx
// File: ComboBox.tsx

// ❌ Incorrect Export
// This results in `react-docgen-typescript` associating the props of `ListBoxItem` with `ComboBox` in the documentation.
export { _ComboBox as ComboBox, ListBoxItem as ComboBoxItem };
```

### Recommended approach

To ensure proper parsing and accurate documentation, separate your exports:
```tsx
// File: ComboBox.tsx

// ✅ Correct Export
// Explicitly assign and export components individually to avoid parsing issues.
export const ComboBoxItem = ListBoxItem;
export const ComboBoxSection = ListBoxSection;

// Export the main component separately
export { _ComboBox as ComboBox };
```
