### PR TITLE
fix: mirror Workleap Button typography tokens in ShareGate

### DIFF
--- a/.changeset/sharegate-button-mirror-workleap-typography.md
+++ b/.changeset/sharegate-button-mirror-workleap-typography.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Mirror Workleap Button typography tokens in ShareGate: font-weight, text-transform, font-size, line-height, and letter-spacing for all sizes (md, sm, xs).

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -22,47 +22,47 @@
         },
         "text-font-weight": {
             "$type": "fontWeight",
-            "$value": "{font.weight.410}"
+            "$value": "{font.weight.505}"
         },
         "text-transform": {
-            "$type": "textTransform",
-            "$value": "uppercase"
+            "$type": "",
+            "$value": "none"
         },
         "text-font-size-md": {
             "$type": "fontSize",
-            "$value": "{caption.lg.font-size}"
+            "$value": "{body.md.font-size}"
         },
         "text-font-lineheight-md": {
             "$type": "lineHeight",
-            "$value": "{line-height.1-4285}"
+            "$value": "{line-height.1-50}"
         },
         "text-font-letterspacing-md": {
-            "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-15}"
+            "$type": "",
+            "$value": "normal"
         },
         "text-font-size-sm": {
             "$type": "fontSize",
-            "$value": "{caption.lg.font-size}"
+            "$value": "{body.sm.font-size}"
         },
         "text-font-lineheight-sm": {
             "$type": "lineHeight",
             "$value": "{line-height.1-4285}"
         },
         "text-font-letterspacing-sm": {
-            "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-15}"
+            "$type": "",
+            "$value": "normal"
         },
         "text-font-size-xs": {
             "$type": "fontSize",
-            "$value": "{caption.md.font-size}"
+            "$value": "{body.xs.font-size}"
         },
         "text-font-lineheight-xs": {
             "$type": "lineHeight",
             "$value": "{line-height.1-33}"
         },
         "text-font-letterspacing-xs": {
-            "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-10}"
+            "$type": "",
+            "$value": "normal"
         },
         "primary": {
             "box-shadow": {


### PR DESCRIPTION
## Summary
- Mirror Workleap Button typography tokens in ShareGate for font-weight, text-transform, font-size, line-height, and letter-spacing (md, sm, xs)

| Token | Before | After |
|---|---|---|
| `text-font-weight` | `font.weight.410` | `font.weight.505` |
| `text-transform` | `uppercase` | `none` |
| `text-font-size-md` | `caption.lg.font-size` | `body.md.font-size` |
| `text-font-lineheight-md` | `line-height.1-4285` | `line-height.1-50` |
| `text-font-letterspacing-md/sm/xs` | `wide-15 / wide-15 / wide-10` | `normal` |
| `text-font-size-sm` | `caption.lg.font-size` | `body.sm.font-size` |
| `text-font-size-xs` | `caption.md.font-size` | `body.xs.font-size` |

## Test plan
- [ ] Confirm ShareGate Button typography matches Workleap in Storybook (all sizes)
- [ ] Check Chromatic visual diff for ShareGate brand (light and dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)