### PR TITLE
feat(tokens): add Callout & CompactCallout branding tokens [SGPLTD-1734]

### DIFF
--- a/.changeset/breezy-wasps-travel.md
+++ b/.changeset/breezy-wasps-travel.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/components": patch
+"@hopper-ui/icons": patch
+"@hopper-ui/styled-system": patch
+---
+
+Add Callout and CompactCallout component tokens

--- a/.changeset/breezy-wasps-travel.md
+++ b/.changeset/breezy-wasps-travel.md
@@ -1,7 +1,8 @@
 ---
-"@hopper-ui/components": patch
+"@hopper-ui/components": minor
 "@hopper-ui/tokens": patch
 "@hopper-ui/styled-system": patch
 ---
 
-Add Callout and CompactCallout component tokens
+- Add Callout and CompactCallout component tokens
+- Add border-box to Card component

--- a/.changeset/breezy-wasps-travel.md
+++ b/.changeset/breezy-wasps-travel.md
@@ -1,6 +1,6 @@
 ---
 "@hopper-ui/components": patch
-"@hopper-ui/icons": patch
+"@hopper-ui/tokens": patch
 "@hopper-ui/styled-system": patch
 ---
 

--- a/packages/components/src/callout/src/Callout.module.css
+++ b/packages/components/src/callout/src/Callout.module.css
@@ -27,29 +27,6 @@
     --hop-Callout-content-font-weight: var(--hop-body-sm-font-weight);
     --hop-Callout-content-line-height: var(--hop-body-sm-line-height);
 
-    /* Information */
-    --hop-Callout-border-information: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-information-border);
-    --hop-Callout-background-information: var(--hop-information-surface);
-    --hop-Callout-color-information: var(--hop-information-text);
-
-    /* Success */
-    --hop-Callout-border-success: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-success-border);
-    --hop-Callout-background-success: var(--hop-success-surface);
-    --hop-Callout-color-success: var(--hop-success-text);
-
-    /* Warning */
-    --hop-Callout-border-warning: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-warning-border);
-    --hop-Callout-background-warning: var(--hop-warning-surface);
-    --hop-Callout-color-warning: var(--hop-warning-text);
-
-    /* Upsell */
-    --hop-Callout-border-upsell: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-upsell-border);
-    --hop-Callout-background-upsell: var(--hop-upsell-surface);
-    --hop-Callout-color-upsell: var(--hop-upsell-text);
-
-    /* Subtle */
-    --hop-Callout-border-subtle: transparent;
-
     display: var(--hop-Callout-display);
     grid-template-areas: var(--hop-Callout-grid-template-areas);
     grid-template-columns: var(--hop-Callout-grid-template-columns);
@@ -65,6 +42,7 @@
 .hop-Callout__icon {
     grid-area: icon;
     margin-inline-end: var(--hop-Callout-margin-right-icon);
+
 }
 
 .hop-Callout__heading {
@@ -103,29 +81,29 @@
 }
 
 .hop-Callout--information {
-    --border: var(--hop-Callout-border-information);
-    --background: var(--hop-Callout-background-information);
-    --color: var(--hop-Callout-color-information);
+    --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-information-border-color);
+    --background: var(--hop-comp-callout-information-background-color);
+    --color: var(--hop-comp-callout-information-text-color);
 }
 
 .hop-Callout--success {
-    --border: var(--hop-Callout-border-success);
-    --background: var(--hop-Callout-background-success);
-    --color: var(--hop-Callout-color-success);
+    --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-success-border-color);
+    --background: var(--hop-comp-callout-success-background-color);
+    --color: var(--hop-comp-callout-success-text-color);
 }
 
 .hop-Callout--warning {
-    --border: var(--hop-Callout-border-warning);
-    --background: var(--hop-Callout-background-warning);
-    --color: var(--hop-Callout-color-warning);
+    --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-warning-border-color);
+    --background: var(--hop-comp-callout-warning-background-color);
+    --color: var(--hop-comp-callout-warning-text-color);
 }
 
 .hop-Callout--upsell {
-    --border: var(--hop-Callout-border-upsell);
-    --background: var(--hop-Callout-background-upsell);
-    --color: var(--hop-Callout-color-upsell);
+    --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-upsell-border-color);
+    --background: var(--hop-comp-callout-upsell-background-color);
+    --color: var(--hop-comp-callout-upsell-text-color);
 }
 
 .hop-Callout--subtle-fill {
-    --border: var(--hop-Callout-border-subtle);
+    --border: transparent;
 }

