### PR TITLE
fix: update ShareGate Button font family to Inter

### DIFF
--- a/.changeset/sharegate-button-font-family.md
+++ b/.changeset/sharegate-button-font-family.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update ShareGate Button font family from ABC Favorit Mono to Inter by referencing `{body.md.font-family}` instead of `{caption.md.font-family}`.

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -18,7 +18,7 @@
         },
         "text-font": {
             "$type": "fontFamily",
-            "$value": "{caption.md.font-family}"
+            "$value": "{body.md.font-family}"
         },
         "text-font-weight": {
             "$type": "fontWeight",


### PR DESCRIPTION
## Summary
- Updated ShareGate Button `text-font` from `{caption.md.font-family}` (ABC Favorit Mono) to `{body.md.font-family}` (Inter), mirroring Workleap Button

## Test plan
- [ ] Confirm ShareGate Button text renders in Inter in Storybook
- [ ] Check Chromatic visual diff for ShareGate brand (light and dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)