### PR TITLE
[SGD-24989] Add prefix prop to PasswordField

### DIFF
--- a/.changeset/password-field-prefix.md
+++ b/.changeset/password-field-prefix.md
@@ -1,0 +1,5 @@
+---
+"@hopper-ui/components": patch
+---
+
+feat(PasswordField): add `prefix` prop to display an icon or short text at the start of the input, matching TextField.

--- a/apps/docs/content/components/forms/PasswordField.mdx
+++ b/apps/docs/content/components/forms/PasswordField.mdx
@@ -40,6 +40,16 @@ A password field with a helper message.
 
 <Example src="inputs/docs/password-field/description" />
 
+### Icon Prefix
+An icon can be displayed at the start of the input.
+
+<Example src="inputs/docs/password-field/iconPrefix" />
+
+### Text Prefix
+A short text can be displayed at the start of the input.
+
+<Example src="inputs/docs/password-field/textPrefix" />
+
 ### ContextualHelp
 
 A [ContextualHelp](/components/ContextualHelp) element may be placed next to the label to provide additional information or help about a PasswordField.

--- a/packages/components/src/inputs/docs/password-field/iconPrefix.tsx
+++ b/packages/components/src/inputs/docs/password-field/iconPrefix.tsx
@@ -1,0 +1,8 @@
+import { PasswordField } from "@hopper-ui/components";
+import { SearchIcon } from "@hopper-ui/icons";
+
+export default function Example() {
+    return (
+        <PasswordField placeholder="Enter password" prefix={<SearchIcon />} label="Password" />
+    );
+}

--- a/packages/components/src/inputs/docs/password-field/textPrefix.tsx
+++ b/packages/components/src/inputs/docs/password-field/textPrefix.tsx
@@ -1,0 +1,7 @@
+import { PasswordField } from "@hopper-ui/components";
+
+export default function Example() {
+    return (
+        <PasswordField placeholder="Enter password" prefix="pwd:" label="Password" />
+    );
+}

--- a/packages/components/src/inputs/src/PasswordField.module.css
+++ b/packages/components/src/inputs/src/PasswordField.module.css
@@ -22,6 +22,10 @@
     order: 0;
 }
 
+.hop-PasswordField__prefix {
+    color: var(--hop-comp-field-prefill-color);
+}
+
 .hop-PasswordField__InputGroup {
     order: 1;
     padding-inline-end: var(--hop-PasswordField-input-group-padding-inline-end); /* the eye image needs to be closer to the right than other type of buttons */

--- a/packages/components/src/inputs/src/PasswordField.tsx
+++ b/packages/components/src/inputs/src/PasswordField.tsx
@@ -134,7 +134,8 @@ function PasswordField(props: PasswordFieldProps, ref: ForwardedRef<HTMLDivEleme
         <SlotProvider values={[
             [TextContext, { size, className: styles["hop-PasswordField__prefix"] }],
             [IconContext, { size, className: styles["hop-PasswordField__prefix"] }]
-        ]}>
+        ]}
+        >
             {ensureTextWrapper(prefix)}
         </SlotProvider>
     ) : null;

