### PR TITLE
feat(tokens): update button branding tokens

### DIFF
--- a/.changeset/lazy-bears-mix.md
+++ b/.changeset/lazy-bears-mix.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+"@hopper-ui/tokens": patch
+---
+
+Update Button tokens to match new ShareGate theme

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -56,7 +56,7 @@ jobs:
                     path: .turbo
 
             -   name: Publish to Chromatic
-                uses: chromaui/action@v1
+                uses: chromaui/action@v16
                 id: chromatic
                 with:
                     autoAcceptChanges: "main"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@workleap/swc-configs": "2.3.0",
         "@workleap/typescript-configs": "3.0.4",
         "axe-playwright": "2.2.2",
-        "chromatic": "13.3.5",
+        "chromatic": "16.2.0",
         "cross-env": "10.1.0",
         "eslint": "9.38.0",
         "eslint-plugin-import": "2.32.0",

--- a/packages/components/src/buttons/src/Button.module.css
+++ b/packages/components/src/buttons/src/Button.module.css
@@ -369,49 +369,6 @@
 }
 
 /* Loading */
-
-.hop-Button--loading.hop-Button--primary {
-    --background: var(--hop-comp-button-primary-background);
-    --color: var(--hop-comp-button-primary-text-color);
-    --border: var(--hop-Button-primary-border);
-}
-
-.hop-Button--loading.hop-Button--secondary {
-    --background: var(--hop-comp-button-secondary-background);
-    --color: var(--hop-comp-button-secondary-text-color);
-    --border: var(--hop-Button-secondary-border);
-}
-
-.hop-Button--loading.hop-Button--upsell {
-    --background: var(--hop-comp-button-upsell-background);
-    --color: var(--hop-comp-button-upsell-text-color);
-    --border: var(--hop-Button-upsell-border);
-}
-
-.hop-Button--loading.hop-Button--danger {
-    --background: var(--hop-comp-button-danger-background);
-    --color: var(--hop-comp-button-danger-text-color);
-    --border: var(--hop-Button-danger-border);
-}
-
-.hop-Button--loading.hop-Button--ghost-primary {
-    --background: var(--hop-comp-button-ghost-primary-background);
-    --color: var(--hop-comp-button-ghost-primary-text-color);
-    --border: var(--hop-Button-ghost-primary-border);
-}
-
-.hop-Button--loading.hop-Button--ghost-secondary {
-    --background: var(--hop-comp-button-ghost-secondary-background);
-    --color: var(--hop-comp-button-ghost-secondary-text-color);
-    --border: var(--hop-Button-ghost-secondary-border);
-}
-
-.hop-Button--loading.hop-Button--ghost-danger {
-    --background: var(--hop-comp-button-ghost-danger-background);
-    --color: var(--hop-comp-button-ghost-danger-text-color);
-    --border: var(--hop-Button-ghost-danger-border);
-}
-
 .hop-Button--loading {
     background: var(--background-loading);
     color: var(--color-loading);

--- a/packages/components/src/buttons/src/Button.module.css
+++ b/packages/components/src/buttons/src/Button.module.css
@@ -1,5 +1,5 @@
 .hop-Button {
-    --hop-Button-focus-ring-color: var(--hop-primary-border-focus);
+    --hop-Button-focus-ring-color: var(--hop-comp-button-border-color-focus);
     --hop-Button-column-gap: var(--hop-space-inline-xs);
     --hop-Button-icon-only-column-gap: 0;
     --hop-Button-outline-size: var(--hop-space-20);
@@ -20,57 +20,42 @@
     --hop-Button-ghost-md-padding: 0 var(--hop-space-inset-sm);
 
     /* Disabled */
-    --hop-Button-border-disabled: var(--hop-Button-border-size) solid var(--hop-comp-button-disabled-border-color);
-    --hop-Button-ghost-border-disabled: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-disabled-border-color);
 
 
     /* Primary */
     --hop-Button-primary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-primary-border-color);
-    --hop-Button-primary-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-primary-border-color-hover);
-    --hop-Button-primary-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-primary-border-color-pressed);
     --hop-Button-primary-spinner-color: var(--hop-primary-icon-strong);
 
     /* Secondary */
     --hop-Button-secondary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-secondary-border-color);
-    --hop-Button-secondary-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-secondary-border-color-hover);
-    --hop-Button-secondary-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-secondary-border-color-pressed);
     --hop-Button-secondary-spinner-color: var(--hop-neutral-icon);
 
     /* Upsell */
     --hop-Button-upsell-border: var(--hop-Button-border-size) solid var(--hop-comp-button-upsell-border-color);
-    --hop-Button-upsell-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-upsell-border-color-hover);
-    --hop-Button-upsell-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-upsell-border-color-pressed);
     --hop-Button-upsell-spinner-color: var(--hop-upsell-icon);
 
     /* Danger */
     --hop-Button-danger-border: var(--hop-Button-border-size) solid var(--hop-comp-button-danger-border-color);
-    --hop-Button-danger-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-danger-border-color-hover);
-    --hop-Button-danger-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-danger-border-color-pressed);
     --hop-Button-danger-spinner-color: var(--hop-primary-icon-strong);
 
     /* Ghost Primary */
     --hop-Button-ghost-primary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-primary-border-color);
-    --hop-Button-ghost-primary-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-primary-border-color-hover);
-    --hop-Button-ghost-primary-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-primary-border-color-pressed);
     --hop-Button-ghost-primary-spinner-color: var(--hop-neutral-icon);
 
     /* Ghost Secondary */
     --hop-Button-ghost-secondary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-secondary-border-color);
-    --hop-Button-ghost-secondary-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-secondary-border-color-hover);
-    --hop-Button-ghost-secondary-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-secondary-border-color-pressed);
     --hop-Button-ghost-secondary-spinner-color: var(--hop-neutral-icon);
 
     /* Ghost Danger */
     --hop-Button-ghost-danger-border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-danger-border-color);
-    --hop-Button-ghost-danger-border-hover: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-danger-border-color-hover);
-    --hop-Button-ghost-danger-border-pressed: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-danger-border-color-pressed);
     --hop-Button-ghost-danger-spinner-color: var(--hop-neutral-icon);
 
     /* Internal variable */
     --inline-size: max-content;
     --block-size: var(--hop-Button-md-height);
-    --background-color: var(--hop-primary-surface-strong);
+    --background: var(--hop-primary-surface-strong);
     --color: var(--hop-primary-text-strong);
+    --icon-color: var(--color);
     --column-gap: var(--hop-Button-column-gap);
     --spinner: var(--hop-primary-icon-strong);
     --border: 0;
@@ -97,7 +82,7 @@
     text-decoration: none;
     white-space: nowrap;
 
-    background-color: var(--background-color);
+    background: var(--background);
     border: var(--border);
     border-radius: var(--hop-comp-button-border-radius);
     outline: none;
