### PR TITLE
fix(tokens): fix dark mode semantic colors and glassy overlay tokens [SGPLTD-1189]

### DIFF
--- a/.changeset/ninety-icons-cough.md
+++ b/.changeset/ninety-icons-cough.md
@@ -1,0 +1,9 @@
+---
+"@hopper-ui/components": patch
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+---
+
+- Update dark tokens for Information, Warning, Success for all themes.
+- Update dark tokens for Upsell (only for Workleap theme).
+- Update glassy modal related tokens.

--- a/packages/components/src/modal/src/BaseModal.module.css
+++ b/packages/components/src/modal/src/BaseModal.module.css
@@ -10,7 +10,7 @@
     --hop-BaseModal-justify-content: center;
     --hop-BaseModal-inline-size: 100%;
     --hop-BaseModal-block-size: 100%;
-    --hop-BaseModal-background-color: #3c3c3c99;
+    --hop-BaseModal-backdrop-color: #3c3c3c99;
     --hop-BaseModal-z-index: 10000;
     --hop-BaseModal-font-family: var(--hop-body-md-font-family);
     --hop-BaseModal-font-size: var(--hop-body-md-font-size);
@@ -67,5 +67,5 @@
     border-radius: var(--border-radius);
 
     /* hop-rock-800 with a 60% transparency for backdrop */
-    box-shadow: 0 0 0 100vmax var(--hop-BaseModal-background-color), var(--hop-comp-modal-box-shadow, 0 0 0 0 transparent);
+    box-shadow: 0 0 0 100vmax var(--hop-BaseModal-backdrop-color), var(--hop-comp-modal-box-shadow, 0 0 0 0 transparent);
 }

--- a/packages/components/src/modal/tests/chromatic/Modal.stories.tsx
+++ b/packages/components/src/modal/tests/chromatic/Modal.stories.tsx
@@ -12,6 +12,7 @@ import {
     Modal,
     Text
 } from "@hopper-ui/components";
+import { CheckmarkIcon, InfoIcon, MailIcon, StarIcon } from "@hopper-ui/icons";
 import { allColorModesAndThemes } from "@hopper-ui/storybook-addon";
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
 
@@ -271,7 +272,52 @@ export const FullscreenTakeover = {
     }
 };
 
