### PR TITLE
feat(tokens): update Danger/Status semantic tokens and Sharegate Button Danger styling [SGPLTD-2049]

### DIFF
--- a/.changeset/fiery-rules-fix.md
+++ b/.changeset/fiery-rules-fix.md
@@ -1,0 +1,11 @@
+---
+"@hopper-ui/styled-system": patch
+"@hopper-ui/tokens": patch
+"@hopper-ui/components": patch
+---
+
+- Updated "rose" core color tokens
+- Added `danger-surface-weak-selected` semantic token (Workleap and ShareGate, light and dark)
+- Updated ShareGate Danger semantic tokens to use the Rose palette
+- Updated ShareGate Status semantic tokens (Neutral, Progress, Positive, Caution, Inactive, Option1–6)
+- Updated ShareGate Button Danger component tokens: background now uses a Rose gradient (`rose.300` → `rose.600`) and the same inset box-shadow as the Primary variant; hover/pressed/selected states converted to single-stop gradients for smooth transitions

--- a/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
+++ b/packages/styled-system/src/tokens/generated/styledSystemToTokenMappings.ts
@@ -237,6 +237,7 @@ export const BackgroundColors = {
     "danger-weak": "danger-surface-weak",
     "danger-weak-hover": "danger-surface-weak-hover",
     "danger-weak-press": "danger-surface-weak-press",
+    "danger-weak-selected": "danger-surface-weak-selected",
     "neutral-active": "neutral-surface-active",
     "neutral-weak-active": "neutral-surface-weak-active",
     "neutral": "neutral-surface",

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -346,7 +346,10 @@
         "danger": {
             "box-shadow": {
                 "$type": "shadow",
-                "$value": "none"
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
             },
             "text-color": {
                 "$type": "color",
@@ -381,12 +384,18 @@
                 "$value": "{danger.icon-selected}"
             },
             "background": {
-                "$type": "color",
-                "$value": "{danger.surface-strong}"
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{rose.300}", "position": 0 },
+                    { "color": "{rose.600}", "position": 1 }
+                ]
             },
             "background-loading": {
-                "$type": "color",
-                "$value": "{danger.surface-strong}"
+                "$type": "gradient",
+                "$value": [
+                    { "color": "{rose.300}", "position": 0 },
+                    { "color": "{rose.600}", "position": 1 }
+                ]
             },
             "color-loading": {
                 "$type": "color",
@@ -398,19 +407,34 @@
             },
             "box-shadow-loading": {
                 "$type": "shadow",
-                "$value": "none"
+                "$value": [
+                    { "offsetX": "0", "offsetY": "2px", "blur": "1px", "spread": "0", "color": "rgba(255, 255, 255, 0.25)", "inset": true },
+                    { "offsetX": "0", "offsetY": "-2px", "blur": "4px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true }
+                ]
             },
             "background-hover": {
-                "$type": "color",
-                "$value": "{danger.surface-strong-hover}"
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{danger.surface-strong-hover}", "position": 0 },
+                    { "color": "{danger.surface-strong-hover}", "position": 1 }
+                ]
             },
             "background-pressed": {
-                "$type": "color",
-                "$value": "{danger.surface-press}"
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{danger.surface-press}", "position": 0 },
+                    { "color": "{danger.surface-press}", "position": 1 }
+                ]
             },
             "background-selected": {
-                "$type": "color",
-                "$value": "{danger.surface-selected}"
+                "$type": "gradient",
+                "$description": "Single-stop gradient to allow smooth CSS transition from the multi-stop gradient default background.",
+                "$value": [
+                    { "color": "{danger.surface-selected}", "position": 0 },
+                    { "color": "{danger.surface-selected}", "position": 1 }
+                ]
             },
             "background-disabled": {
                 "$type": "color",

--- a/packages/tokens/src/tokens/core/colors.tokens.json
+++ b/packages/tokens/src/tokens/core/colors.tokens.json
@@ -714,51 +714,51 @@
     "rose": {
         "25": {
             "$type": "color",
-            "$value": "#fdecef"
+            "$value": "#feeaec"
         },
         "50": {
             "$type": "color",
-            "$value": "#fbd6df"
+            "$value": "#fdd3d8"
         },
         "75": {
             "$type": "color",
-            "$value": "#f9c1cf"
+            "$value": "#fcbcc5"
         },
         "100": {
             "$type": "color",
-            "$value": "#f7a3ba"
+            "$value": "#fa9ba9"
         },
         "200": {
             "$type": "color",
-            "$value": "#f47c9e"
+            "$value": "#f76d83"
         },
         "300": {
             "$type": "color",
-            "$value": "#fc5992"
+            "$value": "#f5425d"
         },
         "400": {
             "$type": "color",
-            "$value": "#995068"
+            "$value": "#de2840"
         },
         "500": {
             "$type": "color",
-            "$value": "#80435a"
+            "$value": "#ba1f34"
         },
         "600": {
             "$type": "color",
-            "$value": "#6a394c"
+            "$value": "#951b2a"
         },
         "700": {
             "$type": "color",
-            "$value": "#542f3e"
+            "$value": "#711822"
         },
         "800": {
             "$type": "color",
-            "$value": "#3d2630"
+            "$value": "#50161c"
         },
         "900": {
             "$type": "color",
-            "$value": "#2b1e23"
+            "$value": "#341417"
         }
     },
     "amber": {

--- a/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/dark/colors.tokens.json
@@ -2,39 +2,39 @@
     "danger": {
         "border": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.600}"
         },
         "border-selected": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.300}"
         },
         "border-press": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "border-strong": {
             "$type": "color",
-            "$value": "{amanita.300}"
+            "$value": "{rose.400}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{amanita.900}"
+            "$value": "{rose.75}"
         },
         "icon-selected": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.300}"
         },
         "icon-disabled": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.500}"
         },
         "icon-hover": {
             "$type": "color",
-            "$value": "{amanita.200}"
+            "$value": "{rose.200}"
         },
         "icon-press": {
             "$type": "color",
-            "$value": "{amanita.50}"
+            "$value": "{rose.50}"
         },
         "icon-strong": {
             "$type": "color",
@@ -46,79 +46,83 @@
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.300}"
         },
         "icon-weak-hover": {
             "$type": "color",
-            "$value": "{amanita.200}"
+            "$value": "{rose.200}"
         },
         "icon-weak-press": {
             "$type": "color",
-            "$value": "{amanita.300}"
+            "$value": "{rose.100}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.700}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{amanita.200}"
+            "$value": "{rose.900}"
         },
         "surface-selected": {
             "$type": "color",
-            "$value": "{amanita.800}"
+            "$value": "{rose.800}"
         },
         "surface-disabled": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.600}"
         },
         "surface-hover": {
             "$type": "color",
-            "$value": "{amanita.300}"
+            "$value": "{rose.200}"
         },
         "surface-press": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.100}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.300}"
         },
         "surface-strong-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.200}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{amanita.900}"