@@ -147,8 +132,9 @@
 
 /** Variants */
 .hop-Button--primary {
-    --background-color: var(--hop-comp-button-primary-background-color);
+    --background: var(--hop-comp-button-primary-background);
     --color: var(--hop-comp-button-primary-text-color);
+    --icon-color: var(--hop-comp-button-primary-icon-color);
     --border: var(--hop-Button-primary-border);
     --spinner-color: var(--hop-Button-primary-spinner-color);
     --box-shadow: var(--hop-comp-button-primary-box-shadow);
@@ -157,20 +143,23 @@
 .hop-Button--primary[data-hovered],
 .hop-Button--primary[data-focus-visible]
  {
-    --background-color: var(--hop-comp-button-primary-background-color-hover);
+    --background: var(--hop-comp-button-primary-background-hover);
     --color: var(--hop-comp-button-primary-text-color-hover);
-    --border: var(--hop-Button-primary-border-hover);
+    --icon-color: var(--hop-comp-button-primary-icon-color-hover);
+    --border: var(--hop-Button-primary-border);
 }
 
 .hop-Button--primary[data-pressed] {
-    --background-color: var(--hop-comp-button-primary-background-color-pressed);
+    --background: var(--hop-comp-button-primary-background-pressed);
     --color: var(--hop-comp-button-primary-text-color-pressed);
-    --border: var(--hop-Button-primary-border-pressed);
+    --icon-color: var(--hop-comp-button-primary-icon-color-press);
+    --border: var(--hop-Button-primary-border);
 }
 
 .hop-Button--secondary {
-    --background-color: var(--hop-comp-button-secondary-background-color);
+    --background: var(--hop-comp-button-secondary-background);
     --color: var(--hop-comp-button-secondary-text-color);
+    --icon-color: var(--hop-comp-button-secondary-icon-color);
     --border: var(--hop-Button-secondary-border);
     --spinner-color: var(--hop-Button-secondary-spinner-color);
     --box-shadow: var(--hop-comp-button-secondary-box-shadow);
@@ -178,20 +167,23 @@
 
 .hop-Button--secondary[data-hovered],
 .hop-Button--secondary[data-focus-visible] {
-    --background-color: var(--hop-comp-button-secondary-background-color-hover);
+    --background: var(--hop-comp-button-secondary-background-hover);
     --color: var(--hop-comp-button-secondary-text-color-hover);
-    --border: var(--hop-Button-secondary-border-hover);
+    --icon-color: var(--hop-comp-button-secondary-icon-color-hover);
+    --border: var(--hop-Button-secondary-border);
 }
 
 .hop-Button--secondary[data-pressed] {
-    --background-color: var(--hop-comp-button-secondary-background-color-pressed);
+    --background: var(--hop-comp-button-secondary-background-pressed);
     --color: var(--hop-comp-button-secondary-text-color-pressed);
-    --border: var(--hop-Button-secondary-border-pressed);
+    --icon-color: var(--hop-comp-button-secondary-icon-color-press);
+    --border: var(--hop-Button-secondary-border);
 }
 
 .hop-Button--upsell {
-    --background-color: var(--hop-comp-button-upsell-background-color);
+    --background: var(--hop-comp-button-upsell-background);
     --color: var(--hop-comp-button-upsell-text-color);
+    --icon-color: var(--hop-comp-button-upsell-icon-color);
     --border: var(--hop-Button-upsell-border);
     --spinner-color: var(--hop-Button-upsell-spinner-color);
     --box-shadow: var(--hop-comp-button-upsell-box-shadow);
@@ -199,20 +191,23 @@
 
 .hop-Button--upsell[data-hovered],
 .hop-Button--upsell[data-focus-visible] {
-    --background-color: var(--hop-comp-button-upsell-background-color-hover);
+    --background: var(--hop-comp-button-upsell-background-hover);
     --color: var(--hop-comp-button-upsell-text-color-hover);
-    --border: var(--hop-Button-upsell-border-hover);
+    --icon-color: var(--hop-comp-button-upsell-icon-color-hover);
+    --border: var(--hop-Button-upsell-border);
 }
 
 .hop-Button--upsell[data-pressed] {
-    --background-color: var(--hop-comp-button-upsell-background-color-pressed);
+    --background: var(--hop-comp-button-upsell-background-pressed);
     --color: var(--hop-comp-button-upsell-text-color-pressed);
-    --border: var(--hop-Button-upsell-border-pressed);
+    --icon-color: var(--hop-comp-button-upsell-icon-color-press);
+    --border: var(--hop-Button-upsell-border);
 }
 
 .hop-Button--danger {
-    --background-color: var(--hop-comp-button-danger-background-color);
+    --background: var(--hop-comp-button-danger-background);
     --color: var(--hop-comp-button-danger-text-color);
+    --icon-color: var(--hop-comp-button-danger-icon-color);
     --border: var(--hop-Button-danger-border);
     --spinner-color: var(--hop-Button-danger-spinner-color);
     --box-shadow: var(--hop-comp-button-danger-box-shadow);
@@ -220,20 +215,23 @@
 
 .hop-Button--danger[data-hovered],
 .hop-Button--danger[data-focus-visible] {
-    --background-color: var(--hop-comp-button-danger-background-color-hover);
+    --background: var(--hop-comp-button-danger-background-hover);
     --color: var(--hop-comp-button-danger-text-color-hover);
-    --border: var(--hop-Button-danger-border-hover);
+    --icon-color: var(--hop-comp-button-danger-icon-color-hover);
+    --border: var(--hop-Button-danger-border);
 }
 
 .hop-Button--danger[data-pressed] {
-    --background-color: var(--hop-comp-button-danger-background-color-pressed);
+    --background: var(--hop-comp-button-danger-background-pressed);
     --color: var(--hop-comp-button-danger-text-color-pressed);
-    --border: var(--hop-Button-danger-border-pressed);
+    --icon-color: var(--hop-comp-button-danger-icon-color-press);
+    --border: var(--hop-Button-danger-border);
 }
 
 .hop-Button--ghost-primary {
-    --background-color: var(--hop-comp-button-ghost-primary-background-color);
+    --background: var(--hop-comp-button-ghost-primary-background);
     --color: var(--hop-comp-button-ghost-primary-text-color);
+    --icon-color: var(--hop-comp-button-ghost-primary-icon-color);
     --border: var(--hop-Button-ghost-primary-border);
     --spinner-color: var(--hop-Button-ghost-primary-spinner-color);
     --box-shadow: var(--hop-comp-button-ghost-primary-box-shadow);
@@ -241,20 +239,23 @@
 
 .hop-Button--ghost-primary[data-hovered],
 .hop-Button--ghost-primary[data-focus-visible] {
-    --background-color: var(--hop-comp-button-ghost-primary-background-color-hover);
+    --background: var(--hop-comp-button-ghost-primary-background-hover);
     --color: var(--hop-comp-button-ghost-primary-text-color-hover);
-    --border: var(--hop-Button-ghost-primary-border-hover);
+    --icon-color: var(--hop-comp-button-ghost-primary-icon-color-hover);
+    --border: var(--hop-Button-ghost-primary-border);
 }
 
 .hop-Button--ghost-primary[data-pressed] {
-    --background-color: var(--hop-comp-button-ghost-primary-background-color-pressed);
+    --background: var(--hop-comp-button-ghost-primary-background-pressed);
     --color: var(--hop-comp-button-ghost-primary-text-color-pressed);
-    --border: var(--hop-Button-ghost-primary-border-pressed);
+    --icon-color: var(--hop-comp-button-ghost-primary-icon-color-press);
+    --border: var(--hop-Button-ghost-primary-border);
 }
 
 .hop-Button--ghost-secondary {
-    --background-color: var(--hop-comp-button-ghost-secondary-background-color);
+    --background: var(--hop-comp-button-ghost-secondary-background);
     --color: var(--hop-comp-button-ghost-secondary-text-color);
+    --icon-color: var(--hop-comp-button-ghost-secondary-icon-color);
     --border: var(--hop-Button-ghost-secondary-border);
     --spinner-color: var(--hop-Button-ghost-secondary-spinner-color);
     --box-shadow: var(--hop-comp-button-ghost-secondary-box-shadow);
@@ -262,20 +263,23 @@
 
 .hop-Button--ghost-secondary[data-hovered],
 .hop-Button--ghost-secondary[data-focus-visible] {
-    --background-color: var(--hop-comp-button-ghost-secondary-background-color-hover);
+    --background: var(--hop-comp-button-ghost-secondary-background-hover);
     --color: var(--hop-comp-button-ghost-secondary-text-color-hover);
-    --border: var(--hop-Button-ghost-secondary-border-hover);
+    --icon-color: var(--hop-comp-button-ghost-secondary-icon-color-hover);
+    --border: var(--hop-Button-ghost-secondary-border);
 }
 
 .hop-Button--ghost-secondary[data-pressed] {
-    --background-color: var(--hop-comp-button-ghost-secondary-background-color-pressed);
+    --background: var(--hop-comp-button-ghost-secondary-background-pressed);
     --color: var(--hop-comp-button-ghost-secondary-text-color-pressed);
-    --border: var(--hop-Button-ghost-secondary-border-pressed);
+    --icon-color: var(--hop-comp-button-ghost-secondary-icon-color-press);
+    --border: var(--hop-Button-ghost-secondary-border);
 }
 
 .hop-Button--ghost-danger {
-    --background-color: var(--hop-comp-button-ghost-danger-background-color);
+    --background: var(--hop-comp-button-ghost-danger-background);
     --color: var(--hop-comp-button-ghost-danger-text-color);
+    --icon-color: var(--hop-comp-button-ghost-danger-icon-color);
     --border: var(--hop-Button-ghost-danger-border);
     --spinner-color: var(--hop-Button-ghost-danger-spinner-color);
     --box-shadow: var(--hop-comp-button-ghost-danger-box-shadow);
@@ -283,15 +287,17 @@
 
 .hop-Button--ghost-danger[data-hovered],
 .hop-Button--ghost-danger[data-focus-visible] {
-    --background-color: var(--hop-comp-button-ghost-danger-background-color-hover);
+    --background: var(--hop-comp-button-ghost-danger-background-hover);
     --color: var(--hop-comp-button-ghost-danger-text-color-hover);
-    --border: var(--hop-Button-ghost-danger-border-hover);
+    --icon-color: var(--hop-comp-button-ghost-danger-icon-color-hover);
+    --border: var(--hop-Button-ghost-danger-border);
 }
 
 .hop-Button--ghost-danger[data-pressed] {
-    --background-color: var(--hop-comp-button-ghost-danger-background-color-pressed);
+    --background: var(--hop-comp-button-ghost-danger-background-pressed);
     --color: var(--hop-comp-button-ghost-danger-text-color-pressed);
-    --border: var(--hop-Button-ghost-danger-border-pressed);
+    --icon-color: var(--hop-comp-button-ghost-danger-icon-color-press);
+    --border: var(--hop-Button-ghost-danger-border);
 }
 
 /** Focus Ring */
@@ -306,57 +312,85 @@
 }
 
 .hop-Button[data-disabled] {
-    --background-color: var(--hop-comp-button-disabled-background-color);
-    --color: var(--hop-comp-button-disabled-text-color);
-    --border: var(--hop-Button-border-disabled);
+    --color: var(--hop-comp-button-text-color-disabled);
+    --icon-color: var(--hop-comp-button-icon-color-disabled);
 }
 
-.hop-Button[class*="--ghost"][data-disabled] {
-    --background-color: var(--hop-comp-button-ghost-disabled-background-color);
-    --color: var(--hop-comp-button-ghost-disabled-text-color);
-    --border: var(--hop-Button-ghost-border-disabled);
+.hop-Button--primary[data-disabled] {
+    --background: var(--hop-comp-button-primary-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-primary-border-color-disabled);
+}
+
+.hop-Button--secondary[data-disabled] {
+    --background: var(--hop-comp-button-secondary-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-secondary-border-color-disabled);
+}
+
+.hop-Button--upsell[data-disabled] {
+    --background: var(--hop-comp-button-upsell-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-upsell-border-color-disabled);
+}
+
+.hop-Button--danger[data-disabled] {
+    --background: var(--hop-comp-button-danger-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-danger-border-color-disabled);
+}
+
+.hop-Button--ghost-primary[data-disabled] {
+    --background: var(--hop-comp-button-ghost-primary-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-primary-border-color-disabled);
+}
+
+.hop-Button--ghost-secondary[data-disabled] {
+    --background: var(--hop-comp-button-ghost-secondary-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-secondary-border-color-disabled);
+}
+
+.hop-Button--ghost-danger[data-disabled] {
+    --background: var(--hop-comp-button-ghost-danger-background-disabled);
+    --border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-danger-border-color-disabled);
 }
 
 /* Loading */
 
 .hop-Button--loading.hop-Button--primary {
-    --background-color: var(--hop-comp-button-primary-background-color);
+    --background: var(--hop-comp-button-primary-background);
     --color: var(--hop-comp-button-primary-text-color);
     --border: var(--hop-Button-primary-border);
 }
 
 .hop-Button--loading.hop-Button--secondary {
-    --background-color: var(--hop-comp-button-secondary-background-color);
+    --background: var(--hop-comp-button-secondary-background);
     --color: var(--hop-comp-button-secondary-text-color);
     --border: var(--hop-Button-secondary-border);
 }
 
 .hop-Button--loading.hop-Button--upsell {
-    --background-color: var(--hop-comp-button-upsell-background-color);
+    --background: var(--hop-comp-button-upsell-background);
     --color: var(--hop-comp-button-upsell-text-color);
     --border: var(--hop-Button-upsell-border);
 }
 
 .hop-Button--loading.hop-Button--danger {
-    --background-color: var(--hop-comp-button-danger-background-color);
+    --background: var(--hop-comp-button-danger-background);
     --color: var(--hop-comp-button-danger-text-color);
     --border: var(--hop-Button-danger-border);
 }
 
 .hop-Button--loading.hop-Button--ghost-primary {
-    --background-color: var(--hop-comp-button-ghost-primary-background-color);
+    --background: var(--hop-comp-button-ghost-primary-background);
     --color: var(--hop-comp-button-ghost-primary-text-color);
     --border: var(--hop-Button-ghost-primary-border);
 }
 
 .hop-Button--loading.hop-Button--ghost-secondary {
-    --background-color: var(--hop-comp-button-ghost-secondary-background-color);
+    --background: var(--hop-comp-button-ghost-secondary-background);
     --color: var(--hop-comp-button-ghost-secondary-text-color);
     --border: var(--hop-Button-ghost-secondary-border);
 }
 
 .hop-Button--loading.hop-Button--ghost-danger {
-    --background-color: var(--hop-comp-button-ghost-danger-background-color);
+    --background: var(--hop-comp-button-ghost-danger-background);
     --color: var(--hop-comp-button-ghost-danger-text-color);
     --border: var(--hop-Button-ghost-danger-border);
 }
@@ -372,6 +406,7 @@
     flex: 0 0 auto;
     justify-self: end;
     order: 1;
+    color: var(--icon-color);
 }
 
 .hop-Button__text {
@@ -390,6 +425,7 @@
 .hop-Button__end-icon-list {
     flex: 0 0 auto;
     order: 3;
+    color: var(--icon-color);
 }
 
 .hop-Button .hop-Button__icon-list,

--- a/packages/components/src/buttons/src/Button.module.css
+++ b/packages/components/src/buttons/src/Button.module.css
@@ -24,31 +24,24 @@
 
     /* Primary */
     --hop-Button-primary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-primary-border-color);
-    --hop-Button-primary-spinner-color: var(--hop-primary-icon-strong);
 
     /* Secondary */
     --hop-Button-secondary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-secondary-border-color);
-    --hop-Button-secondary-spinner-color: var(--hop-neutral-icon);
 
     /* Upsell */
     --hop-Button-upsell-border: var(--hop-Button-border-size) solid var(--hop-comp-button-upsell-border-color);
-    --hop-Button-upsell-spinner-color: var(--hop-upsell-icon);
 
     /* Danger */
     --hop-Button-danger-border: var(--hop-Button-border-size) solid var(--hop-comp-button-danger-border-color);
-    --hop-Button-danger-spinner-color: var(--hop-primary-icon-strong);
 
     /* Ghost Primary */
     --hop-Button-ghost-primary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-primary-border-color);
-    --hop-Button-ghost-primary-spinner-color: var(--hop-neutral-icon);
 
     /* Ghost Secondary */
     --hop-Button-ghost-secondary-border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-secondary-border-color);
-    --hop-Button-ghost-secondary-spinner-color: var(--hop-neutral-icon);
 
     /* Ghost Danger */
     --hop-Button-ghost-danger-border: var(--hop-Button-border-size) solid var(--hop-comp-button-ghost-danger-border-color);
-    --hop-Button-ghost-danger-spinner-color: var(--hop-neutral-icon);
 
     /* Internal variable */
     --inline-size: max-content;
@@ -58,6 +51,9 @@
     --icon-color: var(--color);
     --column-gap: var(--hop-Button-column-gap);
     --spinner: var(--hop-primary-icon-strong);
+    --background-loading: var(--background);
+    --border-color-loading: transparent;
+    --box-shadow-loading: none;
     --border: 0;
     --padding: var(--hop-Button-md-padding);
     --box-shadow: none;
@@ -136,7 +132,10 @@
     --color: var(--hop-comp-button-primary-text-color);
     --icon-color: var(--hop-comp-button-primary-icon-color);
     --border: var(--hop-Button-primary-border);
-    --spinner-color: var(--hop-Button-primary-spinner-color);
+    --color-loading: var(--hop-comp-button-primary-color-loading);
+    --background-loading: var(--hop-comp-button-primary-background-loading);
+    --border-color-loading: var(--hop-comp-button-primary-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-primary-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-primary-box-shadow);
 }
 
@@ -161,7 +160,10 @@
     --color: var(--hop-comp-button-secondary-text-color);
     --icon-color: var(--hop-comp-button-secondary-icon-color);
     --border: var(--hop-Button-secondary-border);
-    --spinner-color: var(--hop-Button-secondary-spinner-color);
+    --color-loading: var(--hop-comp-button-secondary-color-loading);
+    --background-loading: var(--hop-comp-button-secondary-background-loading);
+    --border-color-loading: var(--hop-comp-button-secondary-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-secondary-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-secondary-box-shadow);
 }
 
