### PR TITLE
fix(chromatic): add externals for token JSON files to fix TurboSnap cache miss

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -63,6 +63,7 @@ jobs:
                     projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
                     traceChanged: true
                     onlyChanged: true # TurboSnap
+                    externals: "packages/tokens/src/tokens/**" # Token JSON files are outside webpack's module graph; when they change the generated CSS changes, affecting all stories
                     exitOnceUploaded: true # The PRs will be marked as success/failure based on the Chromatic build status
                     skip: ${{ github.event.pull_request.draft == true || startsWith(github.ref, 'refs/heads/changeset-release/') }}
 

--- a/packages/tokens/src/tokens/components/workleap/button.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/button.tokens.json
@@ -2,7 +2,7 @@
     "comp-button": {
         "border-radius": {
             "$type": "borderRadius",
-            "$value": "{shape.rounded-md}"
+            "$value": "999px"
         },
         "border-color-focus": {
             "$type": "color",

--- a/packages/tokens/src/tokens/components/workleap/button.tokens.json
+++ b/packages/tokens/src/tokens/components/workleap/button.tokens.json
@@ -2,7 +2,7 @@
     "comp-button": {
         "border-radius": {
             "$type": "borderRadius",
-            "$value": "999px"
+            "$value": "{shape.rounded-md}"
         },
         "border-color-focus": {
             "$type": "color",


### PR DESCRIPTION
TurboSnap (onlyChanged) traces git-changed files through webpack's module
graph to find affected stories. Token JSON files are processed by Style
Dictionary outside of webpack — the generated CSS lands in dist/ (gitignored)
so TurboSnap never traces from JSON changes to affected stories, resulting in
0 snapshots on every token-only PR.

Adding externals: "packages/tokens/src/tokens/**" tells TurboSnap to fall
back to a full build whenever any token JSON file changes.

The border-radius change on the workleap button token is a test to confirm
Chromatic now detects token-driven visual changes (will be reverted after
verification).

https://claude.ai/code/session_01A1UCp6TdAWwU6bEfW8Y1Vv