### PR TITLE
fix: ShareGate Tag to sentence case and remove tracking

### DIFF
--- a/.changeset/sharegate-tag-sentence-case.md
+++ b/.changeset/sharegate-tag-sentence-case.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update the ShareGate Tag to use sentence case instead of uppercase, and remove the letter-spacing (tracking) across all sizes.

--- a/packages/tokens/src/tokens/components/sharegate/tag.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/tag.tokens.json
@@ -110,7 +110,7 @@
         },
         "text-transform": {
             "$type": "textCase",
-            "$value": "uppercase"
+            "$value": "none"
         },
         "text-font-size-sm": {
             "$type": "fontSize",
@@ -121,8 +121,8 @@
             "$value": "{line-height.1-33}"
         },
         "text-font-letterspacing-sm": {
-            "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-20}"
+            "$type": "",
+            "$value": "normal"
         },
         "text-font-size-md": {
             "$type": "fontSize",
@@ -133,8 +133,8 @@
             "$value": "{line-height.1-33}"
         },
         "text-font-letterspacing-md": {
-            "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-20}"
+            "$type": "",
+            "$value": "normal"
         },
         "text-font-size-lg": {
             "$type": "fontSize",
@@ -145,8 +145,8 @@
             "$value": "{line-height.1-2857}"
         },
         "text-font-letterspacing-lg": {
-            "$type": "letterSpacing",
-            "$value": "{letter-spacing.wide-30}"
+            "$type": "",
+            "$value": "normal"
         }
     }
 }


### PR DESCRIPTION
## Summary

Updates the **ShareGate** Tag component typography:

- **Text casing**: `uppercase` → sentence case (`none`)
- **Letter-spacing (tracking)**: removed across all sizes (sm, md, lg) — was `wide-20` / `wide-30`, now `normal`

Workleap's Tag was already sentence case with no tracking, so this is a ShareGate-only change that brings the two brands in line.

## Validation

- `pnpm build:pkg` ✅
- `pnpm lint` ✅
- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅ (646 tests passing)

Changeset included (`patch` bump for tokens, styled-system, and components).

## Visual review

Please confirm in Chromatic that the ShareGate Tag looks correct in both light and dark.

https://claude.ai/code/session_01TtieGd4jy9e3cZvB6HPWxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtieGd4jy9e3cZvB6HPWxW)_