+            "$value": "{rose.800}"
         },
         "surface-weak-hover": {
             "$type": "color",
-            "$value": "{amanita.700}"
+            "$value": "{rose.700}"
         },
         "surface-weak-press": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.600}"
+        },
+        "surface-weak-selected": {
+            "$type": "color",
+            "$value": "{rose.600}"
         },
         "text": {
             "$type": "color",
-            "$value": "{amanita.900}"
+            "$value": "{rose.75}"
         },
         "text-selected": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.300}"
         },
         "text-disabled": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.600}"
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{amanita.200}"
+            "$value": "{rose.200}"
         },
         "text-press": {
             "$type": "color",
-            "$value": "{amanita.50}"
+            "$value": "{rose.50}"
         },
         "text-strong": {
             "$type": "color",
@@ -130,15 +134,15 @@
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.300}"
         },
         "text-weak-hover": {
             "$type": "color",
-            "$value": "{amanita.200}"
+            "$value": "{rose.200}"
         },
         "text-weak-press": {
             "$type": "color",
-            "$value": "{amanita.300}"
+            "$value": "{rose.100}"
         }
     },
     "decorative": {
@@ -1049,87 +1053,87 @@
         "caution": {
             "border": {
                 "$type": "color",
-                "$value": "{koi.400}"
+                "$value": "{amber.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{koi.600}"
+                "$value": "{amber.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{koi.500}"
+                "$value": "{amber.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{koi.400}"
+                "$value": "{amber.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{koi.75}"
+                "$value": "{amber.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{koi.500}"
+                "$value": "{amber.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{koi.900}"
+                "$value": "{amber.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{koi.75}"
+                "$value": "{amber.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{koi.100}"
+                "$value": "{amber.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{koi.200}"
+                "$value": "{amber.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{koi.300}"
+                "$value": "{amber.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{koi.200}"
+                "$value": "{amber.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{koi.500}"
+                "$value": "{amber.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{koi.900}"
+                "$value": "{amber.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{koi.75}"
+                "$value": "{amber.75}"
             }
         },
         "inactive": {
@@ -1139,15 +1143,15 @@
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{rock.600}"
+                "$value": "{rock.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{rock.500}"
+                "$value": "{rock.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{rock.400}"
+                "$value": "{rock.200}"
             },
             "border-selected": {
                 "$type": "color",
@@ -1155,7 +1159,7 @@
             },
             "icon": {
                 "$type": "color",
-                "$value": "{rock.800}"
+                "$value": "{rock.100}"
             },
             "icon-disabled": {
                 "$type": "color",
@@ -1163,11 +1167,11 @@
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{rock.900}"
+                "$value": "{rock.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{rock.800}"
+                "$value": "{rock.50}"
             },
             "icon-selected": {
                 "$type": "color",
@@ -1175,19 +1179,19 @@
             },
             "surface": {
                 "$type": "color",
-                "$value": "{rock.75}"
+                "$value": "{rock.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{rock.800}"
+                "$value": "{rock.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{rock.200}"
+                "$value": "{rock.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{rock.300}"
+                "$value": "{rock.600}"
             },
             "surface-selected": {
                 "$type": "color",
@@ -1195,11 +1199,11 @@
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{rock.100}"
+                "$value": "{rock.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{rock.800}"
+                "$value": "{rock.100}"
             },
             "text-disabled": {
                 "$type": "color",
@@ -1207,11 +1211,11 @@
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{rock.900}"
+                "$value": "{rock.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{rock.800}"
+                "$value": "{rock.50}"
             },
             "text-selected": {
                 "$type": "color",
@@ -1319,7 +1323,7 @@
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{rock.25}"
+                "$value": "{rock.20}"
             },
             "border-selected": {
                 "$type": "color",
@@ -1339,11 +1343,11 @@
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{rock.25}"
+                "$value": "{rock.20}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{rock.25}"
+                "$value": "{rock.900}"
             },
             "surface": {
                 "$type": "color",
@@ -1363,11 +1367,11 @@
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{toad.25}"
+                "$value": "{rock.25}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{rock.100}"
+                "$value": "{rock.500}"
             },
             "text": {
                 "$type": "color",
@@ -1375,7 +1379,7 @@
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{rock.500}"
+                "$value": "{rock.300}"
             },
             "text-hover": {
                 "$type": "color",
@@ -1383,7 +1387,7 @@
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{rock.25}"
+                "$value": "{rock.20}"
             },
             "text-selected": {
                 "$type": "color",
@@ -1393,259 +1397,259 @@
         "option1": {
             "border": {
                 "$type": "color",
-                "$value": "{coastal.400}"
+                "$value": "{iris.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{coastal.600}"
+                "$value": "{iris.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{coastal.500}"
+                "$value": "{iris.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{coastal.400}"
+                "$value": "{iris.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{coastal.75}"
+                "$value": "{iris.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{coastal.500}"
+                "$value": "{iris.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{coastal.900}"
+                "$value": "{iris.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{coastal.75}"
+                "$value": "{iris.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{coastal.100}"
+                "$value": "{iris.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{coastal.200}"
+                "$value": "{iris.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{coastal.300}"
+                "$value": "{iris.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{coastal.100}"
+                "$value": "{iris.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{coastal.500}"
+                "$value": "{iris.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{coastal.900}"
+                "$value": "{iris.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{coastal.75}"
+                "$value": "{iris.75}"
             }
         },
         "option2": {
             "border": {
                 "$type": "color",
-                "$value": "{orchid-bloom.300}"
+                "$value": "{persimmon.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.600}"
+                "$value": "{persimmon.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.500}"
+                "$value": "{persimmon.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.300}"
+                "$value": "{persimmon.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.500}"
+                "$value": "{persimmon.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.900}"
+                "$value": "{persimmon.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.75}"
+                "$value": "{persimmon.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{orchid-bloom.100}"
+                "$value": "{persimmon.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.200}"
+                "$value": "{persimmon.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.300}"
+                "$value": "{persimmon.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{orchid-bloom.100}"
+                "$value": "{persimmon.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.500}"
+                "$value": "{persimmon.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.900}"
+                "$value": "{persimmon.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.75}"
+                "$value": "{persimmon.75}"
             }
         },
         "option3": {
             "border": {
                 "$type": "color",
-                "$value": "{quetzal.400}"
+                "$value": "{moss.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.600}"
+                "$value": "{moss.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{quetzal.500}"
+                "$value": "{moss.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{quetzal.400}"
+                "$value": "{moss.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{quetzal.75}"
+                "$value": "{moss.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.500}"
+                "$value": "{moss.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{quetzal.900}"
+                "$value": "{moss.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{quetzal.75}"
+                "$value": "{moss.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{quetzal.100}"
+                "$value": "{moss.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{quetzal.200}"
+                "$value": "{moss.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{quetzal.300}"
+                "$value": "{moss.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{quetzal.100}"
+                "$value": "{moss.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.200}"
+                "$value": "{moss.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{quetzal.900}"
+                "$value": "{moss.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{quetzal.75}"
+                "$value": "{moss.75}"
             }
         },
         "option4": {
@@ -1655,15 +1659,15 @@
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{fog.600}"
+                "$value": "{fog.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{fog.500}"
+                "$value": "{fog.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{fog.400}"
+                "$value": "{fog.200}"
             },
             "border-selected": {
                 "$type": "color",
@@ -1671,7 +1675,7 @@
             },
             "icon": {
                 "$type": "color",
-                "$value": "{fog.800}"
+                "$value": "{fog.100}"
             },
             "icon-disabled": {
                 "$type": "color",
@@ -1679,11 +1683,11 @@
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{fog.900}"
+                "$value": "{fog.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{fog.800}"
+                "$value": "{fog.50}"
             },
             "icon-selected": {
                 "$type": "color",
@@ -1691,19 +1695,19 @@
             },
             "surface": {
                 "$type": "color",
-                "$value": "{fog.100}"
+                "$value": "{fog.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{fog.600}"
+                "$value": "{fog.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{fog.200}"
+                "$value": "{fog.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{fog.300}"
+                "$value": "{fog.600}"
             },
             "surface-selected": {
                 "$type": "color",
@@ -1711,11 +1715,11 @@
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{fog.100}"
+                "$value": "{fog.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{fog.800}"
+                "$value": "{fog.100}"
             },
             "text-disabled": {
                 "$type": "color",
@@ -1723,11 +1727,11 @@
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{fog.900}"
+                "$value": "{fog.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{fog.900}"
+                "$value": "{fog.50}"
             },
             "text-selected": {
                 "$type": "color",
@@ -1741,15 +1745,15 @@
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{toad.600}"
+                "$value": "{toad.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{toad.500}"
+                "$value": "{toad.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{toad.400}"
+                "$value": "{toad.200}"
             },
             "border-selected": {
                 "$type": "color",
@@ -1757,7 +1761,7 @@
             },
             "icon": {
                 "$type": "color",
-                "$value": "{toad.800}"
+                "$value": "{toad.100}"
             },
             "icon-disabled": {
                 "$type": "color",
@@ -1765,11 +1769,11 @@
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{toad.900}"
+                "$value": "{toad.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{toad.800}"
+                "$value": "{toad.50}"
             },
             "icon-selected": {
                 "$type": "color",
@@ -1777,19 +1781,19 @@
             },
             "surface": {
                 "$type": "color",
-                "$value": "{toad.100}"
+                "$value": "{toad.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{toad.800}"
+                "$value": "{toad.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{toad.200}"
+                "$value": "{toad.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{toad.300}"
+                "$value": "{toad.600}"
             },
             "surface-selected": {
                 "$type": "color",
@@ -1797,11 +1801,11 @@
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{toad.100}"
+                "$value": "{toad.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{toad.800}"
+                "$value": "{toad.100}"
             },
             "text-disabled": {
                 "$type": "color",
@@ -1809,11 +1813,11 @@
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{toad.900}"
+                "$value": "{toad.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{toad.800}"
+                "$value": "{toad.50}"
             },
             "text-selected": {
                 "$type": "color",
@@ -1823,302 +1827,302 @@
         "option6": {
             "border": {
                 "$type": "color",
-                "$value": "{sunken-treasure.400}"
+                "$value": "{limeburst.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.600}"
+                "$value": "{limeburst.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.500}"
+                "$value": "{limeburst.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.400}"
+                "$value": "{limeburst.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.75}"
+                "$value": "{limeburst.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.500}"
+                "$value": "{limeburst.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.900}"
+                "$value": "{limeburst.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.75}"
+                "$value": "{limeburst.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{sunken-treasure.100}"
+                "$value": "{limeburst.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.200}"
+                "$value": "{limeburst.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.300}"
+                "$value": "{limeburst.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{sunken-treasure.100}"
+                "$value": "{limeburst.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.500}"
+                "$value": "{limeburst.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.900}"
+                "$value": "{limeburst.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.75}"
+                "$value": "{limeburst.75}"
             }
         },
         "positive": {
             "border": {
                 "$type": "color",
-                "$value": "{moss.400}"
+                "$value": "{mint.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{moss.500}"
+                "$value": "{mint.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{moss.400}"
+                "$value": "{mint.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{moss.75}"
+                "$value": "{mint.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{moss.500}"
+                "$value": "{mint.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{moss.900}"
+                "$value": "{mint.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{moss.75}"
+                "$value": "{mint.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{moss.100}"
+                "$value": "{mint.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{moss.200}"
+                "$value": "{mint.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{moss.300}"
+                "$value": "{mint.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{moss.200}"
+                "$value": "{mint.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{moss.500}"
+                "$value": "{mint.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{moss.900}"
+                "$value": "{mint.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{moss.75}"
+                "$value": "{mint.75}"
             }
         },
         "progress": {
             "border": {
                 "$type": "color",
-                "$value": "{sapphire.400}"
+                "$value": "{cobalt.400}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.600}"
+                "$value": "{cobalt.800}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{sapphire.500}"
+                "$value": "{cobalt.300}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{sapphire.400}"
+                "$value": "{cobalt.200}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{sapphire.75}"
+                "$value": "{cobalt.75}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.100}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.500}"
+                "$value": "{cobalt.500}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{sapphire.900}"
+                "$value": "{cobalt.75}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.50}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{sapphire.75}"
+                "$value": "{cobalt.75}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{sapphire.100}"
+                "$value": "{cobalt.800}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.900}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{sapphire.200}"
+                "$value": "{cobalt.700}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{sapphire.300}"
+                "$value": "{cobalt.600}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.800}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{sapphire.200}"
+                "$value": "{cobalt.500}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.100}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.500}"
+                "$value": "{cobalt.500}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{sapphire.900}"
+                "$value": "{cobalt.75}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.50}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{sapphire.75}"
+                "$value": "{cobalt.75}"
             }
         }
     },
     "success": {
         "border": {
             "$type": "color",
-            "$value": "{moss.600}"
+            "$value": "{mint.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{mint.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{moss.600}"
+            "$value": "{mint.600}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{moss.400}"
+            "$value": "{mint.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{moss.900}"
+            "$value": "{mint.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{moss.600}"
+            "$value": "{mint.600}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{moss.800}"
+            "$value": "{mint.800}"
         },
         "text": {
             "$type": "color",
-            "$value": "{moss.75}"
+            "$value": "{mint.75}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{moss.400}"
+            "$value": "{mint.400}"
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{moss.50}"
+            "$value": "{mint.50}"
         }
     },
     "upsell": {
@@ -2238,39 +2242,39 @@
     "warning": {
         "border": {
             "$type": "color",
-            "$value": "{koi.600}"
+            "$value": "{amber.600}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{amber.75}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{koi.600}"
+            "$value": "{amber.600}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{koi.400}"
+            "$value": "{amber.400}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{koi.900}"
+            "$value": "{amber.900}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{koi.600}"
+            "$value": "{amber.600}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{koi.800}"
+            "$value": "{amber.800}"
         },
         "text": {
             "$type": "color",
-            "$value": "{koi.75}"
+            "$value": "{amber.75}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{koi.400}"
+            "$value": "{amber.400}"
         }
     }
 }

--- a/packages/tokens/src/tokens/semantic/sharegate/light/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/sharegate/light/colors.tokens.json
@@ -2,39 +2,39 @@
     "danger": {
         "border": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.100}"
         },
         "border-selected": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "border-strong": {
             "$type": "color",
-            "$value": "{amanita.300}"
+            "$value": "{rose.300}"
         },
         "border-press": {
             "$type": "color",
-            "$value": "{amanita.300}"
+            "$value": "{rose.300}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{amanita.700}"
+            "$value": "{rose.700}"
         },
         "icon-selected": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "icon-disabled": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.100}"
         },
         "icon-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.500}"
         },
         "icon-press": {
             "$type": "color",
-            "$value": "{amanita.800}"
+            "$value": "{rose.800}"
         },
         "icon-strong": {
             "$type": "color",
@@ -46,79 +46,83 @@
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "icon-weak-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.500}"
         },
         "icon-weak-press": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.600}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{amanita.75}"