@@ -185,7 +187,10 @@
     --color: var(--hop-comp-button-upsell-text-color);
     --icon-color: var(--hop-comp-button-upsell-icon-color);
     --border: var(--hop-Button-upsell-border);
-    --spinner-color: var(--hop-Button-upsell-spinner-color);
+    --color-loading: var(--hop-comp-button-upsell-color-loading);
+    --background-loading: var(--hop-comp-button-upsell-background-loading);
+    --border-color-loading: var(--hop-comp-button-upsell-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-upsell-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-upsell-box-shadow);
 }
 
@@ -209,7 +214,10 @@
     --color: var(--hop-comp-button-danger-text-color);
     --icon-color: var(--hop-comp-button-danger-icon-color);
     --border: var(--hop-Button-danger-border);
-    --spinner-color: var(--hop-Button-danger-spinner-color);
+    --color-loading: var(--hop-comp-button-danger-color-loading);
+    --background-loading: var(--hop-comp-button-danger-background-loading);
+    --border-color-loading: var(--hop-comp-button-danger-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-danger-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-danger-box-shadow);
 }
 
@@ -233,7 +241,10 @@
     --color: var(--hop-comp-button-ghost-primary-text-color);
     --icon-color: var(--hop-comp-button-ghost-primary-icon-color);
     --border: var(--hop-Button-ghost-primary-border);