-export const GlassyBackground = {
+export const GlassyBackground_WithText = {
+    render: args => (
+        <>
+            <Flex direction="column" gap="stack-lg" padding="inset-xl">
+                <Heading>Background Content</Heading>
+                <Text>This content sits behind the modal overlay to test the glass effect.</Text>
+                <Flex gap="stack-md">
+                    <Flex direction="column" gap="stack-sm" flex={1}>
+                        <InfoIcon size="lg" />
+                        <Heading>Information</Heading>
+                        <Text>Important details about your account and recent activity are displayed here. Stay informed about changes, updates, and announcements relevant to your workspace. Regularly reviewing this section ensures you never miss critical information that may affect your workflow or team collaboration.</Text>
+                    </Flex>
+                    <Flex direction="column" gap="stack-sm" flex={1}>
+                        <CheckmarkIcon size="lg" />
+                        <Heading>Completed</Heading>
+                        <Text>All tasks have been reviewed and marked as done. Each completed item represents a step forward in your project's progress. Keeping track of finished work helps the team celebrate milestones, measure velocity, and plan upcoming sprints with greater confidence and accuracy.</Text>
+                    </Flex>
+                    <Flex direction="column" gap="stack-sm" flex={1}>
+                        <StarIcon size="lg" />
+                        <Heading>Favorites</Heading>
+                        <Text>Your starred items and bookmarked content appear here for quick access. Organize the resources, documents, and tools you use most often so you can get back to them without searching. A well-maintained favorites list dramatically reduces the time spent navigating large workspaces.</Text>
+                    </Flex>
+                    <Flex direction="column" gap="stack-sm" flex={1}>
+                        <MailIcon size="lg" />
+                        <Heading>Messages</Heading>
+                        <Text>Unread notifications and incoming messages from your team are collected in this section. Timely responses keep projects on track and foster a culture of open communication. Make sure to check this regularly to stay aligned with your colleagues and address any pending requests promptly.</Text>
+                    </Flex>
+                </Flex>
+            </Flex>
+            <Modal {...args}>
+                <Heading>Glassy Modal</Heading>
+                <Content>
+                    <Text>
+                        This modal is rendered over a text and icon background to verify the glass/blur overlay effect looks correct.
+                    </Text>
+                </Content>
+                <ButtonGroup>
+                    <Button variant="secondary">Cancel</Button>
+                    <Button variant="primary">Save</Button>
+                </ButtonGroup>
+            </Modal>
+        </>
+    )
+} satisfies Story;
+
+export const GlassyBackground_WithImage = {
     render: args => (
         <>
 
@@ -297,7 +343,6 @@ export const GlassyBackground = {
             </Flex>
             <Modal {...args}>
                 <Heading>Glassy Modal</Heading>
-                <Header>Glass effect test</Header>
                 <Content>
                     <Text>
                         This modal is rendered over a colorful gradient background to verify the glass/blur overlay effect looks correct.

--- a/packages/tokens/src/tokens/components/sharegate/modal.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/modal.tokens.json
@@ -14,7 +14,7 @@
         },
         "backdrop-filter": {
             "$type": "backdropFilter",
-            "$value": "blur(15px)"
+            "$value": "blur(10px)"
         },
         "box-shadow": {
             "$type": "shadow",

--- a/packages/tokens/src/tokens/components/sharegate/popover.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/popover.tokens.json
@@ -14,7 +14,7 @@
         },
         "backdrop-filter": {
             "$type": "backdropFilter",
-            "$value": "blur(15px)"
+            "$value": "blur(10px)"
         },
         "box-shadow": {
             "$type": "shadow",

--- a/packages/tokens/src/tokens/components/sharegate/tooltip.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/tooltip.tokens.json
@@ -2,7 +2,7 @@
     "comp-tooltip": {
         "backdrop-filter": {
             "$type": "backdropFilter",
-            "$value": "blur(15px)"
+            "$value": "blur(10px)"
         },
         "background": {
             "$type": "color",

--- a/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
@@ -524,27 +524,27 @@
     "information": {
         "border": {
             "$type": "color",
-            "$value": "{coastal.400}"
+            "$value": "{coastal.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{coastal.900}"
+            "$value": "{coastal.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{coastal.200}"
+            "$value": "{coastal.700}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{coastal.300}"
+            "$value": "{coastal.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{coastal.75}"
+            "$value": "{coastal.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{coastal.300}"
+            "$value": "{coastal.600}"
         },
         "surface-weak": {
             "$type": "color",
@@ -552,11 +552,11 @@
         },
         "text": {
             "$type": "color",
-            "$value": "{coastal.900}"
+            "$value": "{coastal.50}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{coastal.75}"
+            "$value": "{coastal.400}"
         }
     },
     "neutral": {
@@ -682,7 +682,7 @@
         },
         "surface-transparent": {
             "$type": "color",
-            "$value": "rgb(35 36 38 / 0.75)"
+            "$value": "rgb(35 36 38 / 0.9)"
         },
         "surface-weakest": {
             "$type": "color",
@@ -2082,27 +2082,27 @@
     "success": {
         "border": {
             "$type": "color",
-            "$value": "{moss.500}"
+            "$value": "{moss.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{moss.900}"
+            "$value": "{moss.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{moss.200}"
+            "$value": "{moss.600}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{moss.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{moss.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{moss.300}"
+            "$value": "{moss.600}"
         },
         "surface-weak": {
             "$type": "color",
@@ -2110,15 +2110,15 @@
         },
         "text": {
             "$type": "color",
-            "$value": "{moss.900}"
+            "$value": "{moss.75}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{moss.400}"
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{moss.700}"
+            "$value": "{moss.50}"
         }
     },
     "upsell": {
@@ -2238,27 +2238,27 @@
     "warning": {
         "border": {
             "$type": "color",
-            "$value": "{koi.500}"
+            "$value": "{koi.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{koi.900}"
+            "$value": "{koi.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{koi.200}"
+            "$value": "{koi.600}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{koi.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{koi.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{koi.300}"
+            "$value": "{koi.600}"
         },
         "surface-weak": {
             "$type": "color",
@@ -2266,11 +2266,11 @@
         },
         "text": {
             "$type": "color",
-            "$value": "{koi.900}"
+            "$value": "{koi.75}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{koi.400}"
         }
     }
 }

--- a/packages/tokens/src/tokens/semantic/sharegate/light/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/light/colors.tokens.json
@@ -682,7 +682,7 @@
         },
         "surface-transparent": {
             "$type": "color",
-            "$value": "rgb(255 255 255 / 0.75)"
+            "$value": "rgb(255 255 255 / 0.9)"
         },
         "surface-weak": {
             "$type": "color",

--- a/packages/tokens/src/tokens/semantic/workleap/dark/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/workleap/dark/colors.tokens.json
@@ -524,27 +524,27 @@
     "information": {
         "border": {
             "$type": "color",
-            "$value": "{coastal.400}"
+            "$value": "{coastal.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{coastal.900}"
+            "$value": "{coastal.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{coastal.200}"
+            "$value": "{coastal.700}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{coastal.300}"
+            "$value": "{coastal.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{coastal.75}"
+            "$value": "{coastal.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{coastal.300}"
+            "$value": "{coastal.600}"
         },
         "surface-weak": {
             "$type": "color",
@@ -552,11 +552,11 @@
         },
         "text": {
             "$type": "color",
-            "$value": "{coastal.900}"
+            "$value": "{coastal.50}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{coastal.75}"
+            "$value": "{coastal.400}"
         }
     },
     "neutral": {
@@ -682,7 +682,7 @@
         },
         "surface-transparent": {
             "$type": "color",
-            "$value": "rgb(35 36 38 / 0.75)"
+            "$value": "rgb(35 36 38 / 0.9)"
         },
         "surface-weakest": {
             "$type": "color",
@@ -2082,27 +2082,27 @@
     "success": {
         "border": {
             "$type": "color",
-            "$value": "{moss.500}"
+            "$value": "{moss.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{moss.900}"
+            "$value": "{moss.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{moss.200}"
+            "$value": "{moss.600}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{moss.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{moss.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{moss.300}"
+            "$value": "{moss.600}"
         },
         "surface-weak": {
             "$type": "color",
@@ -2110,25 +2110,25 @@
         },
         "text": {
             "$type": "color",
-            "$value": "{moss.900}"
+            "$value": "{moss.75}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{moss.400}"
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{moss.700}"
+            "$value": "{moss.50}"
         }
     },
     "upsell": {
         "border": {
             "$type": "color",
-            "$value": "{sunken-treasure.200}"
+            "$value": "{sunken-treasure.600}"
         },
         "border-selected": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.300}"
         },
         "border-disabled": {
             "$type": "color",
@@ -2140,27 +2140,27 @@
         },
         "icon": {
             "$type": "color",
-            "$value": "{sunken-treasure.700}"
+            "$value": "{sunken-treasure.75}"
         },
         "icon-selected": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.300}"
         },
         "icon-hover": {
             "$type": "color",
-            "$value": "{sunken-treasure.800}"
+            "$value": "{sunken-treasure.50}"
         },
         "icon-press": {
             "$type": "color",
-            "$value": "{sunken-treasure.900}"
+            "$value": "{sunken-treasure.25}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.700}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.400}"
         },
         "icon-weak-hover": {
             "$type": "color",
@@ -2168,11 +2168,11 @@
         },
         "icon-weak-press": {
             "$type": "color",
-            "$value": "{sunken-treasure.300}"
+            "$value": "{sunken-treasure.100}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{sunken-treasure.75}"
+            "$value": "{sunken-treasure.900}"
         },
         "surface-selected": {
             "$type": "color",
@@ -2180,35 +2180,35 @@
         },
         "surface-disabled": {
             "$type": "color",
-            "$value": "{sunken-treasure.700}"
+            "$value": "{sunken-treasure.900}"
         },
         "surface-hover": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.800}"
         },
         "surface-press": {
             "$type": "color",
-            "$value": "{sunken-treasure.200}"
+            "$value": "{sunken-treasure.700}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{sunken-treasure.800}"
+            "$value": "{sunken-treasure.700}"
         },
         "surface-weak-hover": {
             "$type": "color",
-            "$value": "{sunken-treasure.700}"
+            "$value": "{sunken-treasure.600}"
         },
         "surface-weak-press": {
             "$type": "color",
-            "$value": "{sunken-treasure.600}"
+            "$value": "{sunken-treasure.500}"
         },
         "text": {
             "$type": "color",
-            "$value": "{sunken-treasure.700}"
+            "$value": "{sunken-treasure.75}"
         },
         "text-selected": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.300}"
         },
         "text-disabled": {
             "$type": "color",
@@ -2216,15 +2216,15 @@
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{sunken-treasure.800}"
+            "$value": "{sunken-treasure.50}"
         },
         "text-press": {
             "$type": "color",
-            "$value": "{sunken-treasure.900}"
+            "$value": "{sunken-treasure.25}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{sunken-treasure.100}"
+            "$value": "{sunken-treasure.400}"
         },
         "text-weak-hover": {
             "$type": "color",
@@ -2232,33 +2232,33 @@
         },
         "text-weak-press": {
             "$type": "color",
-            "$value": "{sunken-treasure.300}"
+            "$value": "{sunken-treasure.100}"
         }
     },
     "warning": {
         "border": {
             "$type": "color",
-            "$value": "{koi.500}"
+            "$value": "{koi.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{koi.900}"
+            "$value": "{koi.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{koi.200}"
+            "$value": "{koi.600}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{koi.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{koi.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{koi.300}"
+            "$value": "{koi.600}"
         },
         "surface-weak": {
             "$type": "color",
@@ -2266,11 +2266,11 @@
         },
         "text": {
             "$type": "color",
-            "$value": "{koi.900}"
+            "$value": "{koi.75}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{koi.400}"
         }
     }
 }