+            "$value": "{rose.75}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{amanita.25}"
+            "$value": "{rose.25}"
         },
         "surface-selected": {
             "$type": "color",
-            "$value": "{amanita.50}"
+            "$value": "{rose.50}"
         },
         "surface-disabled": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.100}"
         },
         "surface-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.500}"
         },
         "surface-press": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.600}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "surface-strong-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.500}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{amanita.50}"
+            "$value": "{rose.50}"
         },
         "surface-weak-hover": {
             "$type": "color",
-            "$value": "{amanita.75}"
+            "$value": "{rose.75}"
         },
         "surface-weak-press": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.100}"
+        },
+        "surface-weak-selected": {
+            "$type": "color",
+            "$value": "{rose.100}"
         },
         "text": {
             "$type": "color",
-            "$value": "{amanita.700}"
+            "$value": "{rose.700}"
         },
         "text-selected": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "text-disabled": {
             "$type": "color",
-            "$value": "{amanita.100}"
+            "$value": "{rose.100}"
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.500}"
         },
         "text-press": {
             "$type": "color",
-            "$value": "{amanita.800}"
+            "$value": "{rose.800}"
         },
         "text-strong": {
             "$type": "color",
@@ -130,15 +134,15 @@
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{amanita.400}"
+            "$value": "{rose.400}"
         },
         "text-weak-hover": {
             "$type": "color",
-            "$value": "{amanita.500}"
+            "$value": "{rose.500}"
         },
         "text-weak-press": {
             "$type": "color",
-            "$value": "{amanita.600}"
+            "$value": "{rose.600}"
         }
     },
     "decorative": {
@@ -1049,87 +1053,87 @@
         "caution": {
             "border": {
                 "$type": "color",
-                "$value": "{koi.300}"
+                "$value": "{amber.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{koi.50}"
+                "$value": "{amber.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{koi.400}"
+                "$value": "{amber.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{koi.500}"
+                "$value": "{amber.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{koi.700}"
+                "$value": "{amber.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{koi.600}"
+                "$value": "{amber.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{koi.200}"
+                "$value": "{amber.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{koi.700}"
+                "$value": "{amber.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{koi.700}"
+                "$value": "{amber.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{koi.50}"
+                "$value": "{amber.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{koi.25}"
+                "$value": "{amber.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{koi.75}"
+                "$value": "{amber.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{koi.100}"
+                "$value": "{amber.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{koi.50}"
+                "$value": "{amber.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{koi.200}"
+                "$value": "{amber.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{koi.600}"
+                "$value": "{amber.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{koi.200}"
+                "$value": "{amber.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{koi.700}"
+                "$value": "{amber.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{koi.800}"
+                "$value": "{amber.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{koi.700}"
+                "$value": "{amber.700}"
             }
         },
         "inactive": {
@@ -1393,259 +1397,259 @@
         "option1": {
             "border": {
                 "$type": "color",
-                "$value": "{coastal.300}"
+                "$value": "{iris.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{coastal.50}"
+                "$value": "{iris.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{coastal.400}"
+                "$value": "{iris.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{coastal.500}"
+                "$value": "{iris.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{coastal.700}"
+                "$value": "{iris.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{coastal.600}"
+                "$value": "{iris.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{coastal.200}"
+                "$value": "{iris.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{coastal.700}"
+                "$value": "{iris.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{coastal.700}"
+                "$value": "{iris.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{coastal.50}"
+                "$value": "{iris.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{coastal.25}"
+                "$value": "{iris.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{coastal.75}"
+                "$value": "{iris.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{coastal.100}"
+                "$value": "{iris.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{coastal.50}"
+                "$value": "{iris.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{coastal.200}"
+                "$value": "{iris.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{coastal.600}"
+                "$value": "{iris.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{coastal.200}"
+                "$value": "{iris.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{coastal.700}"
+                "$value": "{iris.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{coastal.800}"
+                "$value": "{iris.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{coastal.700}"
+                "$value": "{iris.700}"
             }
         },
         "option2": {
             "border": {
                 "$type": "color",
-                "$value": "{orchid-bloom.300}"
+                "$value": "{persimmon.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.50}"
+                "$value": "{persimmon.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.400}"
+                "$value": "{persimmon.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.500}"
+                "$value": "{persimmon.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.700}"
+                "$value": "{persimmon.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{orchid-bloom.600}"
+                "$value": "{persimmon.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.200}"
+                "$value": "{persimmon.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.700}"
+                "$value": "{persimmon.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.700}"
+                "$value": "{persimmon.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{orchid-bloom.50}"
+                "$value": "{persimmon.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.25}"
+                "$value": "{persimmon.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.75}"
+                "$value": "{persimmon.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.100}"
+                "$value": "{persimmon.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.50}"
+                "$value": "{persimmon.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{orchid-bloom.200}"
+                "$value": "{persimmon.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{orchid-bloom.600}"
+                "$value": "{persimmon.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{orchid-bloom.200}"
+                "$value": "{persimmon.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{orchid-bloom.700}"
+                "$value": "{persimmon.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{orchid-bloom.800}"
+                "$value": "{persimmon.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{orchid-bloom.700}"
+                "$value": "{persimmon.700}"
             }
         },
         "option3": {
             "border": {
                 "$type": "color",
-                "$value": "{quetzal.300}"
+                "$value": "{moss.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.50}"
+                "$value": "{moss.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{quetzal.400}"
+                "$value": "{moss.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{quetzal.500}"
+                "$value": "{moss.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{quetzal.50}"
+                "$value": "{moss.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{quetzal.600}"
+                "$value": "{moss.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.200}"
+                "$value": "{moss.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{quetzal.700}"
+                "$value": "{moss.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{quetzal.700}"
+                "$value": "{moss.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{quetzal.50}"
+                "$value": "{moss.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.25}"
+                "$value": "{moss.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{quetzal.75}"
+                "$value": "{moss.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{quetzal.100}"
+                "$value": "{moss.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{quetzal.700}"
+                "$value": "{moss.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{quetzal.200}"
+                "$value": "{moss.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{quetzal.600}"
+                "$value": "{moss.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{quetzal.200}"
+                "$value": "{moss.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{quetzal.700}"
+                "$value": "{moss.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{quetzal.800}"
+                "$value": "{moss.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{quetzal.700}"
+                "$value": "{moss.700}"
             }
         },
         "option4": {
@@ -1823,302 +1827,302 @@
         "option6": {
             "border": {
                 "$type": "color",
-                "$value": "{sunken-treasure.300}"
+                "$value": "{limeburst.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.50}"
+                "$value": "{limeburst.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.400}"
+                "$value": "{limeburst.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.500}"
+                "$value": "{limeburst.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.700}"
+                "$value": "{limeburst.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{sunken-treasure.600}"
+                "$value": "{limeburst.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.200}"
+                "$value": "{limeburst.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.700}"
+                "$value": "{limeburst.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.700}"
+                "$value": "{limeburst.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{sunken-treasure.25}"
+                "$value": "{limeburst.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.25}"
+                "$value": "{limeburst.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.50}"
+                "$value": "{limeburst.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.100}"
+                "$value": "{limeburst.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.50}"
+                "$value": "{limeburst.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{sunken-treasure.200}"
+                "$value": "{limeburst.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{sunken-treasure.600}"
+                "$value": "{limeburst.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{sunken-treasure.200}"
+                "$value": "{limeburst.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{sunken-treasure.700}"
+                "$value": "{limeburst.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{sunken-treasure.800}"
+                "$value": "{limeburst.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{sunken-treasure.700}"
+                "$value": "{limeburst.700}"
             }
         },
         "positive": {
             "border": {
                 "$type": "color",
-                "$value": "{moss.300}"
+                "$value": "{mint.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{moss.50}"
+                "$value": "{mint.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{moss.400}"
+                "$value": "{mint.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{moss.500}"
+                "$value": "{mint.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{moss.700}"
+                "$value": "{mint.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{moss.600}"
+                "$value": "{mint.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{moss.200}"
+                "$value": "{mint.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{moss.700}"
+                "$value": "{mint.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{moss.700}"
+                "$value": "{mint.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{moss.50}"
+                "$value": "{mint.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{moss.25}"
+                "$value": "{mint.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{moss.75}"
+                "$value": "{mint.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{moss.100}"
+                "$value": "{mint.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{moss.50}"
+                "$value": "{mint.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{moss.200}"
+                "$value": "{mint.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{moss.600}"
+                "$value": "{mint.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{moss.200}"
+                "$value": "{mint.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{moss.700}"
+                "$value": "{mint.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{moss.800}"
+                "$value": "{mint.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{moss.700}"
+                "$value": "{mint.700}"
             }
         },
         "progress": {
             "border": {
                 "$type": "color",
-                "$value": "{sapphire.300}"
+                "$value": "{cobalt.300}"
             },
             "border-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.50}"
+                "$value": "{cobalt.50}"
             },
             "border-hover": {
                 "$type": "color",
-                "$value": "{sapphire.400}"
+                "$value": "{cobalt.400}"
             },
             "border-press": {
                 "$type": "color",
-                "$value": "{sapphire.500}"
+                "$value": "{cobalt.500}"
             },
             "border-selected": {
                 "$type": "color",
-                "$value": "{sapphire.400}"
+                "$value": "{cobalt.700}"
             },
             "icon": {
                 "$type": "color",
-                "$value": "{sapphire.600}"
+                "$value": "{cobalt.600}"
             },
             "icon-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.200}"
+                "$value": "{cobalt.200}"
             },
             "icon-hover": {
                 "$type": "color",
-                "$value": "{sapphire.700}"
+                "$value": "{cobalt.700}"
             },
             "icon-press": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.800}"
             },
             "icon-selected": {
                 "$type": "color",
-                "$value": "{sapphire.500}"
+                "$value": "{cobalt.700}"
             },
             "surface": {
                 "$type": "color",
-                "$value": "{sapphire.50}"
+                "$value": "{cobalt.50}"
             },
             "surface-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.25}"