-    --spinner-color: var(--hop-Button-ghost-primary-spinner-color);
+    --color-loading: var(--hop-comp-button-ghost-primary-color-loading);
+    --background-loading: var(--hop-comp-button-ghost-primary-background-loading);
+    --border-color-loading: var(--hop-comp-button-ghost-primary-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-ghost-primary-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-ghost-primary-box-shadow);
 }
 
@@ -257,7 +268,10 @@
     --color: var(--hop-comp-button-ghost-secondary-text-color);
     --icon-color: var(--hop-comp-button-ghost-secondary-icon-color);
     --border: var(--hop-Button-ghost-secondary-border);
-    --spinner-color: var(--hop-Button-ghost-secondary-spinner-color);
+    --color-loading: var(--hop-comp-button-ghost-secondary-color-loading);
+    --background-loading: var(--hop-comp-button-ghost-secondary-background-loading);
+    --border-color-loading: var(--hop-comp-button-ghost-secondary-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-ghost-secondary-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-ghost-secondary-box-shadow);
 }
 
@@ -281,7 +295,10 @@
     --color: var(--hop-comp-button-ghost-danger-text-color);
     --icon-color: var(--hop-comp-button-ghost-danger-icon-color);
     --border: var(--hop-Button-ghost-danger-border);
-    --spinner-color: var(--hop-Button-ghost-danger-spinner-color);
+    --color-loading: var(--hop-comp-button-ghost-danger-color-loading);
+    --background-loading: var(--hop-comp-button-ghost-danger-background-loading);
+    --border-color-loading: var(--hop-comp-button-ghost-danger-border-color-loading);
+    --box-shadow-loading: var(--hop-comp-button-ghost-danger-box-shadow-loading);
     --box-shadow: var(--hop-comp-button-ghost-danger-box-shadow);
 }
 
@@ -395,10 +412,16 @@
     --border: var(--hop-Button-ghost-danger-border);
 }
 
+.hop-Button--loading {
+    background: var(--background-loading);
+    color: var(--color-loading);
+    border-color: var(--border-color-loading);
+    box-shadow: var(--box-shadow-loading);
+}
+
 /** Elements */
 .hop-Button__Spinner {
     position: absolute;
-    color: var(--spinner-color)
 }
 
 .hop-Button__icon,

--- a/packages/components/src/buttons/src/ToggleButton.module.css
+++ b/packages/components/src/buttons/src/ToggleButton.module.css
@@ -32,8 +32,9 @@
 }
 
 .hop-ToggleButton--primary[data-selected] {
-    --background-color: var(--hop-comp-button-primary-background-color-selected);
+    --background: var(--hop-comp-button-primary-background-selected);
     --color: var(--hop-comp-button-primary-text-color-selected);
+    --icon-color: var(--hop-comp-button-primary-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-primary-border-color-selected);
 }
 
@@ -42,8 +43,9 @@
 }
 
 .hop-ToggleButton--secondary[data-selected] {
-    --background-color: var(--hop-comp-button-secondary-background-color-selected);
+    --background: var(--hop-comp-button-secondary-background-selected);
     --color: var(--hop-comp-button-secondary-text-color-selected);
+    --icon-color: var(--hop-comp-button-secondary-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-secondary-border-color-selected);
 }
 
@@ -52,8 +54,9 @@
 }
 
 .hop-ToggleButton--upsell[data-selected] {
-    --background-color: var(--hop-comp-button-upsell-background-color-selected);
+    --background: var(--hop-comp-button-upsell-background-selected);
     --color: var(--hop-comp-button-upsell-text-color-selected);
+    --icon-color: var(--hop-comp-button-upsell-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-upsell-border-color-selected);
 }
 
@@ -62,8 +65,9 @@
 }
 
 .hop-ToggleButton--danger[data-selected] {
-    --background-color: var(--hop-comp-button-danger-background-color-selected);
+    --background: var(--hop-comp-button-danger-background-selected);
     --color: var(--hop-comp-button-danger-text-color-selected);
+    --icon-color: var(--hop-comp-button-danger-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-danger-border-color-selected);
 }
 
@@ -72,8 +76,9 @@
 }
 
 .hop-ToggleButton--ghost-primary[data-selected] {
-    --background-color: var(--hop-comp-button-ghost-primary-background-color-selected);
+    --background: var(--hop-comp-button-ghost-primary-background-selected);
     --color: var(--hop-comp-button-ghost-primary-text-color-selected);
+    --icon-color: var(--hop-comp-button-ghost-primary-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-ghost-primary-border-color-selected);
 }
 
@@ -82,8 +87,9 @@
 }
 
 .hop-ToggleButton--ghost-secondary[data-selected] {
-    --background-color: var(--hop-comp-button-ghost-secondary-background-color-selected);
+    --background: var(--hop-comp-button-ghost-secondary-background-selected);
     --color: var(--hop-comp-button-ghost-secondary-text-color-selected);
+    --icon-color: var(--hop-comp-button-ghost-secondary-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-ghost-secondary-border-color-selected);
 }
 
