### PR TITLE
feat(alert, menu): remove hardcoded background to support glassy overlays [SGPLTD-1854]

### DIFF
--- a/.changeset/crisp-paths-battle.md
+++ b/.changeset/crisp-paths-battle.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+Remove unnecssary background from Alert modal and Menu Items to support glassy popovers in ShareGate theme

--- a/packages/components/src/alert/src/Alert.module.css
+++ b/packages/components/src/alert/src/Alert.module.css
@@ -1,7 +1,6 @@
 .hop-Alert  {
     --hop-Alert-max-inline-size: 90dvw;
     --hop-Alert-max-block-size: 90dvh;
-    --hop-Alert-background: var(--hop-neutral-surface);
     --hop-Alert-border-radius: var(--hop-shape-rounded-md);
     --hop-Alert-outline: none;
     --hop-Alert-display: grid;
@@ -29,7 +28,6 @@
     max-block-size: var(--max-block-size);
     padding: var(--padding, var(--hop-space-inset-lg));
 
-    background: var(--hop-Alert-background);
     border-radius: var(--border-radius);
     outline: var(--hop-Alert-outline);
 }

--- a/packages/components/src/menu/src/MenuItem.module.css
+++ b/packages/components/src/menu/src/MenuItem.module.css
@@ -40,7 +40,6 @@
     /* Internal variable */
     --display: var(--hop-MenuItem-display);
     --align-items: var(--hop-MenuItem-align-items);
-    --background-color: var(--hop-neutral-surface);
     --cursor: var(--hop-MenuItem-cursor);
     --color: var(--hop-MenuItem-color);
     --padding-block: var(--hop-MenuItem-sm-padding-block);


### PR DESCRIPTION
## Summary

- Remove `--hop-Alert-background` from `Alert.module.css` so the component inherits no default background, allowing the `backdrop-filter` glass effect from the ShareGate theme to render correctly
- Remove `--background-color` from `MenuItem.module.css` for the same reason

## Jira

https://workleap.atlassian.net/browse/SGPLTD-1854

## Test plan

- [ ] Open Alert in Storybook — modal glass effect is visible through the overlay
- [ ] Open a Menu — menu items no longer have a forced solid background
- [ ] Verify both light and dark themes still render correctly in Chromatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)