+                "$value": "{cobalt.25}"
             },
             "surface-hover": {
                 "$type": "color",
-                "$value": "{sapphire.75}"
+                "$value": "{cobalt.75}"
             },
             "surface-press": {
                 "$type": "color",
-                "$value": "{sapphire.100}"
+                "$value": "{cobalt.100}"
             },
             "surface-selected": {
                 "$type": "color",
-                "$value": "{sapphire.50}"
+                "$value": "{cobalt.50}"
             },
             "surface-strong": {
                 "$type": "color",
-                "$value": "{sapphire.200}"
+                "$value": "{cobalt.200}"
             },
             "text": {
                 "$type": "color",
-                "$value": "{sapphire.600}"
+                "$value": "{cobalt.600}"
             },
             "text-disabled": {
                 "$type": "color",
-                "$value": "{sapphire.200}"
+                "$value": "{cobalt.200}"
             },
             "text-hover": {
                 "$type": "color",
-                "$value": "{sapphire.700}"
+                "$value": "{cobalt.700}"
             },
             "text-press": {
                 "$type": "color",
-                "$value": "{sapphire.800}"
+                "$value": "{cobalt.800}"
             },
             "text-selected": {
                 "$type": "color",
-                "$value": "{sapphire.500}"
+                "$value": "{cobalt.700}"
             }
         }
     },
     "success": {
         "border": {
             "$type": "color",
-            "$value": "{moss.100}"
+            "$value": "{mint.100}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{moss.700}"
+            "$value": "{mint.700}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{moss.100}"
+            "$value": "{mint.100}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{moss.300}"
+            "$value": "{mint.300}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{moss.25}"
+            "$value": "{mint.25}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{moss.100}"
+            "$value": "{mint.100}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{moss.50}"
+            "$value": "{mint.50}"
         },
         "text": {
             "$type": "color",
-            "$value": "{moss.700}"
+            "$value": "{mint.700}"
         },
         "text-hover": {
             "$type": "color",
-            "$value": "{moss.800}"
+            "$value": "{mint.800}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{moss.300}"
+            "$value": "{mint.300}"
         }
     },
     "upsell": {
@@ -2238,39 +2242,39 @@
     "warning": {
         "border": {
             "$type": "color",
-            "$value": "{koi.100}"
+            "$value": "{amber.100}"
         },
         "icon": {
             "$type": "color",
-            "$value": "{koi.700}"
+            "$value": "{amber.700}"
         },
         "icon-weakest": {
             "$type": "color",
-            "$value": "{koi.100}"
+            "$value": "{amber.100}"
         },
         "icon-weak": {
             "$type": "color",
-            "$value": "{koi.300}"
+            "$value": "{amber.300}"
         },
         "surface": {
             "$type": "color",
-            "$value": "{koi.25}"
+            "$value": "{amber.25}"
         },
         "surface-strong": {
             "$type": "color",
-            "$value": "{koi.100}"
+            "$value": "{amber.100}"
         },
         "surface-weak": {
             "$type": "color",
-            "$value": "{koi.50}"
+            "$value": "{amber.50}"
         },
         "text": {
             "$type": "color",
-            "$value": "{koi.700}"
+            "$value": "{amber.700}"
         },
         "text-weak": {
             "$type": "color",
-            "$value": "{koi.300}"
+            "$value": "{amber.300}"
         }
     }
 }

