### PR TITLE
Use box-shadow for Modal back-drop instead of regular background

### DIFF
--- a/.changeset/sparkly-nights-give.md
+++ b/.changeset/sparkly-nights-give.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/components": minor
+"@hopper-ui/tokens": minor
+"@hopper-ui/styled-system": minor
+---
+
+Support Glassy modals considering its back-drop

--- a/.changeset/sparkly-nights-give.md
+++ b/.changeset/sparkly-nights-give.md
@@ -4,4 +4,4 @@
 "@hopper-ui/styled-system": minor
 ---
 
-Support Glassy modals considering its back-drop
+Support Glassy modals with a backdrop

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -47,7 +47,8 @@ const config = {
                     {
                         ignoreKeywords: ["/^hop-.*$/"]
                     }
-                ]
+                ],
+                "unit-allowed-list": ["vmax"]
             }
         }
     ]

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -48,7 +48,7 @@ const config = {
                         ignoreKeywords: ["/^hop-.*$/"]
                     }
                 ],
-                "unit-allowed-list": ["vmax"]
+                "unit-allowed-list": ["em", "rem", "%", "fr", "deg", "vh", "vw", "dvh", "dvw", "s", "ch", "vmax"]
             }
         }
     ]

--- a/packages/components/src/modal/src/BaseModal.module.css
+++ b/packages/components/src/modal/src/BaseModal.module.css
@@ -40,9 +40,7 @@
     -webkit-font-smoothing: var(--hop-BaseModal-font-smoothing);
     line-height: var(--hop-BaseModal-line-height);
     color: var(--hop-BaseModal-color);
-
-    /* hop-rock-800 with a 60% transparency */
-    background-color: var(--hop-BaseModal-background-color);
+    background-color: transparent;
 }
 
 .hop-BaseModal__modal {
@@ -67,5 +65,7 @@
     background: var(--hop-comp-modal-background);
     border: var(--border);
     border-radius: var(--border-radius);
-    box-shadow: var(--hop-comp-modal-box-shadow);
+
+    /* hop-rock-800 with a 60% transparency for backdrop */
+    box-shadow: 0 0 0 100vmax var(--hop-BaseModal-background-color), var(--hop-comp-modal-box-shadow, 0 0 0 0 transparent);
 }

--- a/packages/components/src/modal/tests/chromatic/Modal.stories.tsx
+++ b/packages/components/src/modal/tests/chromatic/Modal.stories.tsx
@@ -270,3 +270,44 @@ export const FullscreenTakeover = {
         size: "fullscreenTakeover"
     }
 };
+
+export const GlassyBackground = {
+    render: args => (
+        <>
+
+            <Flex direction="column" gap="stack-lg" padding="inset-xl">
+                <Heading>Background Content</Heading>
+                <Text>This content sits behind the modal overlay to test the glass effect.</Text>
+                <Flex gap="stack-md">
+                    <Card flex={1}>
+                        <Image objectFit="cover" alt="Frog" src={Frog} />
+                        <Flex direction="column" gap="stack-sm" padding="inset-md">
+                            <Heading>Frog</Heading>
+                            <Content>Common frog found in ponds and marshes.</Content>
+                        </Flex>
+                    </Card>
+                    <Card flex={1}>
+                        <Image objectFit="cover" alt="Mossy Frog" src={MossyFrog} />
+                        <Flex direction="column" gap="stack-sm" padding="inset-md">
+                            <Heading>Mossy Frog</Heading>
+                            <Content>Camouflaged tree frog with bark-like skin.</Content>
+                        </Flex>
+                    </Card>
+                </Flex>
+            </Flex>
+            <Modal {...args}>
+                <Heading>Glassy Modal</Heading>
+                <Header>Glass effect test</Header>
+                <Content>
+                    <Text>
+                        This modal is rendered over a colorful gradient background to verify the glass/blur overlay effect looks correct.
+                    </Text>
+                </Content>
+                <ButtonGroup>
+                    <Button variant="secondary">Cancel</Button>
+                    <Button variant="primary">Save</Button>
+                </ButtonGroup>
+            </Modal>
+        </>
+    )
+} satisfies Story;

--- a/packages/tokens/src/style-dictionary/build.ts
+++ b/packages/tokens/src/style-dictionary/build.ts
@@ -5,6 +5,7 @@ import "style-dictionary-utils"; // auto-registers gradient/css transform
 
 import { fontsConfig, getStyleDictionaryConfig, getStyledSystemTokenMappingConfig, getStyledSystemTokensConfig } from "./config.ts";
 import { AUTO_GENERATED_COMMENT, HOPPER_PREFIX, STYLED_SYSTEM_BUILD_PATH, STYLED_SYSTEM_THEME_BUILD_PATH, StyledSystemRootCssClass } from "./constant.ts";
