### PR TITLE
fix(Badge): Fixes badge display with zero value

### DIFF
--- a/.changeset/quick-crabs-bathe.md
+++ b/.changeset/quick-crabs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Fixes badge dot display with zero value

--- a/packages/components/src/badge/src/Badge.tsx
+++ b/packages/components/src/badge/src/Badge.tsx
@@ -5,7 +5,7 @@ import { mergeProps } from "react-aria";
 import { composeRenderProps, useContextProps } from "react-aria-components";
 
 import { OverlineText } from "../../typography/index.ts";
-import { ClearContainerSlots, composeClassnameRenderProps, cssModule, useRenderProps, type AccessibleSlotProps, type RenderProps } from "../../utils/index.ts";
+import { ClearContainerSlots, composeClassnameRenderProps, cssModule, isNil, useRenderProps, type AccessibleSlotProps, type RenderProps } from "../../utils/index.ts";
 import { mapOrbiterToHopperVariants } from "../utils/Badge.utils.ts";
 
 import { BadgeContext, type BadgeContextValue } from "./BadgeContext.ts";
@@ -107,7 +107,7 @@ function Badge(props: BadgeProps, ref: ForwardedRef<HTMLSpanElement>) {
         }
     });
 
-    const isDot = isIndeterminate || !renderProps.children;
+    const isDot = isIndeterminate || isNil(renderProps.children);
     const filteredProps = filterDOMProps(otherProps, { labelable: true });
 
     return (

--- a/packages/components/src/badge/tests/chromatic/Badge.stories.tsx
+++ b/packages/components/src/badge/tests/chromatic/Badge.stories.tsx
@@ -100,3 +100,9 @@ export const AccessToIndeterminateState = {
         />
     )
 } satisfies Story;
+
+export const Number = {
+    render: props => (
+        <Badge {...props}>{0}</Badge>
+    )
+} satisfies Story;


### PR DESCRIPTION
Ensures the badge correctly displays as a dot when the child component's value is zero. 
Updates the logic to use `isNil` instead of checking for the existence of renderProps.children. 
Also, adds a Chromatic story to cover the new functionality.