--- a/packages/tokens/src/tokens/semantic/workleap/light/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/workleap/light/colors.tokens.json
@@ -682,7 +682,7 @@
         },
         "surface-transparent": {
             "$type": "color",
-            "$value": "rgb(255 255 255 / 0.75)"
+            "$value": "rgb(255 255 255 / 0.9)"
         },
         "surface-weak": {
             "$type": "color",


### PR DESCRIPTION
## Summary

- Fix dark mode color token scale for `information`, `success`, `warning`, and `upsell` semantic categories — surface/icon/text values were inverted (light values in dark mode)
- Increase `neutral.surface-transparent` opacity from `0.75` to `0.9` for both Workleap and ShareGate themes (light & dark)
- Reduce `backdrop-filter` blur from `15px` to `10px` for ShareGate modal, popover, and tooltip tokens
- Rename `--hop-BaseModal-background-color` CSS variable to `--hop-BaseModal-backdrop-color` for semantic clarity
- Add `GlassyBackground_WithText` Chromatic story and rename `GlassyBackground` → `GlassyBackground_WithImage` for better visual coverage of the glass/blur overlay

Jira: [SGPLTD-1189](https://workleap.atlassian.net/browse/SGPLTD-1189)

## Test plan

- [ ] Verify dark mode information/success/warning/upsell components render with correct contrast
- [ ] Check glassy modal overlay in Chromatic (both `GlassyBackground_WithText` and `GlassyBackground_WithImage` stories)
- [ ] Confirm modal/popover/tooltip blur feels right at 10px in ShareGate theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SGPLTD-1189]: https://workleap.atlassian.net/browse/SGPLTD-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