### PR TITLE
fix: update ShareGate SegmentedControl, Checkbox, Switch, and Radio shadow tokens

### DIFF
--- a/.changeset/sharegate-segmented-control-box-shadow.md
+++ b/.changeset/sharegate-segmented-control-box-shadow.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update ShareGate SegmentedControl box-shadow layer #3 (offsetX: -1px, offsetY: 1px, blur: 2px) and item-box-shadow-selected layer #1 (offsetX: 1px, offsetY: 1px, blur: 4px).

--- a/packages/tokens/src/tokens/components/sharegate/control.segmentedControl.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/control.segmentedControl.tokens.json
@@ -2,7 +2,7 @@
     "comp-segmented-control": {
         "border-radius": {
             "$type": "borderRadius",
-            "$value": "{shape.rounded-sm}"
+            "$value": "{shape.rounded-md}"
         },
         "text-color": {
             "$type": "color",
@@ -25,17 +25,17 @@
             "$value": [
                 { "offsetX": "1.5px", "offsetY": "1.5px", "blur": "1.5px", "spread": "0", "color": "rgba(0, 0, 0, 0.03)", "inset": false },
                 { "offsetX": "0.5px", "offsetY": "1.5px", "blur": "5px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true },
-                { "offsetX": "-2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
+                { "offsetX": "-1px", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
             ]
         },
         "item-border-radius": {
             "$type": "borderRadius",
-            "$value": "{shape.rounded-sm}"
+            "$value": "{shape.rounded-md}"
         },
         "item-box-shadow-selected": {
             "$type": "shadow",
             "$value": [
-                { "offsetX": "2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(255, 255, 255, 0.10)", "inset": false },
+                { "offsetX": "1px", "offsetY": "1px", "blur": "4px", "spread": "0", "color": "rgba(255, 255, 255, 0.10)", "inset": false },
                 { "offsetX": "2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(0, 0, 0, 0.05)", "inset": false }
             ]
         },

--- a/packages/tokens/src/tokens/components/sharegate/control.switch.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/control.switch.tokens.json
@@ -20,13 +20,13 @@
             "$type": "shadow",
             "$value": [
                 { "offsetX": "0.5px", "offsetY": "1.5px", "blur": "5px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true },
-                { "offsetX": "-2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
+                { "offsetX": "-1px", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
             ]
         },
         "thumb-box-shadow": {
             "$type": "shadow",
             "$value": [
-                { "offsetX": "2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(255, 255, 255, 0.10)", "inset": false },
+                { "offsetX": "1px", "offsetY": "1px", "blur": "4px", "spread": "0", "color": "rgba(255, 255, 255, 0.10)", "inset": false },
                 { "offsetX": "2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(0, 0, 0, 0.05)", "inset": false }
             ]
         },

--- a/packages/tokens/src/tokens/components/sharegate/mark.checkbox.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/mark.checkbox.tokens.json
@@ -9,7 +9,7 @@
             "$value": [
                 { "offsetX": "1.5px", "offsetY": "1.5px", "blur": "1.5px", "spread": "0", "color": "rgba(0, 0, 0, 0.03)", "inset": false },
                 { "offsetX": "0.5px", "offsetY": "1.5px", "blur": "5px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true },
-                { "offsetX": "-2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
+                { "offsetX": "-1px", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
             ]
         }
     }

--- a/packages/tokens/src/tokens/components/sharegate/mark.radio.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/mark.radio.tokens.json
@@ -9,7 +9,7 @@
             "$value": [
                 { "offsetX": "1.5px", "offsetY": "1.5px", "blur": "1.5px", "spread": "0", "color": "rgba(0, 0, 0, 0.03)", "inset": false },
                 { "offsetX": "0.5px", "offsetY": "1.5px", "blur": "5px", "spread": "0", "color": "rgba(0, 0, 0, 0.10)", "inset": true },
-                { "offsetX": "-2.5px", "offsetY": "2.5px", "blur": "5px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
+                { "offsetX": "-1px", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "rgba(255, 255, 255, 0.50)", "inset": true }
             ]
         }
     }


### PR DESCRIPTION
## Summary
**SegmentedControl**
- `border-radius` + `item-border-radius`: `rounded-sm` → `rounded-md`
- `box-shadow` #3: offsetX `-2.5px` → `-1px`, offsetY `2.5px` → `1px`, blur `5px` → `2px`
- `item-box-shadow-selected` #1: offsetX `2.5px` → `1px`, offsetY `2.5px` → `1px`, blur `5px` → `4px`

**Checkbox**
- `box-shadow` #3: offsetX `-2.5px` → `-1px`, offsetY `2.5px` → `1px`, blur `5px` → `2px`

**Switch**
- `track-box-shadow` #2: offsetX `-2.5px` → `-1px`, offsetY `2.5px` → `1px`, blur `5px` → `2px`
- `thumb-box-shadow` #1: offsetX `2.5px` → `1px`, offsetY `2.5px` → `1px`, blur `5px` → `4px`

**Radio**
- `box-shadow` #3: offsetX `-2.5px` → `-1px`, offsetY `2.5px` → `1px`, blur `5px` → `2px`

## Test plan
- [ ] Confirm shadows and border-radius look correct in Storybook for ShareGate brand
- [ ] Check Chromatic visual diff for ShareGate brand (light and dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)