### PR TITLE
feat(tokens): add support for gradient and shadow tokens (W3C standard)

### DIFF
--- a/.changeset/funky-oranges-send.md
+++ b/.changeset/funky-oranges-send.md
@@ -1,0 +1,8 @@
+---
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+"@hopper-ui/tokens": patch
+---
+
+- Add support for gradient color tokens: https://www.npmjs.com/package/style-dictionary-utils#gradientcss
+- Add support for shadow tokens:  https://www.npmjs.com/package/style-dictionary-utils#shadowcss

--- a/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
+++ b/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
@@ -993,6 +993,10 @@ export const DataVizColors = {
     "dataviz_text-ondark": "dataviz-text-ondark"
 } as const;
 
+export const GradientColors = {
+
+} as const;
+
 export const Elevation = {
     "core_none": "shadow-none",
     "core_sm": "shadow-sm",
@@ -1276,5 +1280,5 @@ export const Motions = {
     "easing-expressive": "easing-expressive"
 } as const;
 
-export type HopperTokenKey = `--hop-${typeof HopperColors[keyof typeof HopperColors] | typeof BackgroundColors[keyof typeof BackgroundColors] | typeof TextColors[keyof typeof TextColors] | typeof IconColors[keyof typeof IconColors] | typeof BorderColors[keyof typeof BorderColors] | typeof DataVizColors[keyof typeof DataVizColors] | typeof Elevation[keyof typeof Elevation] | typeof FontFamily[keyof typeof FontFamily] | typeof FontWeight[keyof typeof FontWeight] | typeof FontOffset[keyof typeof FontOffset] | typeof FontSize[keyof typeof FontSize] | typeof LineHeight[keyof typeof LineHeight] | typeof Shape[keyof typeof Shape] | typeof CoreSpace[keyof typeof CoreSpace] | typeof Motions[keyof typeof Motions] | typeof SemanticSimplePaddingSpace[keyof typeof SemanticSimplePaddingSpace] | typeof SemanticComplexPaddingSpace[keyof typeof SemanticComplexPaddingSpace] | typeof SemanticSimpleMarginSpace[keyof typeof SemanticSimpleMarginSpace] | typeof SemanticComplexMarginSpace[keyof typeof SemanticComplexMarginSpace]}`;
+export type HopperTokenKey = `--hop-${typeof HopperColors[keyof typeof HopperColors] | typeof BackgroundColors[keyof typeof BackgroundColors] | typeof TextColors[keyof typeof TextColors] | typeof IconColors[keyof typeof IconColors] | typeof BorderColors[keyof typeof BorderColors] | typeof DataVizColors[keyof typeof DataVizColors] | typeof GradientColors[keyof typeof GradientColors] | typeof Elevation[keyof typeof Elevation] | typeof FontFamily[keyof typeof FontFamily] | typeof FontWeight[keyof typeof FontWeight] | typeof FontOffset[keyof typeof FontOffset] | typeof FontSize[keyof typeof FontSize] | typeof LineHeight[keyof typeof LineHeight] | typeof Shape[keyof typeof Shape] | typeof CoreSpace[keyof typeof CoreSpace] | typeof Motions[keyof typeof Motions] | typeof SemanticSimplePaddingSpace[keyof typeof SemanticSimplePaddingSpace] | typeof SemanticComplexPaddingSpace[keyof typeof SemanticComplexPaddingSpace] | typeof SemanticSimpleMarginSpace[keyof typeof SemanticSimpleMarginSpace] | typeof SemanticComplexMarginSpace[keyof typeof SemanticComplexMarginSpace]}`;
 export type HopperCssVar = `var(${HopperTokenKey})`;

--- a/packages/styled-system/src/tokens/tokenMappings.ts
+++ b/packages/styled-system/src/tokens/tokenMappings.ts
@@ -16,6 +16,7 @@ import {
     FontFamily,
     FontSize,
     FontWeight,
+    GradientColors,
     HopperColors,
     IconColors,
     LineHeight,
@@ -61,6 +62,7 @@ function createOutlineValueTemplate(value: string) {
 // mappings
 export const ColorMapping = createMapping(HopperColors);
 export const DataVizColorMapping = createMapping(DataVizColors);
+export const GradientColorMapping = createMapping(GradientColors);
 
 export const BackgroundColorMapping = {
     ...createMapping(BackgroundColors),

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -49,6 +49,7 @@
         "eslint-plugin-import": "2.32.0",
         "jest": "29.7.0",
         "style-dictionary": "3.9.2",
+        "style-dictionary-utils": "2.4.1",
         "tsx": "4.20.6",
         "typescript": "5.5.4",
         "typescript-eslint": "8.46.2"

--- a/packages/tokens/src/style-dictionary/build.ts
+++ b/packages/tokens/src/style-dictionary/build.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import StyleDictionary from "style-dictionary";
+import "style-dictionary-utils"; // auto-registers gradient/css transform
 
 import { fontsConfig, getStyleDictionaryConfig, getStyledSystemTokenMappingConfig, getStyledSystemTokensConfig } from "./config.ts";
 import { AUTO_GENERATED_COMMENT, HOPPER_PREFIX, STYLED_SYSTEM_BUILD_PATH, STYLED_SYSTEM_THEME_BUILD_PATH, StyledSystemRootCssClass } from "./constant.ts";
@@ -10,7 +11,7 @@ import { customTsTokenMapping } from "./format/customTsTokenMapping.ts";
 import { cssDarkMode, customDoc, customJson, fontFace } from "./format/index.ts";
 import { getAvailableThemes } from "./helpers/getThemes.ts";
 import { w3cTokenJsonParser } from "./parser/w3cTokenParser.ts";
-import { attributeFont, isSizeType, pxToRem } from "./transform/index.ts";
+import { attributeFont, gradientCssLinear, isGradientToken, isSizeType, pxToRem } from "./transform/index.ts";
 
 const { fileHeader } = StyleDictionary.formatHelpers;
 
@@ -39,9 +40,17 @@ StyleDictionary.registerTransform({
     transformer: attributeFont
 });
 
+StyleDictionary.registerTransform({
+    name: "gradient/css-linear",
+    type: "value",
+    transitive: true,
+    matcher: isGradientToken,
+    transformer: gradientCssLinear
+});
+
 StyleDictionary.registerTransformGroup({
     name: "custom/css",
-    transforms: StyleDictionary.transformGroup["css"].concat(["pxToRem"])
+    transforms: StyleDictionary.transformGroup["css"].concat(["pxToRem", "gradient/css", "gradient/css-linear", "shadow/css"])
 });
 
 // Format

--- a/packages/tokens/src/style-dictionary/format/customTsTokenMapping.ts
+++ b/packages/tokens/src/style-dictionary/format/customTsTokenMapping.ts
@@ -11,6 +11,7 @@ const MappingType = {
     IconColors: "IconColors",
     BorderColors: "BorderColors",
     DataVizColors: "DataVizColors",
+    GradientColors: "GradientColors",
     Elevation: "Elevation",
     FontFamily: "FontFamily",
     FontWeight: "FontWeight",
@@ -41,6 +42,7 @@ export const customTsTokenMapping = function ({ dictionary}: { dictionary: Dicti
         const cssPrefix = `--${HOPPER_PREFIX}`;
 
         mappings += mapColors(coreTokens, semanticTokens);
+        mappings += mapGradients(coreTokens, semanticTokens);
         mappings += mapElevation(coreTokens, semanticTokens);
         mappings += mapFonts(coreTokens, semanticTokens);
         mappings += mapShape(coreTokens, semanticTokens);
@@ -84,6 +86,16 @@ function createMapping(name: string, tokenPartToRemove?: string, prefixToAdd?: s
     }
 
     return tokenMapping;
+}
+
+function mapGradients(coreTokens: TransformedToken[], semanticTokens: TransformedToken[]) {
+    const coreGradientTokens = coreTokens.filter(t => t.type === "gradient").map(x => x.name);
+    const semanticGradientTokens = semanticTokens.filter(t => t.type === "gradient").map(x => x.name);
+
+    return formatTokenMapping(MappingType.GradientColors, [
+        ...coreGradientTokens.map(name => createMapping(name, undefined, "core")),
+        ...semanticGradientTokens.map(name => createMapping(name))
+    ]);
 }
 
 function mapElevation(coreTokens: TransformedToken[], semanticTokens: TransformedToken[]) {

--- a/packages/tokens/src/style-dictionary/transform/gradient.ts
+++ b/packages/tokens/src/style-dictionary/transform/gradient.ts
@@ -1,0 +1,10 @@
+import type { TransformedToken } from "style-dictionary";
+
+export function isGradientToken(token: TransformedToken): boolean {
+    return token.type === "gradient"
+        && typeof token.value === "string";
+}
+
+export function gradientCssLinear(token: TransformedToken): string {
+    return `linear-gradient(${token.value})`;
+}

--- a/packages/tokens/src/style-dictionary/transform/index.ts
+++ b/packages/tokens/src/style-dictionary/transform/index.ts
@@ -1,2 +1,3 @@
-export { pxToRem, isSizeType } from "./pxToRem.ts";
 export { attributeFont } from "./attributeFont.ts";
+export { gradientCssLinear, isGradientToken } from "./gradient.ts";
+export { isSizeType, pxToRem } from "./pxToRem.ts";

--- a/packages/tokens/tests/jest/components/tokenComparison.test.ts
+++ b/packages/tokens/tests/jest/components/tokenComparison.test.ts
@@ -40,7 +40,9 @@ const collectKeys = (jsonPath: string): string[] => {
         Object.keys(node).forEach(key => {
             const currentPath = prefix ? `${prefix}.${key}` : key;
             keys.push(currentPath);
-            visit((node)[key], currentPath);
+            if (key !== "$value") {
+                visit((node)[key], currentPath);
+            }
         });
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,6 +1004,9 @@ importers:
       style-dictionary:
         specifier: 3.9.2
         version: 3.9.2
+      style-dictionary-utils:
+        specifier: 2.4.1
+        version: 2.4.1(style-dictionary@3.9.2)
       tsx:
         specifier: 4.20.6
         version: 4.20.6
@@ -5325,6 +5328,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color2k@2.0.3:
+    resolution: {integrity: sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==}
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -9853,6 +9859,11 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-dictionary-utils@2.4.1:
+    resolution: {integrity: sha512-Ged3wCzzswC6vw8Fh74IKUJg7ajPiH0ersYsPi0VT2ENWCq/gx6uAYOr1rjslqjSyQUfAVvNnOPxuWGJ2mdncQ==}
+    peerDependencies:
+      style-dictionary: ^3.7.1
 
   style-dictionary@3.9.2:
     resolution: {integrity: sha512-M2pcQ6hyRtqHOh+NyT6T05R3pD/gwNpuhREBKvxC1En0vyywx+9Wy9nXWT1SZ9ePzv1vAo65ItnpA16tT9ZUCg==}
@@ -16483,6 +16494,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color2k@2.0.3: {}
+
   colord@2.9.3: {}
 
   colorette@2.0.20: {}
@@ -22561,6 +22574,13 @@ snapshots:
   strip-json-comments@1.0.4: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-dictionary-utils@2.4.1(style-dictionary@3.9.2):
+    dependencies:
+      color2k: 2.0.3
+      json5: 2.2.3
+      prettier: 2.8.8
+      style-dictionary: 3.9.2
 
   style-dictionary@3.9.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Introduces `$type: "gradient"` following the [W3C Design Tokens gradient spec](https://www.designtokens.org/tr/2025.10/format/#gradient) — `$value` as an array of `{ color, position }` stops with an optional `angle` sibling property
- Adds support for structured `$type: "shadow"` following the [W3C Design Tokens shadow spec](https://www.designtokens.org/tr/2025.10/format/#shadow) — `$value` as an object or array of `{ offsetX, offsetY, blur, spread, color, inset }` stops; raw CSS string values are passed through unchanged for backwards compatibility
- Installs `style-dictionary-utils@2.4.1` which provides `gradient/css` and `shadow/css` transforms; adds a custom `gradient/css-linear` transform that wraps the gradient string in `linear-gradient()`
- Updates token mappings (`tokenMappings.ts`, `styledSystemToTokenMappings.ts`) to expose gradient tokens via `GradientColorMapping`
- Applies the gradient token to the ShareGate primary Button `background-image` (`iris.300` → `iris.600`), while Workleap keeps a solid `background-color`
- Switches `background-color` → `background` in `Button.module.css` so gradient values render correctly
- Updates the component token comparison test to skip recursing into `$value` internals, allowing different value shapes per theme

## Jira

[SGPLTD-1751](https://workleap.atlassian.net/browse/SGPLTD-1751) — Add support of gradient colors in Hopper tokens

## Test plan

- [ ] Run `pnpm build:tokens` and verify gradient and shadow CSS variables are generated correctly
- [ ] Verify ShareGate primary Button renders with `linear-gradient(180deg, ...)` background
- [ ] Verify Workleap primary Button is unaffected (solid `primary.surface-strong`)
- [ ] Verify existing shadow tokens (`sm`, `md`, `lg`, `tactility-*`) are unchanged in the output
- [ ] Run `pnpm test` in `packages/tokens` — all token comparison tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SGPLTD-1751]: https://workleap.atlassian.net/browse/SGPLTD-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