### PR TITLE
fix: ShareGate Button medium font tokens [SGPLTD-1189]

### DIFF
--- a/.changeset/eleven-moose-kick.md
+++ b/.changeset/eleven-moose-kick.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/components": patch
+"@hopper-ui/styled-system": patch
+---
+
+Fix the Button medium font-size for ShareGate

--- a/.changeset/eleven-moose-kick.md
+++ b/.changeset/eleven-moose-kick.md
@@ -4,4 +4,4 @@
 "@hopper-ui/styled-system": patch
 ---
 
-Fix the Button medium font-size for ShareGate
+Fix the Button medium font-size, line-height, and letter-spacing for ShareGate

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -30,15 +30,15 @@
         },
         "text-font-size-md": {
             "$type": "fontSize",
-            "$value": "{caption.xl.font-size}"
+            "$value": "{caption.lg.font-size}"
         },
         "text-font-lineheight-md": {
             "$type": "lineHeight",
-            "$value": "{line-height.1-50}"
+            "$value": "{line-height.1-4285}"
         },
         "text-font-letterspacing-md": {
             "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-25}"
+            "$value": "{letter-spacing.wide-30}"
         },
         "text-font-size-sm": {
             "$type": "fontSize",


### PR DESCRIPTION
## Summary
- Update ShareGate Button medium-size text tokens (`text-font-size-md`, `text-font-lineheight-md`, `text-font-letterspacing-md`) to match the design spec: `caption.lg.font-size`, `line-height.1-4285`, and `letter-spacing.wide-30`.

Jira: [SGPLTD-1189](https://workleap.atlassian.net/browse/SGPLTD-1189)

## Test plan
- [ ] Verify ShareGate Button at medium size renders with the corrected typography
- [ ] Confirm no visual regressions on other Button sizes/variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SGPLTD-1189]: https://workleap.atlassian.net/browse/SGPLTD-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