### PR TITLE
feat(tokens): add Tabs branding tokens [SGPLTD-1748]

### DIFF
--- a/.changeset/open-wasps-nail.md
+++ b/.changeset/open-wasps-nail.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/components": patch
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+---
+
+Add Tabs branding tokens

--- a/packages/components/src/tabs/src/Tab.module.css
+++ b/packages/components/src/tabs/src/Tab.module.css
@@ -3,29 +3,14 @@
     --hop-Tab-gap: var(--hop-space-inset-sm);
     --hop-Tab-align-items: center;
     --hop-Tab-justify-content: center;
-    --hop-Tab-color: var(--hop-neutral-text-weak);
     --hop-Tab-white-space: nowrap;
-    --hop-Tab-border-radius: var(--hop-shape-rounded-md);
     --hop-Tab-outline: none;
     --hop-Tab-padding: var(--hop-space-inset-sm);
     --hop-Tab-text-decoration: none;
     --hop-Tab-cursor: pointer;
 
-    /* Selected */
-    --hop-Tab-selected-color: var(--hop-neutral-text);
-
-    /* Hovered */
-    --hop-Tab-hovered-color: var(--hop-neutral-text-hover);
-
-    /* Pressed */
-    --hop-Tab-pressed-color: var(--hop-neutral-text-press);
-
     /* Focus */
-    --hop-Tab-focus-color: var(--hop-neutral-text-hover);
-    --hop-Tab-focus-outline: var(--hop-space-20) solid var(--hop-primary-border-focus);
-
-    /* Disabled */
-    --hop-Tab-disabled-color: var(--hop-neutral-text-disabled);
+    --hop-Tab-focus-outline: var(--hop-space-20) solid var(--hop-comp-tabs-tab-border-color-focus);
 
     /* Medium */
     --hop-Tab-medium-padding: var(--hop-space-20);
@@ -45,11 +30,11 @@
     box-sizing: border-box;
     padding: var(--padding);
 
-    color: var(--color, var(--hop-Tab-color));
+    color: var(--color, var(--hop-comp-tabs-tab-text-color));
     text-decoration: var(--hop-Tab-text-transform);
     white-space: var(--hop-Tab-white-space);
 
-    border-radius: var(--hop-Tab-border-radius);
+    border-radius: var(--hop-comp-tabs-tab-border-radius);
     outline: var(--outline, var(--hop-Tab-outline));
 }
 
@@ -62,24 +47,24 @@
 }
 
 .hop-Tab[data-selected] {
-    --color: var(--hop-Tab-selected-color);
+    --color: var(--hop-comp-tabs-tab-text-color-selected);
 }
 
 .hop-Tab[data-hovered] {
-    --color: var(--hop-Tab-hovered-color)
+    --color: var(--hop-comp-tabs-tab-text-color-hover);
 }
 
 .hop-Tab[data-pressed] {
-    --color: var(--hop-Tab-pressed-color);
+    --color: var(--hop-comp-tabs-tab-text-color-press);
 }
 
 .hop-Tab[data-focus-visible] {
-    --color: var(--hop-Tab-focus-color);
+    --color: var(--hop-comp-tabs-tab-text-color-focus);
     --outline: var(--hop-Tab-focus-outline);
 }
 
 .hop-Tab[data-disabled] {
-    --color: var(--hop-Tab-disabled-color);
+    --color: var(--hop-comp-tabs-tab-text-color-disabled);
     --cursor: auto;
 }
 
@@ -116,10 +101,10 @@
     inline-size: 100%;
     block-size: 0.125rem;
 
-    background-color: var(--hop-neutral-border-selected);
+    background-color: var(--hop-comp-tabs-tab-border-color-selected);
     border-style: none;
 }
 
 .hop-Tab__selector--disabled .hop-Tab__selector--inner {
-    background-color: var(--hop-neutral-border-disabled);
+    background-color: var(--hop-comp-tabs-tab-border-color-disabled);
 }

