### PR TITLE
fix: use primary border tokens for ShareGate secondary Button

### DIFF
--- a/.changeset/sharegate-secondary-button-brand-border.md
+++ b/.changeset/sharegate-secondary-button-brand-border.md
@@ -1,0 +1,7 @@
+---
+"@hopper-ui/tokens": patch
+"@hopper-ui/styled-system": patch
+"@hopper-ui/components": patch
+---
+
+Update ShareGate secondary Button border-color, border-color-selected, and border-color-loading to use primary brand border tokens.

--- a/packages/tokens/src/tokens/components/sharegate/button.tokens.json
+++ b/packages/tokens/src/tokens/components/sharegate/button.tokens.json
@@ -234,7 +234,7 @@
             },
             "border-color-loading": {
                 "$type": "color",
-                "$value": "{neutral.border-weak}"
+                "$value": "{primary.border}"
             },
             "box-shadow-loading": {
                 "$type": "shadow",
@@ -273,11 +273,11 @@
             },
             "border-color": {
                 "$type": "color",
-                "$value": "{neutral.border-weak}"
+                "$value": "{primary.border}"
             },
             "border-color-selected": {
                 "$type": "color",
-                "$value": "{neutral.border-weak}"
+                "$value": "{primary.border-selected}"
             },
             "border-color-disabled": {
                 "$type": "color",


### PR DESCRIPTION
## Summary
- Rebind ShareGate secondary Button `border-color` and `border-color-loading` to `{primary.border}`
- Rebind `border-color-selected` to `{primary.border-selected}` for semantic correctness
- Leaves disabled border transparent; Workleap theme unchanged

## Test plan
- [ ] `pnpm build:tokens && pnpm build:pkg && pnpm storybook`
- [ ] In Storybook, set theme to Sharegate and verify secondary Button outline is purple brand
- [ ] Check default, hover, selected, loading, and disabled states
- [ ] Confirm Workleap secondary Button is unchanged


Made with [Cursor](https://cursor.com)