--- a/packages/components/src/callout/src/Callout.module.css
+++ b/packages/components/src/callout/src/Callout.module.css
@@ -40,9 +40,12 @@
 }
 
 .hop-Callout__icon {
+    --hop-RichIcon-placeholder-background: var(--icon-background-color);
+    --hop-RichIcon-placeholder-shadow: var(--icon-shadow-color);
+    --hop-RichIcon-placeholder-fill: var(--icon-fill-color);
+
     grid-area: icon;
     margin-inline-end: var(--hop-Callout-margin-right-icon);
-
 }
 
 .hop-Callout__heading {
@@ -84,24 +87,36 @@
     --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-information-border-color);
     --background: var(--hop-comp-callout-information-background-color);
     --color: var(--hop-comp-callout-information-text-color);
+    --icon-shadow-color: var(--hop-comp-callout-information-icon-shadow-color);
+    --icon-background-color: var(--hop-comp-callout-information-icon-background-color);
+    --icon-fill-color: var(--hop-comp-callout-information-icon-fill-color);
 }
 
 .hop-Callout--success {
     --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-success-border-color);
     --background: var(--hop-comp-callout-success-background-color);
     --color: var(--hop-comp-callout-success-text-color);
+    --icon-shadow-color: var(--hop-comp-callout-success-icon-shadow-color);
+    --icon-background-color: var(--hop-comp-callout-success-icon-background-color);
+    --icon-fill-color: var(--hop-comp-callout-success-icon-fill-color);
 }
 
 .hop-Callout--warning {
     --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-warning-border-color);
     --background: var(--hop-comp-callout-warning-background-color);
     --color: var(--hop-comp-callout-warning-text-color);
+    --icon-shadow-color: var(--hop-comp-callout-warning-icon-shadow-color);
+    --icon-background-color: var(--hop-comp-callout-warning-icon-background-color);
+    --icon-fill-color: var(--hop-comp-callout-warning-icon-fill-color);
 }
 
 .hop-Callout--upsell {
     --border: var(--hop-Callout-border-width) var(--hop-Callout-border-style) var(--hop-comp-callout-upsell-border-color);
     --background: var(--hop-comp-callout-upsell-background-color);
     --color: var(--hop-comp-callout-upsell-text-color);
+    --icon-shadow-color: var(--hop-comp-callout-upsell-icon-shadow-color);
+    --icon-background-color: var(--hop-comp-callout-upsell-icon-background-color);
+    --icon-fill-color: var(--hop-comp-callout-upsell-icon-fill-color);
 }
 
 .hop-Callout--subtle-fill {

--- a/packages/components/src/callout/src/CompactCallout.module.css
+++ b/packages/components/src/callout/src/CompactCallout.module.css
@@ -16,29 +16,6 @@
     --hop-CompactCallout-line-height: var(--hop-body-sm-line-height);
     --hop-CompactCallout-min-block-size: var(--hop-space-480);
 
-    /* Information */
-    --hop-CompactCallout-border-information: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-information-border);
-    --hop-CompactCallout-background-information: var(--hop-information-surface);
-    --hop-CompactCallout-color-information: var(--hop-information-text);
-
-    /* Success */
-    --hop-CompactCallout-border-success: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-success-border);
-    --hop-CompactCallout-background-success: var(--hop-success-surface);
-    --hop-CompactCallout-color-success: var(--hop-success-text);
-
-    /* Warning */
-    --hop-CompactCallout-border-warning: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-warning-border);
-    --hop-CompactCallout-background-warning: var(--hop-warning-surface);
-    --hop-CompactCallout-color-warning: var(--hop-warning-text);
-
-    /* Upsell */
-    --hop-CompactCallout-border-upsell: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-upsell-border);
-    --hop-CompactCallout-background-upsell: var(--hop-upsell-surface);
-    --hop-CompactCallout-color-upsell: var(--hop-upsell-text);
-
-    /* Subtle */
-    --hop-CompactCallout-border-subtle: transparent;
-
     /* Internal Variables */
     --grid-template: var(--hop-CompactCallout-grid-template);
 
