### PR TITLE
fix(tokens): update sharegate dark primary-icon-hover from iris/300 to iris/200

### DIFF
--- a/.changeset/polite-mangos-show.md
+++ b/.changeset/polite-mangos-show.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/components": patch
+"@hopper-ui/styled-system": patch
+---
+
+Update icon-hover token in dark mode for ShareGate

--- a/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
@@ -816,7 +816,7 @@
         },
         "icon-hover": {
             "$type": "color",
-            "$value": "{iris.300}"
+            "$value": "{iris.200}"
         },
         "icon-press": {
             "$type": "color",


### PR DESCRIPTION
## Summary
- Updates `primary.icon-hover` semantic token in Sharegate dark mode from `{iris.300}` to `{iris.200}`

## Test plan
- [ ] Verify `hop-primary-icon-hover` renders with `iris/200` in Sharegate dark mode
- [ ] Confirm no visual regressions in light mode or Workleap theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)