--- a/packages/components/src/tabs/src/Tab.module.css
+++ b/packages/components/src/tabs/src/Tab.module.css
@@ -35,6 +35,7 @@
 
     border-radius: var(--hop-comp-tabs-tab-border-radius);
     outline: var(--outline, var(--hop-Tab-outline));
+    text-decoration: var(--hop-Tab-text-decoration);
 }
 
 .hop-Tab--fluid {

--- a/packages/components/src/tabs/src/Tab.module.css
+++ b/packages/components/src/tabs/src/Tab.module.css
@@ -31,7 +31,6 @@
     padding: var(--padding);
 
     color: var(--color, var(--hop-comp-tabs-tab-text-color));
-    text-decoration: var(--hop-Tab-text-transform);
     white-space: var(--hop-Tab-white-space);
 
     border-radius: var(--hop-comp-tabs-tab-border-radius);

--- a/packages/components/src/tabs/src/TabList.module.css
+++ b/packages/components/src/tabs/src/TabList.module.css
@@ -2,19 +2,16 @@
     --hop-TabList-display: flex;
     --hop-TabList-position: relative;
     --hop-TabList-overflow-y: auto;
-    --hop-Tablist-border-radius: var(--hop-shape-rounded-md);
     --hop-TabList-padding-inline: var(--hop-space-inset-xs);
 
     /* This is to ensure to the proper height of the TabList */
     --hop-TabList-padding-block: calc(var(--hop-space-inset-xs) + var(--hop-space-10));
 
     /* Standalone */
-    --hop-TabList-standalone-background: var(--hop-neutral-surface-weakest);
-    --hop-TabList-standalone-border: 0.0625rem solid var(--hop-neutral-border-weak);
+    --hop-TabList-standalone-border: 0.0625rem solid var(--hop-comp-tabs-tab-list-border-color);
 
     /* In card */
-    --hop-TabList-in-card-background: var(--hop-neutral-surface-weakest);
-    --hop-TabList-in-card-border: 0.0625rem solid var(--hop-neutral-border-weak);
+    --hop-TabList-in-card-border: 0.0625rem solid var(--hop-comp-tabs-tab-list-border-color);
 
     /* Internal */
     --padding-inline: var(--hop-TabList-padding-inline);
@@ -33,18 +30,18 @@
 }
 
 .hop-TabList--standalone {
-    --background: var(--hop-TabList-standalone-background);
+    --background: var(--hop-comp-tabs-tab-list-background-color);
     --border: var(--hop-TabList-standalone-border);
 
-    border-radius: var(--hop-Tablist-border-radius);
+    border-radius: var(--hop-comp-tabs-tab-list-border-radius);
 }
 
 .hop-TabList--in-card {
-    --background: var(--hop-TabList-in-card-background);
+    --background: var(--hop-comp-tabs-tab-list-background-color);
 
     border: 0;
     border-block-end: var(--hop-TabList-in-card-border);
-    border-radius: var(--hop-Tablist-border-radius) var(--hop-Tablist-border-radius) 0 0;
+    border-radius: var(--hop-comp-tabs-tab-list-border-radius) var(--hop-comp-tabs-tab-list-border-radius) 0 0;
 }
 
 .hop-TabList__tablist {

--- a/packages/components/src/tabs/src/TabList.module.css
+++ b/packages/components/src/tabs/src/TabList.module.css
@@ -7,12 +7,6 @@
     /* This is to ensure to the proper height of the TabList */
     --hop-TabList-padding-block: calc(var(--hop-space-inset-xs) + var(--hop-space-10));
 
-    /* Standalone */
-    --hop-TabList-standalone-border: 0.0625rem solid var(--hop-comp-tabs-tab-list-border-color);
-
-    /* In card */
-    --hop-TabList-in-card-border: 0.0625rem solid var(--hop-comp-tabs-tab-list-border-color);
-
     /* Internal */
     --padding-inline: var(--hop-TabList-padding-inline);
 
@@ -26,13 +20,13 @@
     padding-inline: var(--padding-inline);
 
     background: var(--background);
-    border: var(--border);
 }
 
 .hop-TabList--standalone {
     --background: var(--hop-comp-tabs-tab-list-background-color);
-    --border: var(--hop-TabList-standalone-border);
 
+    border: var(--hop-comp-tabs-tab-list-border);
+    border-block-end: var(--hop-comp-tabs-tab-list-border-block-end);
     border-radius: var(--hop-comp-tabs-tab-list-border-radius);
 }
 