@@ -83,29 +60,29 @@
 }
 
 .hop-CompactCallout--information {
-    --border: var(--hop-CompactCallout-border-information);
-    --background: var(--hop-CompactCallout-background-information);
-    --color: var(--hop-CompactCallout-color-information);
+    --border: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-comp-callout-information-border-color);
+    --background: var(--hop-comp-callout-information-background-color);
+    --color: var(--hop-comp-callout-information-text-color);
 }
 
 .hop-CompactCallout--success {
-    --border: var(--hop-CompactCallout-border-success);
-    --background: var(--hop-CompactCallout-background-success);
-    --color: var(--hop-CompactCallout-color-success);
+    --border: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-comp-callout-success-border-color);
+    --background: var(--hop-comp-callout-success-background-color);
+    --color: var(--hop-comp-callout-success-text-color);
 }
 
 .hop-CompactCallout--warning {
-    --border: var(--hop-CompactCallout-border-warning);
-    --background: var(--hop-CompactCallout-background-warning);
-    --color: var(--hop-CompactCallout-color-warning);
+    --border: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-comp-callout-warning-border-color);
+    --background: var(--hop-comp-callout-warning-background-color);
+    --color: var(--hop-comp-callout-warning-text-color);
 }
 
 .hop-CompactCallout--upsell {
-    --border: var(--hop-CompactCallout-border-upsell);
-    --background: var(--hop-CompactCallout-background-upsell);
-    --color: var(--hop-CompactCallout-color-upsell);
+    --border: var(--hop-CompactCallout-border-width) var(--hop-CompactCallout-border-style) var(--hop-comp-callout-upsell-border-color);
+    --background: var(--hop-comp-callout-upsell-background-color);
+    --color: var(--hop-comp-callout-upsell-text-color);
 }
 
 .hop-CompactCallout--subtle-fill {
-    --border: var(--hop-CompactCallout-border-subtle);
+    --border: transparent;
 }

--- a/packages/components/src/card/src/Card.module.css
+++ b/packages/components/src/card/src/Card.module.css
@@ -23,6 +23,7 @@
     background-color: var(--background-color);
     border: var(--border);
     border-radius: var(--border-radius);
+    box-sizing: border-box;
 
 }
 