@@ -92,50 +98,51 @@
 }
 
 .hop-ToggleButton--ghost-danger[data-selected] {
-    --background-color: var(--hop-comp-button-ghost-danger-background-color-selected);
+    --background: var(--hop-comp-button-ghost-danger-background-selected);
     --color: var(--hop-comp-button-ghost-danger-text-color-selected);
+    --icon-color: var(--hop-comp-button-ghost-danger-icon-color-selected);
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-ghost-danger-border-color-selected);
 }
 
 /* Loading - uses Button's component tokens directly */
 .hop-ToggleButton--loading.hop-ToggleButton--primary {
-    --background-color: var(--hop-comp-button-primary-background-color);
+    --background: var(--hop-comp-button-primary-background);
     --color: var(--hop-comp-button-primary-text-color);
     --border: var(--hop-Button-primary-border);
 }
 
 .hop-ToggleButton--loading.hop-ToggleButton--secondary {
-    --background-color: var(--hop-comp-button-secondary-background-color);
+    --background: var(--hop-comp-button-secondary-background);
     --color: var(--hop-comp-button-secondary-text-color);
     --border: var(--hop-Button-secondary-border);
 }
 
 .hop-ToggleButton--loading.hop-ToggleButton--upsell {
-    --background-color: var(--hop-comp-button-upsell-background-color);
+    --background: var(--hop-comp-button-upsell-background);
     --color: var(--hop-comp-button-upsell-text-color);
     --border: var(--hop-Button-upsell-border);
 }
 
 .hop-ToggleButton--loading.hop-ToggleButton--danger {
-    --background-color: var(--hop-comp-button-danger-background-color);
+    --background: var(--hop-comp-button-danger-background);
     --color: var(--hop-comp-button-danger-text-color);
     --border: var(--hop-Button-danger-border);
 }
 
 .hop-ToggleButton--loading.hop-ToggleButton--ghost-primary {
-    --background-color: var(--hop-comp-button-ghost-primary-background-color);
+    --background: var(--hop-comp-button-ghost-primary-background);
     --color: var(--hop-comp-button-ghost-primary-text-color);
     --border: var(--hop-Button-ghost-primary-border);
 }
 
 .hop-ToggleButton--loading.hop-ToggleButton--ghost-secondary {
-    --background-color: var(--hop-comp-button-ghost-secondary-background-color);
+    --background: var(--hop-comp-button-ghost-secondary-background);
     --color: var(--hop-comp-button-ghost-secondary-text-color);
     --border: var(--hop-Button-ghost-secondary-border);
 }
 
 .hop-ToggleButton--loading.hop-ToggleButton--ghost-danger {
-    --background-color: var(--hop-comp-button-ghost-danger-background-color);
+    --background: var(--hop-comp-button-ghost-danger-background);
     --color: var(--hop-comp-button-ghost-danger-text-color);
     --border: var(--hop-Button-ghost-danger-border);
 }

--- a/packages/components/src/buttons/src/ToggleButton.module.css
+++ b/packages/components/src/buttons/src/ToggleButton.module.css
@@ -104,47 +104,9 @@
     --border: var(--hop-ToggleButton-border-size) solid var(--hop-comp-button-ghost-danger-border-color-selected);
 }
 
-/* Loading - uses Button's component tokens directly */
-.hop-ToggleButton--loading.hop-ToggleButton--primary {
-    --background: var(--hop-comp-button-primary-background);
-    --color: var(--hop-comp-button-primary-text-color);
-    --border: var(--hop-Button-primary-border);
-}
-
-.hop-ToggleButton--loading.hop-ToggleButton--secondary {
-    --background: var(--hop-comp-button-secondary-background);
-    --color: var(--hop-comp-button-secondary-text-color);
-    --border: var(--hop-Button-secondary-border);
-}
-
-.hop-ToggleButton--loading.hop-ToggleButton--upsell {
-    --background: var(--hop-comp-button-upsell-background);
-    --color: var(--hop-comp-button-upsell-text-color);
-    --border: var(--hop-Button-upsell-border);
-}
-
-.hop-ToggleButton--loading.hop-ToggleButton--danger {
-    --background: var(--hop-comp-button-danger-background);
-    --color: var(--hop-comp-button-danger-text-color);
-    --border: var(--hop-Button-danger-border);
-}
-
-.hop-ToggleButton--loading.hop-ToggleButton--ghost-primary {
-    --background: var(--hop-comp-button-ghost-primary-background);
-    --color: var(--hop-comp-button-ghost-primary-text-color);
-    --border: var(--hop-Button-ghost-primary-border);
-}
-
-.hop-ToggleButton--loading.hop-ToggleButton--ghost-secondary {
-    --background: var(--hop-comp-button-ghost-secondary-background);
-    --color: var(--hop-comp-button-ghost-secondary-text-color);
-    --border: var(--hop-Button-ghost-secondary-border);
-}
-
-.hop-ToggleButton--loading.hop-ToggleButton--ghost-danger {
-    --background: var(--hop-comp-button-ghost-danger-background);
-    --color: var(--hop-comp-button-ghost-danger-text-color);
-    --border: var(--hop-Button-ghost-danger-border);
+/* Loading */
+.hop-ToggleButton--loading {
+    composes: hop-Button--loading from "./Button.module.css";
 }
 
 /** Elements */

--- a/packages/components/src/calendar/src/CalendarHeader.module.css
+++ b/packages/components/src/calendar/src/CalendarHeader.module.css
@@ -11,7 +11,7 @@
 }
 
 .hop-CalendarHeader-button {
-    --hop-comp-button-ghost-secondary-text-color: var(--hop-neutral-icon);
+    --hop-comp-button-ghost-secondary-icon-color: var(--hop-neutral-icon); /* TODO: It is temporary. We should fix it when getting back to Calender branding */
 }
 
 .hop-CalendarHeader-heading {

--- a/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
+++ b/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
@@ -1092,7 +1092,6 @@ export const Elevation = {
     "core_sm": "shadow-sm",
     "core_md": "shadow-md",
     "core_lg": "shadow-lg",
-    "core_tactility-button": "shadow-tactility-button",
     "none": "elevation-none",
     "raised": "elevation-raised",
     "lifted": "elevation-lifted",

--- a/packages/tokens/src/style-dictionary/build.ts
+++ b/packages/tokens/src/style-dictionary/build.ts
@@ -50,7 +50,7 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerTransformGroup({
     name: "custom/css",
-    transforms: StyleDictionary.transformGroup["css"].concat(["pxToRem", "gradient/css", "gradient/css-linear", "shadow/css"])
+    transforms: StyleDictionary.transformGroup["css"].concat(["pxToRem", "color/css", "gradient/css", "gradient/css-linear", "shadow/css"])
 });
 
 // Format

--- a/packages/tokens/src/style-dictionary/format/customTsTokenMapping.ts
+++ b/packages/tokens/src/style-dictionary/format/customTsTokenMapping.ts
@@ -32,7 +32,7 @@ function getTokensByFamily(family: string, tokens: TransformedToken[]) {
         return token.filePath.includes(family);
     });
 }
-export const customTsTokenMapping = function ({ dictionary}: { dictionary: Dictionary }) {
+export const customTsTokenMapping = function ({ dictionary }: { dictionary: Dictionary }) {
     const types = handleTypes(dictionary.allTokens);
 
     let mappings = "";

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -64,8 +64,11 @@
                 ]
             },
             "background-loading": {
-                "$type": "color",
-                "$value": "{primary.surface-strong}"
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{iris.300}", "position": 0 },
+                    { "color": "{iris.600}", "position": 1 }
+                ]
             },
             "color-loading": {
                 "$type": "color",

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -4,110 +4,190 @@
             "$type": "borderRadius",
             "$value": "{shape.rounded-md}"
         },