@@ -40,7 +34,7 @@
     --background: var(--hop-comp-tabs-tab-list-background-color);
 
     border: 0;
-    border-block-end: var(--hop-TabList-in-card-border);
+    border-block-end: var(--hop-comp-tabs-tab-list-border-block-end);
     border-radius: var(--hop-comp-tabs-tab-list-border-radius) var(--hop-comp-tabs-tab-list-border-radius) 0 0;
 }
 

--- a/packages/components/src/tabs/src/TabPanel.module.css
+++ b/packages/components/src/tabs/src/TabPanel.module.css
@@ -3,7 +3,7 @@
     --hop-TabPanel-outline-width: 0.125rem;
 
     /* Focus */
-    --hop-TabPanel-focus-outline: var(--hop-TabPanel-outline-width) solid var(--hop-primary-border-focus);
+    --hop-TabPanel-focus-outline: var(--hop-TabPanel-outline-width) solid var(--hop-comp-tabs-tab-panel-border-color-focus);
 
     box-sizing: border-box;
     outline: var(--outline, var(--hop-TabPanel-outline));

--- a/packages/components/src/tabs/tests/chromatic/Tabs.stories.tsx
+++ b/packages/components/src/tabs/tests/chromatic/Tabs.stories.tsx
@@ -387,7 +387,7 @@ export const States: Story = {
             <h1>Tab Disabled</h1>
             <Tabs {...args}>
                 <TabList>
-                    <Tab id="t4-frog-1" isDisabled>Red-Eyed Tree Frog</Tab>
+                    <Tab id="t4-frog-1">Red-Eyed Tree Frog</Tab>
                     <Tab id="t4-frog-2" isDisabled>
                         <SparklesIcon />
                         <Text>Poison Dart Frog</Text>

--- a/packages/components/src/tabs/tests/chromatic/Tabs.stories.tsx
+++ b/packages/components/src/tabs/tests/chromatic/Tabs.stories.tsx
@@ -1,8 +1,10 @@
 import { SparklesIcon } from "@hopper-ui/icons";
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
+import { within } from "storybook/test";
 
 import { Badge } from "../../../badge/index.ts";
 import { Card } from "../../../card/index.ts";
+import { Stack } from "../../../layout/index.ts";
 import { Tag } from "../../../tag/index.ts";
 import { Text } from "../../../typography/index.ts";
 import { TabPanel } from "../../src/index.ts";
@@ -300,3 +302,119 @@ export const WithHref = {
         size: "md"
     }
 } satisfies Story;