--- a/packages/components/src/inputs/src/PasswordField.tsx
+++ b/packages/components/src/inputs/src/PasswordField.tsx
@@ -1,4 +1,4 @@
-import { EyeHiddenIcon, EyeVisibleIcon } from "@hopper-ui/icons";
+import { EyeHiddenIcon, EyeVisibleIcon, IconContext } from "@hopper-ui/icons";
 import {
     useResponsiveValue,
     useStyledSystem,
@@ -7,7 +7,7 @@ import {
 } from "@hopper-ui/styled-system";
 import { mergeRefs } from "@react-aria/utils";
 import clsx from "clsx";
-import { forwardRef, useState, type ForwardedRef, type MutableRefObject } from "react";
+import { forwardRef, useState, type ForwardedRef, type MutableRefObject, type ReactNode } from "react";
 import { useObjectRef } from "react-aria";
 import {
     composeRenderProps,
@@ -21,8 +21,8 @@ import { ErrorMessage } from "../../error-message/index.ts";
 import { useFormProps } from "../../form/index.ts";
 import { HelperMessage } from "../../helper-message/index.ts";
 import { useLocalizedString } from "../../i18n/index.ts";
-import { FieldLabel } from "../../typography/index.ts";
-import { ClearContainerSlots, composeClassnameRenderProps, cssModule, type FieldProps, type FieldSize } from "../../utils/index.ts";
+import { FieldLabel, TextContext } from "../../typography/index.ts";
+import { ClearContainerSlots, composeClassnameRenderProps, cssModule, ensureTextWrapper, SlotProvider, type FieldProps, type FieldSize } from "../../utils/index.ts";
 
 import { Input, type InputProps } from "./Input.tsx";
 import { InputGroup, type InputGroupProps } from "./InputGroup.tsx";
@@ -33,6 +33,11 @@ import styles from "./PasswordField.module.css";
 export const GlobalPasswordFieldCssSelector = "hop-PasswordField";
 
 export interface PasswordFieldProps extends Omit<StyledComponentProps<Omit<RACTextFieldProps, "type" | "size">>, "children">, FieldProps {
+    /**
+     * An icon or text to display at the start of the input.
+     */
+    prefix?: ReactNode;
+
     /**
      * The placeholder text when the PasswordField is empty.
      */
@@ -97,6 +102,7 @@ function PasswordField(props: PasswordFieldProps, ref: ForwardedRef<HTMLDivEleme
         inputGroupProps,
         inputProps,
         embeddedButtonProps,
+        prefix,
         label,
         description,
         errorMessage,
@@ -124,6 +130,15 @@ function PasswordField(props: PasswordFieldProps, ref: ForwardedRef<HTMLDivEleme
         };
     });
 
+    const prefixMarkup = prefix ? (
+        <SlotProvider values={[
+            [TextContext, { size, className: styles["hop-PasswordField__prefix"] }],
+            [IconContext, { size, className: styles["hop-PasswordField__prefix"] }]
+        ]}>
+            {ensureTextWrapper(prefix)}
+        </SlotProvider>
+    ) : null;
+
     const { className: inputGroupClassName, ...otherInputGroupProps } = inputGroupProps ?? {};
     const inputGroupClassNames = clsx(styles["hop-PasswordField__InputGroup"], inputGroupClassName);
 
@@ -136,6 +151,7 @@ function PasswordField(props: PasswordFieldProps, ref: ForwardedRef<HTMLDivEleme
                 className={inputGroupClassNames}
                 {...otherInputGroupProps}
             >
+                {prefixMarkup}
                 <Input ref={inputRef} placeholder={placeholder} type={showPassword ? "text" : "password"} size={size} {...inputProps} />
                 <EmbeddedButton
                     isDisabled={isDisabled}
@@ -156,7 +172,9 @@ function PasswordField(props: PasswordFieldProps, ref: ForwardedRef<HTMLDivEleme
     const childrenMarkup = (
         <>
             <FieldLabel
-                className={styles["hop-PasswordField__Label"]}
+                wrapperProps={{
+                    className: styles["hop-PasswordField__Label"]
+                }}
                 contextualHelp={contextualHelp}
                 isRequired={isRequired}
                 necessityIndicator={necessityIndicator}

--- a/packages/components/src/inputs/tests/chromatic/PasswordField.stories.tsx
+++ b/packages/components/src/inputs/tests/chromatic/PasswordField.stories.tsx
@@ -1,3 +1,4 @@
+import { MailIcon } from "@hopper-ui/icons";
 import { Div } from "@hopper-ui/styled-system";
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
 import { within } from "storybook/test";
@@ -72,6 +73,24 @@ export const Value: Story = {
     ...WithLabel,
     args: {
         ...WithLabel.args,
+        defaultValue: "Hop we go!"
+    }
+};
+
+export const PrefixIcon: Story = {
+    ...WithLabel,
+    args: {
+        ...WithLabel.args,
+        prefix: <MailIcon />,
+        defaultValue: "Hop we go!"
+    }
+};
+
+export const TextIcon: Story = {
+    ...WithLabel,
+    args: {
+        ...WithLabel.args,
+        prefix: "$",
         defaultValue: "Hop we go!"
     }
 };

--- a/packages/components/src/inputs/tests/chromatic/PasswordField.stories.tsx
+++ b/packages/components/src/inputs/tests/chromatic/PasswordField.stories.tsx
@@ -86,7 +86,7 @@ export const PrefixIcon: Story = {
     }
 };
 
-export const TextIcon: Story = {
+export const TextPrefix: Story = {
     ...WithLabel,
     args: {
         ...WithLabel.args,


### PR DESCRIPTION
## Description

Add a `prefix` prop to `PasswordField` to display an icon or short text at the start of the input, bringing it to parity with `TextField`.

- Accepts `ReactNode` — an icon element or a short text string
- Uses `SlotProvider` with `IconContext` and `TextContext` to apply consistent sizing and styling via `--hop-comp-field-prefill-color`
- Wraps plain text through `ensureTextWrapper` so string prefixes receive proper slot context
- Adds `.hop-PasswordField__prefix` CSS class
- Includes doc examples (`iconPrefix.tsx`, `textPrefix.tsx`) and Chromatic stories (`PrefixIcon`, `TextIcon`)
- Changeset included (patch)

## Testing

- Review Chromatic stories: `PrefixIcon` and `TextIcon`
- Check the docs site examples under the new "Icon Prefix" and "Text Prefix" sections on the PasswordField page
