### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ pnpm changeset
 - Follow the prompts to describe the changes made and choose the appropriate version bump.
 - A template for the release notes of svg-icons and icons is available in the `.changeset` folder [here](./.changeset-templates/svg-icons-release.md).
 
-5- Go update the react16 icons from this [github repo](https://github.com/gsoft-inc/wl-hopper-react16/blob/main/CONTRIBUTING.md)
+5- Go update the react16 icons from this [github repo](https://github.com/workleap/wl-hopper-react16/blob/main/CONTRIBUTING.md)
 
 ## Updating or removing an icon
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before starting make sure [node](https://nodejs.org/en/) and [pnpm](https://pnpm
 After cloning the source code, run `pnpm` to install dependencies.
 
 ```bash
-git clone https://github.com/gsoft-inc/wl-hopper.git
+git clone https://github.com/workleap/wl-hopper.git
 cd wl-hopper
 pnpm i
 pnpm build
@@ -27,8 +27,8 @@ pnpm build
 
 ## 🤝 Contributing
 
-Pull requests are welcome. For major changes, please open a [discussions](https://github.com/gsoft-inc/wl-hopper/discussions/new/choose) first to discuss what you would like to change. If you're interested, definitely check out our Contributing Guide!
+Pull requests are welcome. For major changes, please open a [discussions](https://github.com/workleap/wl-hopper/discussions/new/choose) first to discuss what you would like to change. If you're interested, definitely check out our Contributing Guide!
 
 ## License
 
-Copyright © 2023, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2023, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/apps/docs/app/ui/home-page/GithubButton.tsx
+++ b/apps/docs/app/ui/home-page/GithubButton.tsx
@@ -5,7 +5,7 @@ import { ExternalLinkIcon, Icon } from "@/components/icon";
 export const GithubButton = () => {
     return (
         <LinkButton
-            href="https://github.com/gsoft-inc/wl-hopper"
+            href="https://github.com/workleap/wl-hopper"
             variant="secondary"
             target="_blank"
         >

--- a/apps/docs/app/ui/layout/header/Header.tsx
+++ b/apps/docs/app/ui/layout/header/Header.tsx
@@ -73,7 +73,7 @@ const ProductMenuAndBrand = () => {
                     >
                         <span className="hd-product__title">Frontend tools</span>
                         <Link className="hd-product__link"
-                            href="https://gsoft-inc.github.io/wl-idp-docs-hub/"
+                            href="https://workleap.github.io/wl-idp-docs-hub/"
                         >IDP Hub</Link>
                         <ul className="hd-product__items">
                             <span className="hd-product__title">Design Systems</span>

--- a/apps/docs/app/ui/layout/header/Header.tsx
+++ b/apps/docs/app/ui/layout/header/Header.tsx
@@ -142,7 +142,7 @@ const Header = () => {
                     <div className="hd-header__quick-actions">
                         {/*<input type="search" placeholder="Search" />*/}
                         <ThemeSwitch onChange={toggleTheme} colorMode={colorMode as ColorScheme} />
-                        <LinkIconButton href="https://github.com/gsoft-inc/wl-hopper" target="_blank" aria-label="View source on Github">
+                        <LinkIconButton href="https://github.com/workleap/wl-hopper" target="_blank" aria-label="View source on Github">
                             <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                                 {/* eslint-disable max-len */}
                                 <path

--- a/apps/docs/app/ui/layout/mobileMenu/MobileMenu.tsx
+++ b/apps/docs/app/ui/layout/mobileMenu/MobileMenu.tsx
@@ -113,7 +113,7 @@ const MobileMenu = ({ onClose, isOpen }: MobileMenuProps) => {
                     <nav>
                         <ul className="hd-mobile-menu-footer-list">
                             <li>
-                                <Link href="https://github.com/gsoft-inc/wl-hopper"
+                                <Link href="https://github.com/workleap/wl-hopper"
                                     target="_blank"
                                     className="hd-mobile-menu-footer-link"
                                 >

--- a/apps/docs/content/components/application/HopperProvider.mdx
+++ b/apps/docs/content/components/application/HopperProvider.mdx
@@ -4,7 +4,7 @@ description: HopperProvider is the container for all applications using Hopper. 
 order: 1
 category: "application"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/HopperProvider/src/HopperProvider.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/HopperProvider/src/HopperProvider.tsx
 ---
 
 <CodeOnlyExample src="HopperProvider/docs/hopper-provider/preview" />

--- a/apps/docs/content/components/buttons/Button.mdx
+++ b/apps/docs/content/components/buttons/Button.mdx
@@ -3,7 +3,7 @@ title: Button
 description: A button allows a user to initiate an action.
 category: "buttons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/buttons/src/Button.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/buttons/src/Button.tsx
     aria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 ---
 

--- a/apps/docs/content/components/buttons/ButtonGroup.mdx
+++ b/apps/docs/content/components/buttons/ButtonGroup.mdx
@@ -3,7 +3,7 @@ title: ButtonGroup
 description: A button group handles the spacing and orientation for a grouping of buttons.
 category: "buttons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/buttons/src/ButtonGroup.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/buttons/src/ButtonGroup.tsx
 ---
 
 <Example src="buttons/docs/buttonGroup/preview" isOpen />

--- a/apps/docs/content/components/buttons/LinkButton.mdx
+++ b/apps/docs/content/components/buttons/LinkButton.mdx
@@ -3,7 +3,7 @@ title: LinkButton
 description: A LinkButton looks like a button but behaves like a link.
 category: "buttons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/buttons/src/LinkButton.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/buttons/src/LinkButton.tsx
     aria: https://www.w3.org/WAI/ARIA/apg/patterns/link/
 ---
 

--- a/apps/docs/content/components/buttons/SegmentedControl.mdx
+++ b/apps/docs/content/components/buttons/SegmentedControl.mdx
@@ -3,7 +3,7 @@ title: SegmentedControl
 description: The SegmentedControl component presents a horizontal row of options or actions that are contextually or conceptually related. It allows users to select a single option at a time.
 category: "buttons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/SegmentedControl/src/SegmentedControl.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/SegmentedControl/src/SegmentedControl.tsx
 ---
 
 <Example src="SegmentedControl/docs/preview" isOpen />

--- a/apps/docs/content/components/buttons/Tile.mdx
+++ b/apps/docs/content/components/buttons/Tile.mdx
@@ -4,7 +4,7 @@ alpha: "This component is still a work in progress and may not fully address all
 description: A tile groups information into an interactive element to let users browse and take action on a group of related items.
 category: "buttons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Tile/src/Tile.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Tile/src/Tile.tsx
 ---
 
 <Example src="Tile/docs/preview" isOpen />

--- a/apps/docs/content/components/buttons/TileGroup.mdx
+++ b/apps/docs/content/components/buttons/TileGroup.mdx
@@ -4,7 +4,7 @@ alpha: "This component is still a work in progress and may not fully address all
 description: A TileGroup groups Tiles to let users browse and take action on a group of related items.
 category: "buttons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Tile/src/TileGroup.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Tile/src/TileGroup.tsx
 ---
 
 <Example src="Tile/docs/TileGroup/preview" isOpen />

--- a/apps/docs/content/components/collections/Listbox.mdx
+++ b/apps/docs/content/components/collections/Listbox.mdx
@@ -3,7 +3,7 @@ title: ListBox
 description: A list box displays actions relevant to the user’s current selection.
 category: "collections"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/ListBox/src/ListBox.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/ListBox/src/ListBox.tsx
     aria: https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
 ---
 

--- a/apps/docs/content/components/collections/TagGroup.mdx
+++ b/apps/docs/content/components/collections/TagGroup.mdx
@@ -4,7 +4,7 @@ description: The TagGroup is a dynamic UI component that encapsulates a collecti
              Each tag represents a label, category, keyword, or filter, and can be used for various groupings
 category: "collections"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/tag/src/TagGroup.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/tag/src/TagGroup.tsx
 ---
 
 <Example src="tag/docs/preview" />

--- a/apps/docs/content/components/content/Avatar.mdx
+++ b/apps/docs/content/components/content/Avatar.mdx
@@ -3,7 +3,7 @@ title: Avatar
 description: An avatar is used to represent a user, team or another entity.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Avatar/src/Avatar.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Avatar/src/Avatar.tsx
 ---
 
 <Example src="Avatar/docs/preview" isOpen />

--- a/apps/docs/content/components/content/Card.mdx
+++ b/apps/docs/content/components/content/Card.mdx
@@ -3,7 +3,7 @@ title: Card
 description: Cards are used to group similar concepts and tasks to make it easier for users to scan, read and get things done.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Card/src/Card.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Card/src/Card.tsx
 ---
 
 <Example src="Card/docs/preview" isOpen />

--- a/apps/docs/content/components/content/Divider.mdx
+++ b/apps/docs/content/components/content/Divider.mdx
@@ -3,7 +3,7 @@ title: Divider
 description: A divider separates sections of content or groups.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Divider/src/Divider.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Divider/src/Divider.tsx
 ---
 
 <Example src="Divider/docs/preview" isOpen />

--- a/apps/docs/content/components/content/Heading.mdx
+++ b/apps/docs/content/components/content/Heading.mdx
@@ -3,7 +3,7 @@ title: Heading
 description: A heading is a primitive component matching Hopper's typography type scale.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/typography/Heading/src/Heading.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/typography/Heading/src/Heading.tsx
 ---
 <Example src="typography/Heading/docs/preview" isOpen />
 

--- a/apps/docs/content/components/content/IllustratedMessage.mdx
+++ b/apps/docs/content/components/content/IllustratedMessage.mdx
@@ -3,7 +3,7 @@ title: IllustratedMessage
 description: An illustrated message display an image and a message, usually for an empty state or an error page.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/IllustratedMessage/src/IllustratedMessage.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/IllustratedMessage/src/IllustratedMessage.tsx
 ---
 
 <Example src="IllustratedMessage/docs/default" isOpen />

--- a/apps/docs/content/components/content/Image.mdx
+++ b/apps/docs/content/components/content/Image.mdx
@@ -3,7 +3,7 @@ title: Image
 description: An image component that can be used to display images.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Image/src/Image.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Image/src/Image.tsx
 ---
 
 <Example src="Image/docs/image" isOpen />

--- a/apps/docs/content/components/content/Label.mdx
+++ b/apps/docs/content/components/content/Label.mdx
@@ -3,7 +3,7 @@ title: Label
 description: A label is a primitive component matching Hopper's typography type scale.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/typography/Label/src/Label.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/typography/Label/src/Label.tsx
 ---
 <Example src="typography/Label/docs/preview" isOpen />
 

--- a/apps/docs/content/components/content/Text.mdx
+++ b/apps/docs/content/components/content/Text.mdx
@@ -3,7 +3,7 @@ title: Text
 description: A text component is a primitive component matching Hopper's typography type scale.
 category: "content"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/typography/Text/src/Text.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/typography/Text/src/Text.tsx
 ---
 
 <Example src="typography/Text/docs/text/preview" isOpen />

--- a/apps/docs/content/components/forms/CheckboxGroup.mdx
+++ b/apps/docs/content/components/forms/CheckboxGroup.mdx
@@ -3,7 +3,7 @@ title: CheckboxGroup
 description: A checkbox group handles the spacing and orientation for a grouping of checkboxes, as well as providing a label.
 category: "forms"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/checkbox/src/CheckboxGroup.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/checkbox/src/CheckboxGroup.tsx
 ---
 
 <Example src="checkbox/docs/checkboxgroup/preview" isOpen />

--- a/apps/docs/content/components/forms/NumberField.mdx
+++ b/apps/docs/content/components/forms/NumberField.mdx
@@ -3,7 +3,7 @@ title: NumberField
 description: A number field is a specialized input that allows a user to enter a number.
 category: "forms"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/NumberField.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/inputs/src/NumberField.tsx
 ---
 
 <Example src="inputs/docs/numberField/preview" isOpen />

--- a/apps/docs/content/components/forms/PasswordField.mdx
+++ b/apps/docs/content/components/forms/PasswordField.mdx
@@ -3,7 +3,7 @@ title: PasswordField
 description: A password field is a specialized text field that allows a user to enter a password.
 category: "forms"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/PasswordField.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/inputs/src/PasswordField.tsx
 ---
 
 <Example src="inputs/docs/passwordField/preview" isOpen />

--- a/apps/docs/content/components/forms/SearchField.mdx
+++ b/apps/docs/content/components/forms/SearchField.mdx
@@ -3,7 +3,7 @@ title: SearchField
 description: A search field is a specialized text input allowing the user to perform a search.
 category: "forms"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/SearchField.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/inputs/src/SearchField.tsx
 ---
 
 <Example src="inputs/docs/searchField/preview" isOpen />

--- a/apps/docs/content/components/forms/TextArea.mdx
+++ b/apps/docs/content/components/forms/TextArea.mdx
@@ -3,7 +3,7 @@ title: TextArea
 description: A text area serves as a multi-line, plain-text editing interface.
 category: "forms"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/TextArea.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/inputs/src/TextArea.tsx
 ---
 
 <Example src="inputs/docs/textArea/preview" isOpen />

--- a/apps/docs/content/components/forms/TextField.mdx
+++ b/apps/docs/content/components/forms/TextField.mdx
@@ -3,7 +3,7 @@ title: TextField
 description: A text field allows a user to enter a plain text value.
 category: "forms"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/inputs/src/TextField.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/inputs/src/TextField.tsx
 ---
 
 Specialized text fields are available for different scenarios:

--- a/apps/docs/content/components/icons/Icon.mdx
+++ b/apps/docs/content/components/icons/Icon.mdx
@@ -3,7 +3,7 @@ title: Icon
 description: An icon component is used to render a custom icon.
 category: "icons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/icons/src/Icon.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/icons/src/Icon.tsx
 ---
 
 <Example src="icons/docs/icon/preview" isOpen />

--- a/apps/docs/content/components/icons/IconList.mdx
+++ b/apps/docs/content/components/icons/IconList.mdx
@@ -3,7 +3,7 @@ title: IconList
 description: An IconList encapsulates a collection of icons.
 category: "icons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/IconList/src/IconList.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/IconList/src/IconList.tsx
 ---
 
 <Example src="IconList/docs/preview" isOpen />

--- a/apps/docs/content/components/icons/RichIcon.mdx
+++ b/apps/docs/content/components/icons/RichIcon.mdx
@@ -3,7 +3,7 @@ title: RichIcon
 description: A rich icon component is used to render a rich custom icon.
 category: "icons"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/icons/src/RichIcon.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/icons/src/RichIcon.tsx
 ---
 
 <Example src="icons/docs/richIcon/preview" isOpen />

--- a/apps/docs/content/components/internal-parts/ErrorMessage.mdx
+++ b/apps/docs/content/components/internal-parts/ErrorMessage.mdx
@@ -3,7 +3,7 @@ title: ErrorMessage
 description: An error message displays validation errors for a form field.
 category: "internal parts"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/ErrorMessage/src/ErrorMessage.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/ErrorMessage/src/ErrorMessage.tsx
 ---
 
 <Example src="ErrorMessage/docs/preview" isOpen />

--- a/apps/docs/content/components/internal-parts/HelperMessage.mdx
+++ b/apps/docs/content/components/internal-parts/HelperMessage.mdx
@@ -3,7 +3,7 @@ title: HelperMessage
 description: A helper message component displays auxiliary text to guide users in the interface.
 category: "internal parts"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/HelperMessage/src/HelperMessage.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/HelperMessage/src/HelperMessage.tsx
 ---
 
 <Example src="HelperMessage/docs/preview" isOpen />

--- a/apps/docs/content/components/layout/Flex.mdx
+++ b/apps/docs/content/components/layout/Flex.mdx
@@ -3,7 +3,7 @@ title: Flex
 description: A flex component is used to create a flex container.
 category: "layout"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Flex.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/layout/src/Flex.tsx
 ---
 
 <Example src="layout/docs/flex/preview" isOpen />

--- a/apps/docs/content/components/layout/Grid.mdx
+++ b/apps/docs/content/components/layout/Grid.mdx
@@ -3,7 +3,7 @@ title: Grid
 description: The grid component is used to create a grid container.
 category: "layout"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Grid.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/layout/src/Grid.tsx
 ---
 
 <Example src="layout/docs/grid/preview" isOpen />

--- a/apps/docs/content/components/layout/Inline.mdx
+++ b/apps/docs/content/components/layout/Inline.mdx
@@ -3,7 +3,7 @@ title: Inline
 description: An inline component is a layout primitive used to arrange elements horizontally.
 category: "layout"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Inline.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/layout/src/Inline.tsx
 ---
 
 <Example src="layout/docs/inline/preview" isOpen />

--- a/apps/docs/content/components/layout/Stack.mdx
+++ b/apps/docs/content/components/layout/Stack.mdx
@@ -3,7 +3,7 @@ title: Stack
 description: A stack component is a layout primitive used to arrange elements vertically.
 category: "layout"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Stack.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/layout/src/Stack.tsx
 ---
 
 <Example src="layout/docs/stack/preview" isOpen />

--- a/apps/docs/content/components/navigation/Accordion.mdx
+++ b/apps/docs/content/components/navigation/Accordion.mdx
@@ -3,7 +3,7 @@ title: Accordion
 description: An Accordion is a grouping of related disclosures. It supports both single and multiple expanded items.
 category: "navigation"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Accordion/src/Accordion.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Accordion/src/Accordion.tsx
 ---
 
 <Example src="Accordion/docs/preview" isOpen />

--- a/apps/docs/content/components/navigation/Disclosure.mdx
+++ b/apps/docs/content/components/navigation/Disclosure.mdx
@@ -3,7 +3,7 @@ title: Disclosure
 description: The disclosure component is used to put long sections of information under a block that users can expand or collapse.
 category: "navigation"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Disclosure/src/Disclosure.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Disclosure/src/Disclosure.tsx
     aria: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
 ---
 

--- a/apps/docs/content/components/navigation/Link.mdx
+++ b/apps/docs/content/components/navigation/Link.mdx
@@ -3,7 +3,7 @@ title: Link
 description: A link allows a user to navigate to a different location.
 category: "navigation"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Link/src/Link.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Link/src/Link.tsx
     aria: https://www.w3.org/WAI/ARIA/apg/patterns/link/
 ---
 

--- a/apps/docs/content/components/overlays/Modal.mdx
+++ b/apps/docs/content/components/overlays/Modal.mdx
@@ -3,7 +3,7 @@ title: Modal
 description: Modals focus the user’s attention exclusively on one task or piece of information via a window that sits on top of the page content.
 category: "overlays"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Modal/src/Modal.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Modal/src/Modal.tsx
 ---
 
 <Example src="Modal/docs/preview" isOpen />

--- a/apps/docs/content/components/overlays/Popover.mdx
+++ b/apps/docs/content/components/overlays/Popover.mdx
@@ -3,7 +3,7 @@ title: Popover
 description: A popover displays additional content when a user interacts with a trigger element.
 category: "overlays"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/overlays/Popover/src/Popover.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/overlays/Popover/src/Popover.tsx
 ---
 
 <Example src="overlays/Popover/docs/preview" isOpen />

--- a/apps/docs/content/components/pickers/ComboBox.mdx
+++ b/apps/docs/content/components/pickers/ComboBox.mdx
@@ -3,7 +3,7 @@ title: ComboBox
 description: A combo box allows the user to make a selection from a list of suggested, likely or desired values.
 category: "pickers"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/checkbox/src/Checkbox.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/checkbox/src/Checkbox.tsx
     aria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 ---
 

--- a/apps/docs/content/components/pickers/Select.mdx
+++ b/apps/docs/content/components/pickers/Select.mdx
@@ -3,7 +3,7 @@ title: Select
 description: A select displays a collapsible list of options from which the user can select one.
 category: "pickers"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Select/src/Select.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Select/src/Select.tsx
 ---
 
 <Example src="Select/docs/preview" isOpen />

--- a/apps/docs/content/components/placeholders/Content.mdx
+++ b/apps/docs/content/components/placeholders/Content.mdx
@@ -3,7 +3,7 @@ title: Content
 description: A placeholder for the main content section of a component.
 category: "placeholders"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Content.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/layout/src/Content.tsx
 ---
 
 A content placeholder component provides no specific styling by itself, but receives styling from the parent container. In addition, a content placeholder will be automatically placed within the container's layout according to Hopper guidelines.

--- a/apps/docs/content/components/placeholders/Footer.mdx
+++ b/apps/docs/content/components/placeholders/Footer.mdx
@@ -3,7 +3,7 @@ title: Footer
 description: A placeholder for a footer section.
 category: "placeholders"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/layout/src/Footer.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/layout/src/Footer.tsx
 ---
 
 A footer placeholder component provides no specific styling by itself, but receives styling from the parent container. In addition, a footer placeholder will be automatically placed within the container's layout according to Hopper guidelines.

--- a/apps/docs/content/components/placeholders/Header.mdx
+++ b/apps/docs/content/components/placeholders/Header.mdx
@@ -3,7 +3,7 @@ title: Header
 description: A placeholder for an header section.
 category: "placeholders"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Header/src/Header.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Header/src/Header.tsx
 ---
 
 An header placeholder component provides no specific styling by itself, but receives styling from the parent container. In addition, an header placeholder will be automatically placed within the container's layout according to Hopper guidelines.

--- a/apps/docs/content/components/status/Badge.mdx
+++ b/apps/docs/content/components/status/Badge.mdx
@@ -3,7 +3,7 @@ title: Badge
 description: A badge is used to bring attention to an element.
 category: "status"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Badge/src/Badge.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Badge/src/Badge.tsx
 ---
 
 <Example src="Badge/docs/badge/preview" isOpen />

--- a/apps/docs/content/components/status/Callout.mdx
+++ b/apps/docs/content/components/status/Callout.mdx
@@ -4,7 +4,7 @@ alpha: "This component still has accessibility issues in Dark Mode. It can be us
 description: A Callout informs users about important changes or persistent conditions. Use this component to communicate to users in a prominent way. Callouts are placed at the top of the page or section they apply to, and below the page or section header.
 category: "status"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Callout/src/Callout.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Callout/src/Callout.tsx
 ---
 
 <Example src="Callout/docs/preview" isOpen />

--- a/apps/docs/content/components/status/FloatingBadge.mdx
+++ b/apps/docs/content/components/status/FloatingBadge.mdx
@@ -3,7 +3,7 @@ title: FloatingBadge
 description: A floating badge allows the user to position a badge relative to another component.
 category: "status"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Badge/src/FloatingBadge.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Badge/src/FloatingBadge.tsx
 ---
 
 <Example src="Badge/docs/floatingbadge/preview" isOpen />

--- a/apps/docs/content/components/status/Spinner.mdx
+++ b/apps/docs/content/components/status/Spinner.mdx
@@ -3,7 +3,7 @@ title: Spinner
 description: A spinner indicates that a part of the product is currently performing a task of unknown duration.
 category: "status"
 links:
-    source: https://github.com/gsoft-inc/wl-hopper/blob/main/packages/components/src/Spinner/src/Spinner.tsx
+    source: https://github.com/workleap/wl-hopper/blob/main/packages/components/src/Spinner/src/Spinner.tsx
 ---
 <Example src="Spinner/docs/preview" isOpen />
 

--- a/apps/docs/content/getting-started/guides/components.mdx
+++ b/apps/docs/content/getting-started/guides/components.mdx
@@ -155,7 +155,7 @@ function MyCustomButtonPopoverTrigger({ children, ...rest }: PopoverTriggerProps
 
 When you need extensive customizations that go beyond simple styling or behavior adjustments, copying the component code can be an effective solution. This allows you to make specific changes while retaining the existing structure, making the customized component reusable across similar use cases.
 
-Take a look to [Hopper's components source code](https://github.com/gsoft-inc/wl-hopper/tree/main/packages/components)
+Take a look to [Hopper's components source code](https://github.com/workleap/wl-hopper/tree/main/packages/components)
 
 <Callout variant="information">
 **Encountering Design System Limitations?**

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "module",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper.git"
+        "url": "git+https://github.com/workleap/wl-hopper.git"
     },
     "scripts": {
         "doc:start": "pnpm --filter=docs dev",
@@ -96,8 +96,8 @@
         "eslint-plugin-react-hooks": "4.6.2"
     },
     "bugs": {
-        "url": "https://github.com/gsoft-inc/wl-hopper/issues"
+        "url": "https://github.com/workleap/wl-hopper/issues"
     },
-    "homepage": "https://github.com/gsoft-inc/wl-hopper#readme",
+    "homepage": "https://github.com/workleap/wl-hopper#readme",
     "packageManager": "pnpm@10.0.0"
 }

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -36,8 +36,8 @@ View the [user's documentation](https://hopper.workleap.design/).
 
 ## 🤝 Contributing
 
-View the [contributor's documentation](https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md).
+View the [contributor's documentation](https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper.git",
+        "url": "git+https://github.com/workleap/wl-hopper.git",
         "directory": "packages/components"
     },
     "publishConfig": {

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -11,8 +11,8 @@ View the [user's documentation](https://hopper.workleap.design/).
 
 ## 🤝 Contributing
 
-View the [contributor's documentation](https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md).
+View the [contributor's documentation](https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper.git",
+        "url": "git+https://github.com/workleap/wl-hopper.git",
         "directory": "packages/icons"
     },
     "publishConfig": {

--- a/packages/styled-system/README.md
+++ b/packages/styled-system/README.md
@@ -11,8 +11,8 @@ View the [user's documentation](https://hopper.workleap.design/).
 
 ## 🤝 Contributing
 
-View the [contributor's documentation](https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md).
+View the [contributor's documentation](https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper.git",
+        "url": "git+https://github.com/workleap/wl-hopper.git",
         "directory": "packages/styled-system"
     },
     "publishConfig": {

--- a/packages/styled-system/src/useStyledSystem.ts
+++ b/packages/styled-system/src/useStyledSystem.ts
@@ -323,7 +323,7 @@ class StylingContext {
 
     constructor(className: string | undefined, style: CSSProperties | undefined, matchedBreakpoints: Breakpoint[]) {
         this.#classes = !isNil(className) ? [className] : [];
-        this.#style = { ...(style ?? {}) } ; // TODO: different than orbit, in order to not modify the original style object https://github.com/gsoft-inc/sg-orbit/issues/1211
+        this.#style = { ...(style ?? {}) } ; // TODO: different than orbit, in order to not modify the original style object https://github.com/workleap/sg-orbit/issues/1211
         this.matchedBreakpoints = matchedBreakpoints;
     }
 
@@ -338,7 +338,7 @@ class StylingContext {
     addStyleValue(name: string, value: unknown) {
         // TODO: different than orbit, there was a check here to check if the style was already set. It caused issue where
         // if you were doing paddingX and then paddingLeft, the paddingLeft would not be applied because the paddingX was already set.
-        // https://github.com/gsoft-inc/sg-orbit/issues/1210
+        // https://github.com/workleap/sg-orbit/issues/1210
 
         // Removing this line causes 2 tests to fail, but i think the behavior is OK.
         //if ((this.#style as Record<string, unknown>)[name] === undefined) {

--- a/packages/svg-icons/README.md
+++ b/packages/svg-icons/README.md
@@ -11,8 +11,8 @@ View the [user's documentation](https://hopper.workleap.design/).
 
 ## 🤝 Contributing
 
-View the [contributor's documentation](https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md).
+View the [contributor's documentation](https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/packages/svg-icons/package.json
+++ b/packages/svg-icons/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper.git",
+        "url": "git+https://github.com/workleap/wl-hopper.git",
         "directory": "packages/svg-icons"
     },
     "publishConfig": {

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -11,8 +11,8 @@ View the [user's documentation](https://hopper.workleap.design/).
 
 ## 🤝 Contributing
 
-View the [contributor's documentation](https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md).
+View the [contributor's documentation](https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper.git",
+        "url": "git+https://github.com/workleap/wl-hopper.git",
         "directory": "packages/tokens"
     },
     "keywords": [


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 