+
+export const States: Story = {
+    parameters: {
+        chromatic: {
+            delay: 2000
+        }
+    },
+    play: ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        canvas.getAllByRole("tab").forEach(tab => {
+            if (tab.getAttribute("data-chromatic-force-focus")) {
+                tab.setAttribute("data-focus-visible", "true");
+                tab.removeAttribute("data-chromatic-force-focus");
+            }
+
+            if (tab.getAttribute("data-chromatic-force-hover")) {
+                tab.setAttribute("data-hovered", "true");
+                tab.removeAttribute("data-chromatic-force-hover");
+            }
+        });
+
+        canvas.getAllByRole("tabpanel").forEach(panel => {
+            if (panel.getAttribute("data-chromatic-force-focus")) {
+                panel.setAttribute("data-focus-visible", "true");
+                panel.removeAttribute("data-chromatic-force-focus");
+            }
+        });
+    },
+    render: args => (
+        <Stack>
+            <h1>Tab Hovered</h1>
+            <Tabs {...args}>
+                <TabList>
+                    <Tab id="t1-frog-1" data-chromatic-force-hover>Red-Eyed Tree Frog</Tab>
+                    <Tab id="t1-frog-2" data-chromatic-force-hover>
+                        <SparklesIcon />
+                        <Text>Poison Dart Frog</Text>
+                    </Tab>
+                    <Tab id="t1-frog-3" data-chromatic-force-hover>
+                        <Text>Goliath Frog</Text>
+                        <Badge>3</Badge>
+                    </Tab>
+                </TabList>
+                <TabPanel id="t1-frog-1" padding="inset-md">The Red-Eyed Tree Frog is a vibrant nocturnal climber.</TabPanel>
+                <TabPanel id="t1-frog-2" padding="inset-md">The Poison Dart Frog is a tiny but highly toxic amphibian.</TabPanel>
+                <TabPanel id="t1-frog-3" padding="inset-md">The Goliath Frog is the largest frog in the world.</TabPanel>
+            </Tabs>
+            <h1>Tab Focus Visible</h1>
+            <Tabs {...args}>
+                <TabList>
+                    <Tab id="t2-frog-1" data-chromatic-force-focus>Red-Eyed Tree Frog</Tab>
+                    <Tab id="t2-frog-2" data-chromatic-force-focus>
+                        <SparklesIcon />
+                        <Text>Poison Dart Frog</Text>
+                    </Tab>
+                    <Tab id="t2-frog-3" data-chromatic-force-focus>
+                        <Text>Goliath Frog</Text>
+                        <Badge>3</Badge>
+                    </Tab>
+                </TabList>
+                <TabPanel id="t2-frog-1" padding="inset-md">The Red-Eyed Tree Frog is a vibrant nocturnal climber.</TabPanel>
+                <TabPanel id="t2-frog-2" padding="inset-md">The Poison Dart Frog is a tiny but highly toxic amphibian.</TabPanel>
+                <TabPanel id="t2-frog-3" padding="inset-md">The Goliath Frog is the largest frog in the world.</TabPanel>
+            </Tabs>
+            <h1>Tab Focus Visible and Hovered</h1>
+            <Tabs {...args}>
+                <TabList>
+                    <Tab id="t3-frog-1" data-chromatic-force-focus data-chromatic-force-hover>Red-Eyed Tree Frog</Tab>
+                    <Tab id="t3-frog-2" data-chromatic-force-focus data-chromatic-force-hover>
+                        <SparklesIcon />
+                        <Text>Poison Dart Frog</Text>
+                    </Tab>
+                    <Tab id="t3-frog-3" data-chromatic-force-focus data-chromatic-force-hover>
+                        <Text>Goliath Frog</Text>
+                        <Badge>3</Badge>
+                    </Tab>
+                </TabList>
+                <TabPanel id="t3-frog-1" padding="inset-md">The Red-Eyed Tree Frog is a vibrant nocturnal climber.</TabPanel>
+                <TabPanel id="t3-frog-2" padding="inset-md">The Poison Dart Frog is a tiny but highly toxic amphibian.</TabPanel>
+                <TabPanel id="t3-frog-3" padding="inset-md">The Goliath Frog is the largest frog in the world.</TabPanel>
+            </Tabs>
+            <h1>Tab Disabled</h1>
+            <Tabs {...args}>
+                <TabList>
+                    <Tab id="t4-frog-1" isDisabled>Red-Eyed Tree Frog</Tab>
+                    <Tab id="t4-frog-2" isDisabled>
+                        <SparklesIcon />
+                        <Text>Poison Dart Frog</Text>
+                    </Tab>
+                    <Tab id="t4-frog-3" isDisabled>
+                        <Text>Goliath Frog</Text>
+                        <Badge>3</Badge>
+                    </Tab>
+                </TabList>
+                <TabPanel id="t4-frog-1" padding="inset-md">The Red-Eyed Tree Frog is a vibrant nocturnal climber.</TabPanel>
+                <TabPanel id="t4-frog-2" padding="inset-md">The Poison Dart Frog is a tiny but highly toxic amphibian.</TabPanel>
+                <TabPanel id="t4-frog-3" padding="inset-md">The Goliath Frog is the largest frog in the world.</TabPanel>
+            </Tabs>
+            <h1>Tab Panel Focus Visible</h1>
+            <Tabs {...args}>
+                <TabList>
+                    <Tab id="t5-frog-1">Red-Eyed Tree Frog</Tab>
+                    <Tab id="t5-frog-2">Poison Dart Frog</Tab>
+                    <Tab id="t5-frog-3">Goliath Frog</Tab>
+                </TabList>
+                <TabPanel id="t5-frog-1" padding="inset-md" data-chromatic-force-focus>The Red-Eyed Tree Frog is a vibrant nocturnal climber.</TabPanel>
+                <TabPanel id="t5-frog-2" padding="inset-md">The Poison Dart Frog is a tiny but highly toxic amphibian.</TabPanel>
+                <TabPanel id="t5-frog-3" padding="inset-md">The Goliath Frog is the largest frog in the world.</TabPanel>
+            </Tabs>
+        </Stack>
+    ),
+    args: {
+        "aria-label": "Frogs"
+    }
+};