--- a/packages/tokens/src/tokens/components/sharegate/callout.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/callout.tokens.json
@@ -13,13 +13,17 @@
                 "$type": "color",
                 "$value": "{information.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{information.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{information.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         },
         "success": {
@@ -35,13 +39,17 @@
                 "$type": "color",
                 "$value": "{success.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{success.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{success.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         },
         "warning": {
@@ -57,13 +65,17 @@
                 "$type": "color",
                 "$value": "{warning.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{warning.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{warning.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         },
         "upsell": {
@@ -79,13 +91,17 @@
                 "$type": "color",
                 "$value": "{upsell.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{upsell.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{upsell.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         }
     }

--- a/packages/tokens/src/tokens/components/sharegate/callout.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/callout.tokens.json
@@ -15,7 +15,7 @@
             },
             "icon-shadow-color": {
                 "$type": "color",
-                "$value": "{information.icon}"
+                "$value": "{neutral.icon-always-dark}"
             },
             "icon-background-color": {
                 "$type": "color",
@@ -41,7 +41,7 @@
             },
             "icon-shadow-color": {
                 "$type": "color",
-                "$value": "{success.icon}"
+                "$value": "{neutral.icon-always-dark}"
             },
             "icon-background-color": {
                 "$type": "color",
@@ -67,7 +67,7 @@
             },
             "icon-shadow-color": {
                 "$type": "color",
-                "$value": "{warning.icon}"
+                "$value": "{neutral.icon-always-dark}"
             },
             "icon-background-color": {
                 "$type": "color",
@@ -93,7 +93,7 @@
             },
             "icon-shadow-color": {
                 "$type": "color",
-                "$value": "{upsell.icon}"
+                "$value": "{neutral.icon-always-dark}"
             },
             "icon-background-color": {
                 "$type": "color",

--- a/packages/tokens/src/tokens/components/sharegate/callout.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/callout.tokens.json
@@ -1,0 +1,92 @@
+{
+    "comp-callout": {
+        "information": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{information.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{information.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{information.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{information.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{information.icon-weakest}"
+            }
+        },
+        "success": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{success.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{success.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{success.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{success.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{success.icon-weakest}"
+            }
+        },
+        "warning": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{warning.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{warning.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{warning.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{warning.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{warning.icon-weakest}"
+            }
+        },
+        "upsell": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{upsell.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{upsell.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{upsell.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{upsell.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{upsell.icon-weakest}"
+            }
+        }
+    }
+}

--- a/packages/tokens/src/tokens/components/workleap/callout.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/callout.tokens.json
@@ -13,13 +13,17 @@
                 "$type": "color",
                 "$value": "{information.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{information.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{information.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         },
         "success": {
@@ -35,13 +39,17 @@
                 "$type": "color",
                 "$value": "{success.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{success.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{success.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         },
         "warning": {
@@ -57,13 +65,17 @@
                 "$type": "color",
                 "$value": "{warning.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{warning.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{warning.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         },
         "upsell": {
@@ -79,13 +91,17 @@
                 "$type": "color",
                 "$value": "{upsell.text}"
             },
-            "icon-color": {
+            "icon-shadow-color": {
                 "$type": "color",
                 "$value": "{upsell.icon}"
             },
-            "icon-color-bg": {
+            "icon-background-color": {
                 "$type": "color",
                 "$value": "{upsell.icon-weakest}"
+            },
+            "icon-fill-color": {
+                "$type": "color",
+                "$value": "{samoyed}"
             }
         }
     }

--- a/packages/tokens/src/tokens/components/workleap/callout.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/callout.tokens.json
@@ -1,0 +1,92 @@
+{
+    "comp-callout": {
+        "information": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{information.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{information.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{information.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{information.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{information.icon-weakest}"
+            }
+        },
+        "success": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{success.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{success.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{success.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{success.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{success.icon-weakest}"
+            }
+        },
+        "warning": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{warning.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{warning.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{warning.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{warning.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{warning.icon-weakest}"
+            }
+        },
+        "upsell": {
+            "background-color": {
+                "$type": "color",
+                "$value": "{upsell.surface}"
+            },
+            "border-color": {
+                "$type": "color",
+                "$value": "{upsell.border}"
+            },
+            "text-color": {
+                "$type": "color",
+                "$value": "{upsell.text}"
+            },
+            "icon-color": {
+                "$type": "color",
+                "$value": "{upsell.icon}"
+            },
+            "icon-color-bg": {
+                "$type": "color",
+                "$value": "{upsell.icon-weakest}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `callout.tokens.json` for both `sharegate` and `workleap` brands with shared component tokens covering all 4 variants (`information`, `success`, `warning`, `upsell`)
- Each variant defines `background-color`, `border-color`, `text-color`, `icon-color`, and `icon-color-bg`
- Update `Callout.module.css` and `CompactCallout.module.css` to consume `--hop-comp-callout-*` tokens directly, removing all local color pass-through variables

## Jira

[SGPLTD-1734](https://workleap.atlassian.net/browse/SGPLTD-1734)

## Test plan

- [ ] Run token build (`pnpm build` in `packages/tokens`) and verify `--hop-comp-callout-*` CSS variables are generated
- [ ] Visually verify all 4 variants of `Callout` and `CompactCallout` render correctly in both light and dark mode
- [ ] Verify `subtleFill` style still shows a transparent border

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SGPLTD-1734]: https://workleap.atlassian.net/browse/SGPLTD-1734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