--- a/packages/tokens/src/tokens/semantic/workleap/dark/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/workleap/dark/colors.tokens.json
@@ -100,6 +100,10 @@
             "$type": "color",
             "$value": "{amanita.600}"
         },
+        "surface-weak-selected": {
+            "$type": "color",
+            "$value": "{amanita.600}"
+        },
         "text": {
             "$type": "color",
             "$value": "{amanita.900}"

--- a/packages/tokens/src/tokens/semantic/workleap/light/colors.tokens.json
+++ b/packages/tokens/src/tokens/semantic/workleap/light/colors.tokens.json
@@ -100,6 +100,10 @@
             "$type": "color",
             "$value": "{amanita.100}"
         },
+        "surface-weak-selected": {
+            "$type": "color",
+            "$value": "{amanita.100}"
+        },
         "text": {
             "$type": "color",
             "$value": "{amanita.700}"


### PR DESCRIPTION
## Summary
Jira: [SGPLTD-2049](https://workleap.atlassian.net/browse/SGPLTD-2049)

- Added `danger-surface-weak-selected` semantic token across Workleap and ShareGate (light and dark)
- Switched ShareGate **Danger** semantic tokens from the Amanita palette to the **Rose** palette, applying the latest light/dark shade map
- Refreshed ShareGate **Status** sub-categories (Neutral, Progress, Positive, Caution, Inactive, Option1–6) to match the latest design specs — most light values were either kept or palette-swapped; dark values received broader shade-shifts (e.g. `text`/`icon` to `.100`, `surface` to `.800`, etc.)
- Updated **Rose** core palette shades 400–900 to the new design values
- Updated **ShareGate Button Danger** component tokens to align visually with the Primary variant:
  - `background` / `background-loading` now use a Rose gradient (`rose.300` → `rose.600`)
  - `background-hover` / `background-pressed` / `background-selected` converted to single-stop gradients for smooth CSS transitions
  - `box-shadow` / `box-shadow-loading` now use the same inset shadow pattern as the Primary variant

## Test plan
- [ ] Verify Sharegate light/dark Danger swatches render with the new Rose palette in Storybook
- [ ] Verify Sharegate Status sub-categories render correctly in light and dark
- [ ] Verify Workleap Danger renders `danger-surface-weak-selected` correctly
- [ ] Sanity-check any consumer using \`BackgroundColors[\"danger-weak-selected\"]\` resolves to the new token
- [ ] Verify Sharegate Button \`danger\` variant renders the Rose gradient + inset shadow and transitions smoothly on hover/press/select

[Claude Code](https://claude.com/claude-code)

[SGPLTD-2049]: https://workleap.atlassian.net/browse/SGPLTD-2049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