--- a/packages/components/src/tabs/tests/chromatic/Tabs.stories.tsx
+++ b/packages/components/src/tabs/tests/chromatic/Tabs.stories.tsx
@@ -309,10 +309,11 @@ export const States: Story = {
             delay: 2000
         }
     },
-    play: ({ canvasElement }) => {
+    play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        canvas.getAllByRole("tab").forEach(tab => {
+        const tabs = await canvas.findAllByRole("tab");
+        tabs.forEach(tab => {
             if (tab.getAttribute("data-chromatic-force-focus")) {
                 tab.setAttribute("data-focus-visible", "true");
                 tab.removeAttribute("data-chromatic-force-focus");
@@ -324,7 +325,8 @@ export const States: Story = {
             }
         });
 
-        canvas.getAllByRole("tabpanel").forEach(panel => {
+        const panels = await canvas.findAllByRole("tabpanel");
+        panels.forEach(panel => {
             if (panel.getAttribute("data-chromatic-force-focus")) {
                 panel.setAttribute("data-focus-visible", "true");
                 panel.removeAttribute("data-chromatic-force-focus");

--- a/packages/tokens/src/tokens/components/sharegate/tabs.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/tabs.tokens.json
@@ -47,13 +47,17 @@
                 "$type": "color",
                 "$value": "transparent"
             },
-            "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+            "border": {
+                "$type": "border",
+                "$value": "none"
+            },
+            "border-block-end": {
+                "$type": "border",
+                "$value": "{space.10} solid {neutral.border-weak}"
             },
             "border-radius": {
                 "$type": "borderRadius",
-                "$value": "{shape.rounded-sm}"
+                "$value": "none"
             }
         },
         "tab-panel": {

--- a/packages/tokens/src/tokens/components/sharegate/tabs.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/tabs.tokens.json
@@ -1,0 +1,66 @@
+{
+    "comp-tabs": {
+        "tab": {
+            "text-color": {
+                "$type": "color",
+                "$value": "{neutral.text-weak}"
+            },
+            "text-color-hover": {
+                "$type": "color",
+                "$value": "{neutral.text-hover}"
+            },
+            "text-color-press": {
+                "$type": "color",
+                "$value": "{neutral.text-press}"
+            },
+            "text-color-selected": {
+                "$type": "color",
+                "$value": "{primary.text-selected}"
+            },
+            "text-color-focus": {
+                "$type": "color",
+                "$value": "{neutral.text-hover}"
+            },
+            "text-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.text-disabled}"
+            },
+            "border-color-selected": {
+                "$type": "color",
+                "$value": "{primary.border-selected}"
+            },
+            "border-color-focus": {
+                "$type": "color",
+                "$value": "{primary.border-focus}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.border-disabled}"
+            },
+            "border-radius": {
+                "$type": "borderRadius",
+                "$value": "{shape.rounded-sm}"
+            }
+        },
+        "tab-list": {
+            "background-color": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "transparent"
+            },
+            "border-radius": {
+                "$type": "borderRadius",
+                "$value": "{shape.rounded-sm}"
+            }
+        },
+        "tab-panel": {
+            "border-color-focus": {
+                "$type": "color",
+                "$value": "{primary.border-focus}"
+            }
+        }
+    }
+}

--- a/packages/tokens/src/tokens/components/workleap/tabs.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/tabs.tokens.json
@@ -47,9 +47,13 @@
                 "$type": "color",
                 "$value": "{neutral.surface-weakest}"
             },
-            "border-color": {
-                "$type": "color",
-                "$value": "{neutral.border-weak}"
+            "border": {
+                "$type": "border",
+                "$value": "{space.10} solid {neutral.border-weak}"
+            },
+            "border-block-end": {
+                "$type": "border",
+                "$value": "{space.10} solid {neutral.border-weak}"
             },
             "border-radius": {
                 "$type": "borderRadius",

--- a/packages/tokens/src/tokens/components/workleap/tabs.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/tabs.tokens.json
@@ -1,0 +1,66 @@
+{
+    "comp-tabs": {
+        "tab": {
+            "text-color": {
+                "$type": "color",
+                "$value": "{neutral.text-weak}"
+            },
+            "text-color-hover": {
+                "$type": "color",
+                "$value": "{neutral.text-hover}"
+            },
+            "text-color-press": {
+                "$type": "color",
+                "$value": "{neutral.text-press}"
+            },
+            "text-color-selected": {
+                "$type": "color",
+                "$value": "{neutral.text}"
+            },
+            "text-color-focus": {
+                "$type": "color",
+                "$value": "{neutral.text-hover}"
+            },
+            "text-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.text-disabled}"
+            },
+            "border-color-selected": {
+                "$type": "color",
+                "$value": "{neutral.border-selected}"
+            },
+            "border-color-focus": {
+                "$type": "color",
+                "$value": "{primary.border-focus}"
+            },
+            "border-color-disabled": {
+                "$type": "color",
+                "$value": "{neutral.border-disabled}"
+            },
+            "border-radius": {
+                "$type": "borderRadius",
+                "$value": "{shape.rounded-md}"
+            }
+        },
+        "tab-list": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{neutral.surface-weakest}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{neutral.border-weak}"
+            },
+            "border-radius": {
+                "$type": "borderRadius",
+                "$value": "{shape.rounded-md}"
+            }
+        },
+        "tab-panel": {
+            "border-color-focus": {
+                "$type": "color",
+                "$value": "{primary.border-focus}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `comp-tabs` branding token files for both Workleap and Sharegate themes with a structured hierarchy: `tab`, `tab-list`, and `tab-panel` as parallel sub-components
- Wire [Tab.module.css](packages/components/src/tabs/src/Tab.module.css), [TabList.module.css](packages/components/src/tabs/src/TabList.module.css), and [TabPanel.module.css](packages/components/src/tabs/src/TabPanel.module.css) to use the new `--hop-comp-tabs-*` token variables instead of hardcoded global tokens
- Add a chromatic `States` story covering hover, focus visible, focus+hover, disabled (with plain, icon, and badge tab variants), and tab panel focus visible

## Jira
https://workleap.atlassian.net/browse/SGPLTD-1748

## Test plan
- [ ] Chromatic `States` story renders all interactive states correctly for all tab content variants
- [ ] Workleap and Sharegate themes display correct colors for tab text, border, and focus ring
- [ ] No visual regressions in existing Tabs stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)