### PR TITLE
fix: update ShareGate secondary Button border color tokens

### DIFF
--- a/.changeset/sharegate-secondary-button-border-color.md
+++ b/.changeset/sharegate-secondary-button-border-color.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update ShareGate secondary Button border-color, border-color-selected, and border-color-loading from `{neutral.border-weakest}` to `{neutral.border-weak}`.

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -234,7 +234,7 @@
             },
             "border-color-loading": {
                 "$type": "color",
-                "$value": "{neutral.border-weakest}"
+                "$value": "{neutral.border-weak}"
             },
             "box-shadow-loading": {
                 "$type": "shadow",
@@ -273,11 +273,11 @@
             },
             "border-color": {
                 "$type": "color",
-                "$value": "{neutral.border-weakest}"
+                "$value": "{neutral.border-weak}"
             },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{neutral.border-weakest}"
+                "$value": "{neutral.border-weak}"
             },
             "border-color-disabled": {
                 "$type": "color",


### PR DESCRIPTION
## Summary
- Updated ShareGate secondary Button `border-color`, `border-color-selected`, and `border-color-loading` from `{neutral.border-weakest}` to `{neutral.border-weak}`

## Test plan
- [ ] Confirm secondary Button border looks correct in Storybook for ShareGate brand
- [ ] Check Chromatic visual diff for ShareGate brand (light and dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)