+        "border-color-focus": {
+            "$type": "color",
+            "$value": "{primary.border-focus}"
+        },
+        "text-color-disabled": {
+            "$type": "color",
+            "$value": "{neutral.text-disabled}"
+        },
+        "icon-color-disabled": {
+            "$type": "color",
+            "$value": "{neutral.icon-disabled}"
+        },
         "primary": {
             "box-shadow": {
                 "$type": "shadow",
-                "$value": "{shadow.tactility-button}"
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
             },
             "text-color": {
                 "$type": "color",
-                "$value": "{primary.text-strong}"
+                "$value": "{neutral.text-always-light}"
             },
             "text-color-hover": {
                 "$type": "color",
-                "$value": "{primary.text-strong-hover}"
+                "$value": "{neutral.text-always-light}"
             },
             "text-color-pressed": {
                 "$type": "color",
-                "$value": "{primary.text-strong}"
+                "$value": "{neutral.text-always-light}"
             },
             "text-color-selected": {
                 "$type": "color",
-                "$value": "{neutral.text-strong}"
+                "$value": "{neutral.text-always-light}"
             },
-            "background-color": {
+            "icon-color": {
                 "$type": "color",
-                "$value": "{primary.surface-strong}"
+                "$value": "{neutral.icon-always-light}"
             },
-            "background-color-hover": {
+            "icon-color-hover": {
                 "$type": "color",
-                "$value": "{primary.surface-strong-hover}"
+                "$value": "{neutral.icon-always-light}"
             },
-            "background-color-pressed": {
+            "icon-color-press": {
                 "$type": "color",
-                "$value": "{primary.surface-strong-press}"
+                "$value": "{neutral.icon-always-light}"
             },
-            "background-color-selected": {
+            "icon-color-selected": {
                 "$type": "color",
-                "$value": "{primary.surface-selected}"
+                "$value": "{neutral.icon-always-light}"
+            },
+            "background": {
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{iris.300}", "position": 0 },
+                    { "color": "{iris.600}", "position": 1 }
+                ]
+            },
+            "background-hover": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{primary.surface-strong-hover}", "position": 0 },
+                    { "color": "{primary.surface-strong-hover}", "position": 1 }
+                ]
+            },
+            "background-pressed": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{primary.surface-strong-press}", "position": 0 },
+                    { "color": "{primary.surface-strong-press}", "position": 1 }
+                ]
+            },
+            "background-selected": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{primary.surface-strong-selected}", "position": 0 },
+                    { "color": "{primary.surface-strong-selected}", "position": 1 }
+                ]
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             },
             "border-color": {
                 "$type": "color",
-                "$value": "{neutral.border-weakest}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.border-weakest}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{neutral.border-weakest}"
+                "$value": "{primary.border}"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{neutral.border-weakest}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             }
         },
         "secondary": {
             "box-shadow": {
                 "$type": "shadow",
-                "$value": "{shadow.tactility-button}"
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
             },
             "text-color": {
                 "$type": "color",
-                "$value": "{neutral.text}"
+                "$value": "{primary.text}"
             },
             "text-color-hover": {
                 "$type": "color",
-                "$value": "{neutral.text-hover}"
+                "$value": "{primary.text-hover}"
             },
             "text-color-pressed": {
                 "$type": "color",
-                "$value": "{neutral.text-press}"
+                "$value": "{primary.text-press}"
             },
             "text-color-selected": {
                 "$type": "color",
-                "$value": "{neutral.text}"
+                "$value": "{primary.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
                 "$type": "color",
-                "$value": "{neutral.surface}"
+                "$value": "{primary.icon}"
             },
-            "background-color-hover": {
+            "icon-color-hover": {
                 "$type": "color",
-                "$value": "{neutral.surface-hover}"
+                "$value": "{primary.icon-hover}"
             },
-            "background-color-pressed": {
+            "icon-color-press": {
                 "$type": "color",
-                "$value": "{neutral.surface-press}"
+                "$value": "{primary.icon-press}"
             },
-            "background-color-selected": {
+            "icon-color-selected": {
                 "$type": "color",
-                "$value": "{primary.surface-weak-selected}"
+                "$value": "{primary.icon-selected}"
+            },
+            "background": {
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{neutral.surface}", "position": 0 },
+                    { "color": "{neutral.surface-weak}", "position": 1 }
+                ]
+            },
+            "background-hover": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{neutral.surface-weak-hover}", "position": 0 },
+                    { "color": "{neutral.surface-weak-hover}", "position": 1 }
+                ]
+            },
+            "background-pressed": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{neutral.surface-weak-hover}", "position": 0 },
+                    { "color": "{neutral.surface-weak-hover}", "position": 1 }
+                ]
+            },
+            "background-selected": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{neutral.surface-weak-selected}", "position": 0 },
+                    { "color": "{neutral.surface-weak-selected}", "position": 1 }
+                ]
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "{neutral.border-weakest}"
             },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.border-weakest}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{neutral.border-weakest}"
-            },
             "border-color-selected": {
+                "$type": "color",
+                "$value": "{neutral.border-weakest}"
+            },
+            "border-color-disabled": {
                 "$type": "color",
                 "$value": "transparent"
             }
@@ -115,11 +195,11 @@
         "upsell": {
             "box-shadow": {
                 "$type": "shadow",
-                "$value": "{shadow.tactility-button}"
+                "$value": "none"
             },
             "text-color": {
                 "$type": "color",
-                "$value": "{upsell.text}"
+                "$value": "{neutral.text-always-dark}"
             },
             "text-color-hover": {
                 "$type": "color",
@@ -127,49 +207,80 @@
             },
             "text-color-pressed": {
                 "$type": "color",
-                "$value": "{upsell.text-press}"
+                "$value": "{upsell.text-weak-press}"
             },
             "text-color-selected": {
                 "$type": "color",
                 "$value": "{upsell.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
                 "$type": "color",
-                "$value": "{upsell.surface-weak}"
+                "$value": "{neutral.icon-always-dark}"
             },
-            "background-color-hover": {
+            "icon-color-hover": {
                 "$type": "color",
-                "$value": "{upsell.surface-weak-hover}"
+                "$value": "{upsell.icon-hover}"
             },
-            "background-color-pressed": {
+            "icon-color-press": {
                 "$type": "color",
-                "$value": "{upsell.surface-weak-press}"
+                "$value": "{upsell.icon-weak-press}"
             },
-            "background-color-selected": {
+            "icon-color-selected": {
                 "$type": "color",
-                "$value": "{upsell.surface-selected}"
+                "$value": "{upsell.icon-selected}"
+            },
+            "background": {
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{limeburst.50}", "position": 0 },
+                    { "color": "{persimmon.300}", "position": 1.5156 }
+                ]
+            },
+            "background-hover": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{upsell.surface-weak-hover}", "position": 0 },
+                    { "color": "{upsell.surface-weak-hover}", "position": 1 }
+                ]
+            },
+            "background-pressed": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{upsell.surface-weak-press}", "position": 0 },
+                    { "color": "{upsell.surface-weak-press}", "position": 1 }
+                ]
+            },
+            "background-selected": {
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{upsell.surface-weak-press}", "position": 0 },
+                    { "color": "{upsell.surface-weak-press}", "position": 1 }
+                ]
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             },
             "border-color": {
                 "$type": "color",
-                "$value": "{neutral.border-weakest}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.border-weakest}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{neutral.border-weakest}"
+                "$value": "{upsell.border}"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{upsell.border-selected}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             }
         },
         "danger": {
             "box-shadow": {
                 "$type": "shadow",
-                "$value": "{shadow.tactility-button}"
+                "$value": "none"
             },
             "text-color": {
                 "$type": "color",
@@ -187,37 +298,53 @@
                 "$type": "color",
                 "$value": "{danger.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{danger.icon-strong}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{danger.icon-strong-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{danger.icon-strong-hover}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{danger.icon-selected}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "{danger.surface-strong}"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{danger.surface-strong-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{danger.surface-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{danger.surface-selected}"
             },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
+            },
             "border-color": {
                 "$type": "color",
-                "$value": "{danger.surface-strong}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{danger.surface-strong-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{danger.surface-press}"
+                "$value": "{neutral.border-weakest}"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{danger.border-selected}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             }
         },
         "ghost-primary": {
@@ -241,37 +368,53 @@
                 "$type": "color",
                 "$value": "{primary.text-press}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{primary.icon}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{primary.icon-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{primary.icon-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{primary.icon-press}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{primary.surface-weak-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{primary.surface-weak-selected}"
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.surface-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{primary.surface-weak-press}"
-            },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{primary.surface-weak-selected}"
+                "$value": "transparent"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             }
         },
         "ghost-secondary": {
@@ -295,37 +438,53 @@
                 "$type": "color",
                 "$value": "{neutral.text-weak-press}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak-press}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{neutral.surface-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
-                "$value": "{neutral.surface-press}"
+                "$value": "{neutral.surface-weak-selected}"
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.surface-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{neutral.surface-press}"
-            },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{neutral.surface-press}"
+                "$value": "transparent"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             }
         },
         "ghost-danger": {
@@ -349,63 +508,51 @@
                 "$type": "color",
                 "$value": "{danger.text-press}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{danger.icon-weak}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{danger.icon-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{danger.icon-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{danger.icon-press}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{danger.surface-weak-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
-                "$value": "{danger.surface-weak-press}"
+                "$value": "{danger.surface-selected}"
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "transparent"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.surface-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{danger.surface-weak-press}"
             },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{danger.surface-weak-press}"