+import { hasNonEmptyValue } from "./filter/hasNonEmptyValue.ts";
 import { isColorType } from "./filter/isColorType.ts";
 import { isDarkTokens } from "./filter/isDarkTokens.ts";
 import { customTsTokenMapping } from "./format/customTsTokenMapping.ts";
@@ -24,6 +25,11 @@ StyleDictionary.registerFilter({
 StyleDictionary.registerFilter({
     name: "colors",
     matcher: isColorType
+});
+
+StyleDictionary.registerFilter({
+    name: "non-empty-value",
+    matcher: hasNonEmptyValue
 });
 
 // Transform

--- a/packages/tokens/src/style-dictionary/config.ts
+++ b/packages/tokens/src/style-dictionary/config.ts
@@ -47,6 +47,7 @@ export function getStyledSystemTokensConfig(mode: "light" | "dark", theme: strin
                     {
                         "destination": `${theme}/${mode}.css`,
                         "format": "css/variables",
+                        "filter": "non-empty-value",
                         "options": {
                             "outputReferences": true,
                             "selector": isLightMode ? `.${StyledSystemRootCssClass}-${theme}` : `.${StyledSystemRootCssClass}-${theme}-${mode}`
@@ -94,6 +95,7 @@ export function getStyleDictionaryConfig(mode: "light" | "dark", theme: string):
     const lightConfig: File = {
         "destination": `${theme}/tokens.css`,
         "format": "css/variables",
+        "filter": "non-empty-value",
         "options": {
             "outputReferences": true
         }
@@ -102,6 +104,7 @@ export function getStyleDictionaryConfig(mode: "light" | "dark", theme: string):
     const darkConfig: File = {
         "destination": `${theme}/dark/tokens.css`,
         "format": "css/dark-mode",
+        "filter": "non-empty-value",
         "options": {
             "outputReferences": true
         }

--- a/packages/tokens/src/style-dictionary/filter/hasNonEmptyValue.ts
+++ b/packages/tokens/src/style-dictionary/filter/hasNonEmptyValue.ts
@@ -1,0 +1,3 @@
+import type { TransformedToken } from "style-dictionary";
+
+export const hasNonEmptyValue = (token: TransformedToken): boolean => token.value !== "" && token.value != null;

--- a/packages/tokens/src/tokens/components/sharegate/modal.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/modal.tokens.json
@@ -14,7 +14,7 @@
         },
         "backdrop-filter": {
             "$type": "backdropFilter",
-            "$value": "blur(5px)"
+            "$value": "blur(15px)"
         },
         "box-shadow": {
             "$type": "shadow",

--- a/packages/tokens/src/tokens/components/sharegate/popover.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/popover.tokens.json
@@ -14,7 +14,7 @@
         },
         "backdrop-filter": {
             "$type": "backdropFilter",
-            "$value": "blur(5px)"
+            "$value": "blur(15px)"
         },
         "box-shadow": {
             "$type": "shadow",

--- a/packages/tokens/src/tokens/components/sharegate/tooltip.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/tooltip.tokens.json
@@ -2,7 +2,7 @@
     "comp-tooltip": {
         "backdrop-filter": {
             "$type": "backdropFilter",
-            "$value": "blur(5px)"
+            "$value": "blur(15px)"
         },
         "background": {
             "$type": "color",

--- a/packages/tokens/src/tokens/components/workleap/modal.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/modal.tokens.json
@@ -18,7 +18,7 @@
         },
         "box-shadow": {
             "$type": "shadow",
-            "$value": "{elevation.none}"
+            "$value": ""
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `hasNonEmptyValue` filter to the Style Dictionary build that excludes tokens with empty string values
- Applies the filter to all CSS output files (light, dark, and styled-system variants) so declarations like `--hop-comp-modal-box-shadow: ;` are no longer emitted
- Fixes CSS fallback behavior that was broken by these empty variable declarations

## Jira

[SGPLTD-1859](https://workleap.atlassian.net/browse/SGPLTD-1859)

## Test plan

- [ ] Run `pnpm build` in `packages/tokens` and verify no `--hop-*: ;` declarations appear in the output CSS files
- [ ] Confirm tokens with non-empty values are still emitted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SGPLTD-1859]: https://workleap.atlassian.net/browse/SGPLTD-1859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