### PR TITLE
feat(tokens): add comp-select-checkmark-color token to listbox tick

### DIFF
--- a/.changeset/legal-beds-wash.md
+++ b/.changeset/legal-beds-wash.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/components": patch
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+---
+
+Add Listbox checkmark tokens

--- a/packages/components/src/list-box/src/ListBoxItem.module.css
+++ b/packages/components/src/list-box/src/ListBoxItem.module.css
@@ -67,7 +67,7 @@
     --hop-ListBoxItem-text-color-focused: var(--hop-neutral-text-hover);
     --hop-ListBoxItem-icon-color-focused: var(--hop-neutral-icon-hover);
 
-    /* Selected */ 
+    /* Selected */
     --hop-ListBoxItem-background-color-selected: transparent;
     --hop-ListBoxItem-text-color-selected: var(--hop-neutral-text);
     --hop-ListBoxItem-icon-color-selected: var(--hop-neutral-icon);
@@ -114,7 +114,7 @@
     --checkmark-transition: opacity 0.2s ease-in-out .2s;
 
     cursor: var(--cursor);
-    
+
     box-sizing: border-box;
 
     color: var(--text-color);
@@ -292,7 +292,7 @@
 
     margin-inline-end: var(--hop-ListBoxItem-column-gap);
 
-    color: var(--icon-color);
+    color: var(--hop-comp-select-checkmark-color);
 
     opacity: var(--checkmark-opacity);
 

--- a/packages/components/src/list-box/src/ListBoxItem.module.css
+++ b/packages/components/src/list-box/src/ListBoxItem.module.css
@@ -104,6 +104,7 @@
     --background-color: var(--hop-ListBoxItem-background-color);
     --text-color: var(--hop-ListBoxItem-text-color);
     --icon-color: var(--hop-ListBoxItem-icon-color);
+    --checkmark-color: var(--icon-color);
     --outline: none;
     --cursor: default;
     --checkmark-opacity: 0;
@@ -177,6 +178,7 @@
     --background-color: var(--hop-ListBoxItem-background-color-selected);
     --text-color: var(--hop-ListBoxItem-text-color-selected);
     --icon-color: var(--hop-ListBoxItem-icon-color-selected);
+    --checkmark-color: var(--hop-comp-select-checkmark-color);
     --checkmark-opacity: 1;
 }
 
@@ -200,6 +202,7 @@
     --background-color: var(--hop-ListBoxItem-background-color-focused);
     --text-color: var(--hop-ListBoxItem-text-color-focused);
     --icon-color: var(--hop-ListBoxItem-icon-color-focused);
+    --checkmark-color: var(--hop-comp-select-checkmark-color-focused);
     --outline: var(--hop-ListBoxItem-outline-size) solid var(--hop-ListBoxItem-outline-color);
 }
 
@@ -207,18 +210,21 @@
     --background-color: var(--hop-ListBoxItem-background-color-hovered);
     --text-color: var(--hop-ListBoxItem-text-color-hovered);
     --icon-color: var(--hop-ListBoxItem-icon-color-hovered);
+    --checkmark-color: var(--hop-comp-select-checkmark-color-hovered);
 }
 
 .hop-ListBoxItem[data-pressed] {
     --background-color: var(--hop-ListBoxItem-background-color-pressed);
     --text-color: var(--hop-ListBoxItem-text-color-pressed);
     --icon-color: var(--hop-ListBoxItem-icon-color-pressed);
+    --checkmark-color: var(--hop-comp-select-checkmark-color-pressed);
 }
 
 .hop-ListBoxItem[data-disabled] {
     --background-color: var(--hop-ListBoxItem-background-color-disabled);
     --text-color: var(--hop-ListBoxItem-text-color-disabled);
     --icon-color: var(--hop-ListBoxItem-icon-color-disabled);
+    --checkmark-color: var(--hop-comp-select-checkmark-color-disabled);
     --description-text-color: var(--hop-ListBoxItem-text-color-disabled);
     --cursor: not-allowed;
 }
@@ -233,6 +239,7 @@
     --background-color: var(--hop-ListBoxItem-background-color-invalid-selected);
     --text-color: var(--hop-ListBoxItem-text-color-invalid-selected);
     --icon-color: var(--hop-ListBoxItem-icon-color-invalid-selected);
+    --checkmark-color: var(--icon-color);
 }
 
 .hop-ListBoxItem[data-invalid][data-focus-visible] {
@@ -292,7 +299,7 @@
 
     margin-inline-end: var(--hop-ListBoxItem-column-gap);
 
-    color: var(--hop-comp-select-checkmark-color);
+    color: var(--checkmark-color);
 
     opacity: var(--checkmark-opacity);
 

--- a/packages/tokens/src/tokens/components/sharegate/field.select.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/field.select.tokens.json
@@ -11,6 +11,10 @@
         "text-color-hover": {
             "$type": "color",
             "$value": "{neutral.text-hover}"
+        },
+        "checkmark-color": {
+            "$type": "color",
+            "$value": "{primary.icon}"
         }
     }
 }

--- a/packages/tokens/src/tokens/components/sharegate/field.select.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/field.select.tokens.json
@@ -15,6 +15,22 @@
         "checkmark-color": {
             "$type": "color",
             "$value": "{primary.icon}"
+        },
+        "checkmark-color-hovered": {
+            "$type": "color",
+            "$value": "{primary.icon-hover}"
+        },
+        "checkmark-color-focused": {
+            "$type": "color",
+            "$value": "{primary.icon-hover}"
+        },
+        "checkmark-color-pressed": {
+            "$type": "color",
+            "$value": "{primary.icon-press}"
+        },
+        "checkmark-color-disabled": {
+            "$type": "color",
+            "$value": "{neutral.icon-disabled}"
         }
     }
 }

--- a/packages/tokens/src/tokens/components/workleap/field.select.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/field.select.tokens.json
@@ -11,6 +11,10 @@
         "text-color-hover": {
             "$type": "color",
             "$value": "{neutral.text-hover}"
+        },
+        "checkmark-color": {
+            "$type": "color",
+            "$value": "{neutral.icon}"
         }
     }
 }

--- a/packages/tokens/src/tokens/components/workleap/field.select.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/field.select.tokens.json
@@ -15,6 +15,22 @@
         "checkmark-color": {
             "$type": "color",
             "$value": "{neutral.icon}"
+        },
+        "checkmark-color-hovered": {
+            "$type": "color",
+            "$value": "{neutral.icon-hover}"
+        },
+        "checkmark-color-focused": {
+            "$type": "color",
+            "$value": "{neutral.icon-hover}"
+        },
+        "checkmark-color-pressed": {
+            "$type": "color",
+            "$value": "{neutral.icon-press}"
+        },
+        "checkmark-color-disabled": {
+            "$type": "color",
+            "$value": "{neutral.icon-disabled}"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `comp-select.checkmark-color` token to `field.select.tokens.json` for both sharegate and workleap themes
- Sharegate uses `{primary.icon}`, workleap uses `{neutral.icon}`
- Applies the token (`--hop-comp-select-checkmark-color`) directly to `.hop-ListBoxItem__checkmark` in `ListBoxItem.module.css`, keeping it separate from `--hop-ListBoxItem-icon-color-selected` which controls other icons

Closes SGPLTD-1845

## Test plan
- [ ] Verify the tick icon in a Select listbox uses the primary icon color in the sharegate theme when an item is selected
- [ ] Verify other icons (item icon, end-icon) in a selected ListBoxItem are unaffected
- [ ] Verify workleap theme shows no visual change (neutral.icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)