-            }
-        },
-        "disabled": {
-            "text-color": {
-                "$type": "color",
-                "$value": "{neutral.text-disabled}"
-            },
-            "background-color": {
-                "$type": "color",
-                "$value": "{neutral.surface-disabled}"
-            },
-            "border-color": {
-                "$type": "color",
-                "$value": "{neutral.surface-disabled}"
-            }
-        },
-        "ghost-disabled": {
-            "text-color": {
-                "$type": "color",
-                "$value": "{neutral.text-disabled}"
-            },
-            "background-color": {
-                "$type": "color",
                 "$value": "transparent"
             },
-            "border-color": {
+            "border-color-disabled": {
                 "$type": "color",
                 "$value": "transparent"
             }

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -63,6 +63,25 @@
                     { "color": "{iris.600}", "position": 1 }
                 ]
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "{primary.surface-strong}"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{primary.icon-strong}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "{primary.border}"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
+            },
             "background-hover": {
                 "$type": "gradient",
                 "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
@@ -151,6 +170,28 @@
                     { "color": "{neutral.surface-weak}", "position": 1 }
                 ]
             },
+            "background-loading": {
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{neutral.surface}", "position": 0 },
+                    { "color": "{neutral.surface-weak}", "position": 1 }
+                ]
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "{neutral.border-weakest}"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
+            },
             "background-hover": {
                 "$type": "gradient",
                 "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
@@ -236,6 +277,28 @@
                     { "color": "{persimmon.300}", "position": 1.5156 }
                 ]
             },
+            "background-loading": {
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{neutral.surface}", "position": 0 },
+                    { "color": "{neutral.surface-weak}", "position": 1 }
+                ]
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "{neutral.border-weakest}"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
+            },
             "background-hover": {
                 "$type": "gradient",
                 "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
@@ -318,6 +381,22 @@
                 "$type": "color",
                 "$value": "{danger.surface-strong}"
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "{danger.surface-strong}"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{primary.icon-strong}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "{neutral.border-weakest}"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "none"
+            },
             "background-hover": {
                 "$type": "color",
                 "$value": "{danger.surface-strong-hover}"
@@ -387,6 +466,22 @@
             "background": {
                 "$type": "color",
                 "$value": "transparent"
+            },
+            "background-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "none"
             },
             "background-hover": {
                 "$type": "color",
@@ -458,6 +553,22 @@
                 "$type": "color",
                 "$value": "transparent"
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "none"
+            },
             "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
@@ -527,6 +638,22 @@
             "background": {
                 "$type": "color",
                 "$value": "transparent"
+            },
+            "background-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "none"
             },
             "background-hover": {
                 "$type": "color",

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -283,13 +283,13 @@
             "background-loading": {
                 "$type": "gradient",
                 "$value": [
-                    { "color": "{neutral.surface}", "position": 0 },
-                    { "color": "{neutral.surface-weak}", "position": 1 }
+                    { "color": "{limeburst.50}", "position": 0 },
+                    { "color": "{persimmon.300}", "position": 1.5156 }
                 ]
             },
             "color-loading": {
                 "$type": "color",
-                "$value": "{neutral.icon}"
+                "$value": "{neutral.icon-always-dark}"
             },
             "border-color-loading": {
                 "$type": "color",

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -293,7 +293,7 @@
             },
             "border-color-loading": {
                 "$type": "color",
-                "$value": "{neutral.border-weakest}"
+                "$value": "{upsell.border}"
             },
             "box-shadow-loading": {
                 "$type": "shadow",

--- a/packages/tokens/src/tokens/components/workleap/button.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/button.tokens.json
@@ -4,6 +4,18 @@
             "$type": "borderRadius",
             "$value": "{shape.rounded-md}"
         },
+        "border-color-focus": {
+            "$type": "color",
+            "$value": "{primary.border-focus}"
+        },
+        "text-color-disabled": {
+            "$type": "color",
+            "$value": "{neutral.text-disabled}"
+        },
+        "icon-color-disabled": {
+            "$type": "color",
+            "$value": "{neutral.icon-disabled}"
+        },
         "primary": {
             "box-shadow": {
                 "$type": "shadow",
@@ -25,37 +37,53 @@
                 "$type": "color",
                 "$value": "{primary.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{primary.icon-strong}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{primary.icon-strong-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{primary.icon-strong}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{primary.icon-selected}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "{primary.surface-strong}"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{primary.surface-strong-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{primary.surface-strong-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{primary.surface-selected}"
             },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
+            },
             "border-color": {
                 "$type": "color",
-                "$value": "{primary.surface-strong}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{primary.surface-strong-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{primary.surface-strong-press}"
+                "$value": "transparent"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{primary.border-selected}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             }
         },
         "secondary": {
@@ -79,37 +107,53 @@
                 "$type": "color",
                 "$value": "{neutral.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{neutral.icon-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{neutral.icon-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{neutral.icon-selected}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "{neutral.surface}"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{neutral.surface-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{neutral.surface-selected}"
             },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
+            },
             "border-color": {
-                "$type": "color",
-                "$value": "{neutral.border-strong}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.border-strong-hover}"
-            },
-            "border-color-pressed": {
                 "$type": "color",
                 "$value": "{neutral.border-strong}"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{neutral.border-selected}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             }
         },
         "upsell": {
@@ -133,37 +177,53 @@
                 "$type": "color",
                 "$value": "{upsell.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{upsell.icon}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{upsell.icon-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{upsell.icon-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{upsell.icon-selected}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "{upsell.surface-weak}"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{upsell.surface-weak-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{upsell.surface-weak-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{upsell.surface-selected}"
             },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
+            },
             "border-color": {
                 "$type": "color",
-                "$value": "{upsell.surface-weak}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{upsell.surface-weak-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{upsell.surface-weak-press}"
+                "$value": "transparent"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{upsell.border-selected}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             }
         },
         "danger": {
@@ -187,37 +247,53 @@
                 "$type": "color",
                 "$value": "{danger.text-selected}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{danger.icon-strong}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{danger.icon-strong-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{danger.icon-strong-hover}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{danger.icon-selected}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "{danger.surface-strong}"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{danger.surface-strong-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{danger.surface-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{danger.surface-selected}"
             },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
+            },
             "border-color": {
                 "$type": "color",
-                "$value": "{danger.surface-strong}"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{danger.surface-strong-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{danger.surface-press}"
+                "$value": "transparent"
             },
             "border-color-selected": {
                 "$type": "color",
                 "$value": "{danger.border-selected}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.surface-disabled}"
             }
         },
         "ghost-primary": {
@@ -241,37 +317,53 @@
                 "$type": "color",
                 "$value": "{primary.text-press}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{primary.icon}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{primary.text-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{primary.icon-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{primary.icon-press}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{primary.surface-weak-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{primary.surface-weak-press}"
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.surface-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{primary.surface-weak-press}"
-            },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{primary.surface-weak-press}"
+                "$value": "transparent"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             }
         },
         "ghost-secondary": {
@@ -295,37 +387,53 @@
                 "$type": "color",
                 "$value": "{neutral.text-weak-press}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{neutral.icon-weak-press}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{neutral.surface-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
-                "$value": "{neutral.surface-press}"
+                "$value": "{neutral.surface-weak-selected}"
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.surface-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{neutral.surface-press}"
-            },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{neutral.surface-press}"
+                "$value": "transparent"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             }
         },
         "ghost-danger": {
@@ -349,63 +457,51 @@
                 "$type": "color",
                 "$value": "{danger.text-press}"
             },
-            "background-color": {
+            "icon-color": {
+                "$type": "color",
+                "$value": "{danger.icon-weak}"
+            },
+            "icon-color-hover": {
+                "$type": "color",
+                "$value": "{danger.icon-hover}"
+            },
+            "icon-color-press": {
+                "$type": "color",
+                "$value": "{danger.icon-press}"
+            },
+            "icon-color-selected": {
+                "$type": "color",
+                "$value": "{danger.icon-press}"
+            },
+            "background": {
                 "$type": "color",
                 "$value": "transparent"
             },
-            "background-color-hover": {
+            "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
             },
-            "background-color-pressed": {
+            "background-pressed": {
                 "$type": "color",
                 "$value": "{danger.surface-weak-press}"
             },
-            "background-color-selected": {
+            "background-selected": {
                 "$type": "color",
                 "$value": "{danger.surface-weak-press}"
+            },
+            "background-disabled": {
+                "$type": "color",
+                "$value": "transparent"
             },
             "border-color": {
                 "$type": "color",
                 "$value": "transparent"
-            },
-            "border-color-hover": {
-                "$type": "color",
-                "$value": "{neutral.surface-hover}"
-            },
-            "border-color-pressed": {
-                "$type": "color",
-                "$value": "{danger.surface-weak-press}"
             },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{danger.surface-weak-press}"
-            }
-        },
-        "disabled": {
-            "text-color": {
-                "$type": "color",
-                "$value": "{neutral.text-disabled}"
-            },
-            "background-color": {
-                "$type": "color",
-                "$value": "{neutral.surface-disabled}"
-            },
-            "border-color": {
-                "$type": "color",
-                "$value": "{neutral.surface-disabled}"
-            }
-        },
-        "ghost-disabled": {
-            "text-color": {
-                "$type": "color",
-                "$value": "{neutral.text-disabled}"
-            },
-            "background-color": {
-                "$type": "color",
                 "$value": "transparent"
             },
-            "border-color": {
+            "border-color-disabled": {
                 "$type": "color",
                 "$value": "transparent"
             }

--- a/packages/tokens/src/tokens/components/workleap/button.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/button.tokens.json
@@ -57,6 +57,22 @@
                 "$type": "color",
                 "$value": "{primary.surface-strong}"
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "{primary.surface-strong}"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{primary.icon-strong}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
+            },
             "background-hover": {
                 "$type": "color",
                 "$value": "{primary.surface-strong-hover}"
@@ -126,6 +142,22 @@
             "background": {
                 "$type": "color",
                 "$value": "{neutral.surface}"
+            },
+            "background-loading": {
+                "$type": "color",
+                "$value": "{neutral.surface}"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "{neutral.border-strong}"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
             },
             "background-hover": {
                 "$type": "color",
@@ -197,6 +229,22 @@
                 "$type": "color",
                 "$value": "{upsell.surface-weak}"
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "{upsell.surface-weak}"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{upsell.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
+            },
             "background-hover": {
                 "$type": "color",
                 "$value": "{upsell.surface-weak-hover}"
@@ -266,6 +314,22 @@
             "background": {
                 "$type": "color",
                 "$value": "{danger.surface-strong}"
+            },
+            "background-loading": {
+                "$type": "color",
+                "$value": "{danger.surface-strong}"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{primary.icon-strong}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
             },
             "background-hover": {
                 "$type": "color",
@@ -337,6 +401,22 @@
                 "$type": "color",
                 "$value": "transparent"
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
+            },
             "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
@@ -407,6 +487,22 @@
                 "$type": "color",
                 "$value": "transparent"
             },
+            "background-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
+            },
             "background-hover": {
                 "$type": "color",
                 "$value": "{neutral.surface-hover}"
@@ -476,6 +572,22 @@
             "background": {
                 "$type": "color",
                 "$value": "transparent"
+            },
+            "background-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "color-loading": {
+                "$type": "color",
+                "$value": "{neutral.icon}"
+            },
+            "border-color-loading": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "box-shadow-loading": {
+                "$type": "shadow",
+                "$value": "{shadow.none}"
             },
             "background-hover": {
                 "$type": "color",

--- a/packages/tokens/src/tokens/core/elevation.tokens.json
+++ b/packages/tokens/src/tokens/core/elevation.tokens.json
@@ -15,10 +15,6 @@
         "lg": {
             "$type": "shadow",
             "$value": "0 10px 18px 8px rgba(60, 60, 60, 0.08)"
-        },
-        "tactility-button": {
-            "$type": "shadow",
-            "$value": "0 2px 1px 0 rgba(255, 255, 255, 0.25) inset, 0 -2px 2px 0 rgba(0, 0, 0, 0.25) inset"
         }
     }
 }

--- a/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
@@ -856,7 +856,7 @@
         },
         "surface-strong-selected": {
             "$type": "color",
-            "$value": "{iris.800}"
+            "$value": "{iris.300}"
         },
         "surface-strong-hover": {
             "$type": "color",

--- a/packages/tokens/src/tokens/semantic/sharegate/light/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/light/colors.tokens.json
@@ -856,7 +856,7 @@
         },
         "surface-strong-selected": {
             "$type": "color",
-            "$value": "{iris.50}"
+            "$value": "{iris.800}"
         },
         "surface-strong-hover": {
             "$type": "color",

--- a/packages/tokens/tests/jest/components/tokenComparison.test.ts
+++ b/packages/tokens/tests/jest/components/tokenComparison.test.ts
@@ -38,6 +38,9 @@ const collectKeys = (jsonPath: string): string[] => {
         }
 
         Object.keys(node).forEach(key => {
+            if (key === "$description") {
+                return;
+            }
             const currentPath = prefix ? `${prefix}.${key}` : key;
             keys.push(currentPath);
             if (key !== "$value") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 2.2.2
         version: 2.2.2(playwright@1.56.1)
       chromatic:
-        specifier: 13.3.5
-        version: 13.3.5
+        specifier: 16.2.0
+        version: 16.2.0
       cross-env:
         specifier: 10.1.0
         version: 10.1.0
@@ -5211,8 +5211,8 @@ packages:
       '@chromatic-com/playwright':
         optional: true
 
-  chromatic@13.3.5:
-    resolution: {integrity: sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==}
+  chromatic@16.2.0:
+    resolution: {integrity: sha512-yFUC0iCumsw5JDQPmrNAgYuln25HRh79iGdJgm+dj87lv7kFatlRBgRcw8Kmzdw1si3qzGlzu36aCABS7Wg5aQ==}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
@@ -16399,7 +16399,7 @@ snapshots:
 
   chromatic@12.2.0: {}
 
-  chromatic@13.3.5: {}
+  chromatic@16.2.0: {}
 
   chrome-trace-event@1.0.4: {}
 


### PR DESCRIPTION
Jira issue link: [SGPLTD-1787](https://workleap.atlassian.net/browse/SGPLTD-1787)

## Summary

- Align button token JSON files (`sharegate` and `workleap` themes) with Figma designs for all variants: **secondary, upsell, danger, ghost-primary, ghost-secondary, ghost-danger**
- Translate `background-color-*` naming to `background-*`
- Add missing `icon-color*` tokens across variants where absent
- Fix mismatched color references (e.g. `neutral.*` → `primary.*` for ShareGate secondary text/icon)
- Convert ShareGate secondary and upsell `background` to gradients (top/bottom stops differ per design)
- Fix `border-color`, `background-selected`, `background-hover/pressed` mismatches across both themes

## Test plan

- [ ] Verify token JSON files parse correctly via `pnpm build` in `packages/tokens`
- [ ] Visually verify button variants in Storybook for both Workleap and ShareGate themes
- [ ] Confirm gradient backgrounds render correctly for ShareGate secondary and upsell variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SGPLTD-1787]: https://workleap.atlassian.net/browse/SGPLTD-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